### PR TITLE
Add `.go-version` support for the linter configuration

### DIFF
--- a/dev-tools/templates/.golangci.yml
+++ b/dev-tools/templates/.golangci.yml
@@ -1,6 +1,3 @@
-# DO NOT EDIT!
-# This file is a rendered template, the source can be found in "./dev-tools/templates/.golangci.yml"
-#
 # options for analysis running
 run:
   # timeout for analysis, e.g. 30s, 5m, default is 1m
@@ -103,7 +100,7 @@ linters-settings:
 
   gosimple:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "{{.GoVersion}}"
 
   misspell:
     # Correct spellings using locale preferences for US or UK.
@@ -138,11 +135,11 @@ linters-settings:
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "{{.GoVersion}}"
 
   stylecheck:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "{{.GoVersion}}"
 
   unparam:
     # Inspect exported functions, default is false. Set to true if no external program/library imports your code.
@@ -153,4 +150,4 @@ linters-settings:
 
   unused:
     # Select the Go version to target. The default is '1.13'.
-    go: "1.17.6"
+    go: "{{.GoVersion}}"

--- a/magefile.go
+++ b/magefile.go
@@ -204,6 +204,7 @@ func Check() error {
 }
 
 // UpdateGoVersion makes required changes in order to switch to a new version of Go set in `./.go-version`.
+// nolint: deadcode,unparam // it's used as a `mage` target and requires returning an error
 func UpdateGoVersion() error {
 	mg.Deps(Linter.UpdateGoVersion)
 	return nil

--- a/magefile.go
+++ b/magefile.go
@@ -26,20 +26,26 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
+	"text/template"
 
 	"github.com/magefile/mage/mg"
 	"github.com/magefile/mage/sh"
 )
 
 const (
-	linterInstallURL      = "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
-	linterInstallFilename = "./build/intall-golang-ci.sh"
-	linterBinaryFilename  = "./build/golangci-lint"
-	linterVersion         = "v1.44.0"
+	linterInstallURL             = "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
+	linterInstallFilename        = "./build/intall-golang-ci.sh"
+	linterBinaryFilename         = "./build/golangci-lint"
+	linterVersion                = "v1.44.0"
+	linterConfigFilename         = "./.golangci.yml"
+	linterConfigTemplateFilename = "./dev-tools/templates/.golangci.yml"
+	goVersionFilename            = "./.go-version"
 )
 
 // Aliases are shortcuts to long target names.
@@ -51,6 +57,57 @@ var Aliases = map[string]interface{}{
 
 // Linter contains targets related to linting the Go code
 type Linter mg.Namespace
+
+// UpdateGoVersion updates the linter configuration with the new version of Go.
+func (Linter) UpdateGoVersion() error {
+	goVersionBytes, err := ioutil.ReadFile(goVersionFilename)
+	if err != nil {
+		return fmt.Errorf("failed to read the %q file: %w", goVersionFilename, err)
+	}
+	goVersion := strings.TrimSpace(string(goVersionBytes))
+	log.Printf("The Go version is %s\n", goVersion)
+
+	templateContext := struct{ GoVersion string }{GoVersion: goVersion}
+	template, err := template.ParseFiles(linterConfigTemplateFilename)
+	if err != nil {
+		return fmt.Errorf("failed to read the template file %q: %w", linterConfigTemplateFilename, err)
+	}
+
+	configFile, err := os.OpenFile(linterConfigFilename, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0700)
+	if err != nil {
+		return fmt.Errorf("failed to create/replace the linter config %q: %w", linterConfigFilename, err)
+	}
+	defer configFile.Close()
+
+	warning := fmt.Sprintf("# DO NOT EDIT!\n# This file is a rendered template, the source can be found in %q\n#\n", linterConfigTemplateFilename)
+	_, err = configFile.WriteString(warning)
+	if err != nil {
+		return fmt.Errorf("failed to write into the linter config %q: %w", linterConfigFilename, err)
+	}
+
+	err = template.Execute(configFile, templateContext)
+	if err != nil {
+		return fmt.Errorf("failed to execute the template %q: %w", linterConfigTemplateFilename, err)
+	}
+
+	err = assertUnchanged(linterConfigFilename)
+	if err != nil {
+		log.Printf("Successfully updated the linter configuration %q to Go version %s, please commit the changes now", linterConfigFilename, goVersion)
+	} else {
+		log.Printf("The linter configuration %q is up to date, no changes made", linterConfigFilename)
+	}
+
+	return nil
+}
+
+// CheckConfig makes sure that the `.golangci.yml` does not have uncommitted changes
+func (Linter) CheckConfig() error {
+	err := assertUnchanged(linterConfigFilename)
+	if err != nil {
+		return fmt.Errorf("linter configuration has uncommitted changes: %w", err)
+	}
+	return nil
+}
 
 // Install installs golangci-lint (https://golangci-lint.run) to `./build`
 // using the official installation script downloaded from GitHub.
@@ -64,14 +121,14 @@ func (Linter) Install() error {
 
 	_, err = os.Stat(linterBinaryFilename)
 	if err == nil {
-		log.Println("the linter has been already installed, skipping...")
+		log.Println("The linter has been already installed, skipping...")
 		return nil
 	}
 	if !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed check if file %q exists: %w", linterBinaryFilename, err)
 	}
 
-	log.Println("preparing the installation script file...")
+	log.Println("Preparing the installation script file...")
 
 	installScript, err := os.OpenFile(linterInstallFilename, os.O_TRUNC|os.O_CREATE|os.O_WRONLY, 0700)
 	if err != nil {
@@ -79,7 +136,7 @@ func (Linter) Install() error {
 	}
 	defer installScript.Close()
 
-	log.Println("downloading the linter installation script...")
+	log.Println("Downloading the linter installation script...")
 	// nolint: noctx // valid use since there is no context
 	resp, err := http.Get(linterInstallURL)
 	if err != nil {
@@ -110,14 +167,14 @@ func (Linter) Install() error {
 
 // All runs the linter against the entire codebase
 func (l Linter) All() error {
-	mg.Deps(l.Install)
+	mg.Deps(l.Install, l.CheckConfig)
 	return runLinter()
 }
 
 // LastChange runs the linter against all files changed since the fork point from `main`.
 // If the current branch is `main` then runs against the files changed in the last commit.
 func (l Linter) LastChange() error {
-	mg.Deps(l.Install)
+	mg.Deps(l.Install, l.CheckConfig)
 
 	branch, err := sh.Output("git", "branch", "--show-current")
 	if err != nil {
@@ -143,6 +200,12 @@ func (l Linter) LastChange() error {
 // nolint: deadcode,unparam // it's used as a `mage` target and requires returning an error
 func Check() error {
 	mg.Deps(Deps.CheckNoBeats, Deps.CheckModuleTidy, Linter.LastChange)
+	return nil
+}
+
+// UpdateGoVersion makes required changes in order to switch to a new version of Go set in `./.go-version`.
+func UpdateGoVersion() error {
+	mg.Deps(Linter.UpdateGoVersion)
 	return nil
 }
 
@@ -182,9 +245,18 @@ func (Deps) CheckModuleTidy() error {
 	if err != nil {
 		return err
 	}
-	err = sh.Run("git", "diff", "--exit-code", "go.mod")
+	err = assertUnchanged("go.mod")
 	if err != nil {
 		return fmt.Errorf("`go mod tidy` was not called before the last commit: %w", err)
+	}
+
+	return nil
+}
+
+func assertUnchanged(path string) error {
+	err := sh.Run("git", "diff", "--exit-code", path)
+	if err != nil {
+		return fmt.Errorf("failed to assert the unchanged file %q: %w", path, err)
 	}
 
 	return nil
@@ -207,6 +279,7 @@ func runLinter(runFlags ...string) error {
 
 	args = append(args, "run")
 	args = append(args, runFlags...)
+	args = append(args, "-c", linterConfigFilename)
 	args = append(args, "./...")
 
 	return runWithStdErr(linterBinaryFilename, args...)


### PR DESCRIPTION
* Added the linter config template to
`dev-tools/templates/.golangci.yml`
* Added the `UpdateGoVersion` target to the magefile in order to apply
required Go Version changes
* Added assertion before linting that makes sure the linter config
does not have uncommitted changes

In order to change the Go version in the future, it's enough to edit
in the `.go-version` file and then run `mage -v UpdateGoVersion` and
commit the changes.

This is a follow-up to https://github.com/elastic/elastic-agent-libs/pull/10 and this comment in particular https://github.com/elastic/elastic-agent-libs/pull/10#discussion_r808329900

Related to https://github.com/elastic/beats/issues/30150