### PR TITLE
Move common.MapStr and rename it to mapstr.M

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@ This repository is the home to the common libraries used by Elastic Agent and Be
 
 Provided packages:
 * `github.com/elastic/elastic-agent-libs/config` the previous `config.go` file from `github.com/elastic/beats/v7/libbeat/common`. A minimal wrapper around `github.com/elastic/go-ucfg`. It contains helpers for merging and accessing configuration objects and flags.
-* `github.com/elastic/elastic-agent-libs/str` the previous `stringset.go` file from `github.com/elastic/beats/v7/libbeat/common`. It provides a string set implementation. 
 * `github.com/elastic/elastic-agent-libs/file` is responsible for rotating and writing input and output files.
 * `github.com/elastic/elastic-agent-libs/logp` is the well known logger from libbeat.
+* `github.com/elastic/elastic-agent-libs/mapstr` is the old `github.com/elastic/beats/v7/libbeat/common.MapStr`. It is an extra layer on top of `map[string]interface{}`.
+* `github.com/elastic/elastic-agent-libs/safemapstr` contains safe operations for `mapstr.M`.
+* `github.com/elastic/elastic-agent-libs/str` the previous `stringset.go` file from `github.com/elastic/beats/v7/libbeat/common`. It provides a string set implementation. 

--- a/config/config.go
+++ b/config/config.go
@@ -336,7 +336,7 @@ func DebugString(c *C, filterPrivate bool) string {
 			return fmt.Sprintf("<config error> %v", err)
 		}
 		if filterPrivate {
-			applyLoggingMask(content)
+			ApplyLoggingMask(content)
 		}
 		j, _ := json.MarshalIndent(content, "", "  ")
 		bufs = append(bufs, string(j))
@@ -347,7 +347,7 @@ func DebugString(c *C, filterPrivate bool) string {
 			return fmt.Sprintf("<config error> %v", err)
 		}
 		if filterPrivate {
-			applyLoggingMask(content)
+			ApplyLoggingMask(content)
 		}
 		j, _ := json.MarshalIndent(content, "", "  ")
 		bufs = append(bufs, string(j))
@@ -359,7 +359,7 @@ func DebugString(c *C, filterPrivate bool) string {
 	return strings.Join(bufs, "\n")
 }
 
-func applyLoggingMask(c interface{}) {
+func ApplyLoggingMask(c interface{}) {
 	switch cfg := c.(type) {
 	case map[string]interface{}:
 		for k, v := range cfg {
@@ -372,13 +372,13 @@ func applyLoggingMask(c interface{}) {
 					cfg[k] = mask
 				}
 			} else {
-				applyLoggingMask(v)
+				ApplyLoggingMask(v)
 			}
 		}
 
 	case []interface{}:
 		for _, elem := range cfg {
-			applyLoggingMask(elem)
+			ApplyLoggingMask(elem)
 		}
 	}
 }

--- a/config/config.go
+++ b/config/config.go
@@ -359,6 +359,8 @@ func DebugString(c *C, filterPrivate bool) string {
 	return strings.Join(bufs, "\n")
 }
 
+// ApplyLoggingMask redacts the values of keys that might
+// contain sensitive data (password, passphrase, etc.).
 func ApplyLoggingMask(c interface{}) {
 	switch cfg := c.(type) {
 	case map[string]interface{}:

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	github.com/elastic/go-ucfg v0.8.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/magefile/mage v1.12.1
+	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/ecszap v1.0.0
@@ -17,7 +18,6 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/elastic/go-ucfg v0.8.4
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/magefile/mage v1.12.1
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0
 	go.elastic.co/ecszap v1.0.0
@@ -18,6 +17,7 @@ require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/hashicorp/errwrap v1.0.0 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.uber.org/atomic v1.7.0 // indirect

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -1,0 +1,484 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapstr
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sort"
+	"strings"
+
+	"github.com/pkg/errors"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+// Event metadata constants. These keys are used within libbeat to identify
+// metadata stored in an event.
+const (
+	FieldsKey = "fields"
+	TagsKey   = "tags"
+)
+
+var (
+	// ErrKeyNotFound indicates that the specified key was not found.
+	ErrKeyNotFound = errors.New("key not found")
+)
+
+// EventMetadata contains fields and tags that can be added to an event via
+// configuration.
+type EventMetadata struct {
+	Fields          M
+	FieldsUnderRoot bool `config:"fields_under_root"`
+	Tags            []string
+}
+
+// M is a map[string]interface{} wrapper with utility methods for common
+// map operations like converting to JSON.
+type M map[string]interface{}
+
+// Update copies all the key-value pairs from d to this map. If the key
+// already exists then it is overwritten. This method does not merge nested
+// maps.
+func (m M) Update(d M) {
+	for k, v := range d {
+		m[k] = v
+	}
+}
+
+// DeepUpdate recursively copies the key-value pairs from d to this map.
+// If the key is present and a map as well, the sub-map will be updated recursively
+// via DeepUpdate.
+// DeepUpdateNoOverwrite is a version of this function that does not
+// overwrite existing values.
+func (m M) DeepUpdate(d M) {
+	m.deepUpdateMap(d, true)
+}
+
+// DeepUpdateNoOverwrite recursively copies the key-value pairs from d to this map.
+// If a key is already present it will not be overwritten.
+// DeepUpdate is a version of this function that overwrites existing values.
+func (m M) DeepUpdateNoOverwrite(d M) {
+	m.deepUpdateMap(d, false)
+}
+
+func (m M) deepUpdateMap(d M, overwrite bool) {
+	for k, v := range d {
+		switch val := v.(type) {
+		case map[string]interface{}:
+			m[k] = deepUpdateValue(m[k], M(val), overwrite)
+		case M:
+			m[k] = deepUpdateValue(m[k], val, overwrite)
+		default:
+			if overwrite {
+				m[k] = v
+			} else if _, exists := m[k]; !exists {
+				m[k] = v
+			}
+		}
+	}
+}
+
+func deepUpdateValue(old interface{}, val M, overwrite bool) interface{} {
+	switch sub := old.(type) {
+	case M:
+		if sub == nil {
+			return val
+		}
+
+		sub.deepUpdateMap(val, overwrite)
+		return sub
+	case map[string]interface{}:
+		if sub == nil {
+			return val
+		}
+
+		tmp := M(sub)
+		tmp.deepUpdateMap(val, overwrite)
+		return tmp
+	default:
+		// We reach the default branch if old is no map or if old == nil.
+		// In either case we return `val`, such that the old value is completely
+		// replaced when merging.
+		return val
+	}
+}
+
+// Delete deletes the given key from the map.
+func (m M) Delete(key string) error {
+	k, d, _, found, err := mapFind(key, m, false)
+	if err != nil {
+		return err
+	}
+	if !found {
+		return ErrKeyNotFound
+	}
+
+	delete(d, k)
+	return nil
+}
+
+// CopyFieldsTo copies the field specified by key to the given map. It will
+// overwrite the key if it exists. An error is returned if the key does not
+// exist in the source map.
+func (m M) CopyFieldsTo(to M, key string) error {
+	v, err := m.GetValue(key)
+	if err != nil {
+		return err
+	}
+
+	_, err = to.Put(key, v)
+	return err
+}
+
+// Clone returns a copy of the M. It recursively makes copies of inner
+// maps.
+func (m M) Clone() M {
+	result := M{}
+
+	for k, v := range m {
+		if innerMap, ok := tryToM(v); ok {
+			v = innerMap.Clone()
+		}
+		result[k] = v
+	}
+
+	return result
+}
+
+// HasKey returns true if the key exist. If an error occurs then false is
+// returned with a non-nil error.
+func (m M) HasKey(key string) (bool, error) {
+	_, _, _, hasKey, err := mapFind(key, m, false)
+	return hasKey, err
+}
+
+// GetValue gets a value from the map. If the key does not exist then an error
+// is returned.
+func (m M) GetValue(key string) (interface{}, error) {
+	_, _, v, found, err := mapFind(key, m, false)
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, ErrKeyNotFound
+	}
+	return v, nil
+}
+
+// Put associates the specified value with the specified key. If the map
+// previously contained a mapping for the key, the old value is replaced and
+// returned. The key can be expressed in dot-notation (e.g. x.y) to put a value
+// into a nested map.
+//
+// If you need insert keys containing dots then you must use bracket notation
+// to insert values (e.g. m[key] = value).
+func (m M) Put(key string, value interface{}) (interface{}, error) {
+	// XXX `safemapstr.Put` mimics this implementation, both should be updated to have similar behavior
+	k, d, old, _, err := mapFind(key, m, true)
+	if err != nil {
+		return nil, err
+	}
+
+	d[k] = value
+	return old, nil
+}
+
+// StringToPrint returns the M as pretty JSON.
+func (m M) StringToPrint() string {
+	json, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("Not valid json: %v", err)
+	}
+	return string(json)
+}
+
+// String returns the M as JSON.
+func (m M) String() string {
+	bytes, err := json.Marshal(m)
+	if err != nil {
+		return fmt.Sprintf("Not valid json: %v", err)
+	}
+	return string(bytes)
+}
+
+// MarshalLogObject implements the zapcore.ObjectMarshaler interface and allows
+// for more efficient marshaling of M in structured logging.
+func (m M) MarshalLogObject(enc zapcore.ObjectEncoder) error {
+	if len(m) == 0 {
+		return nil
+	}
+
+	debugM := m.Clone()
+	config.ApplyLoggingMask(map[string]interface{}(debugM))
+
+	keys := make([]string, 0, len(debugM))
+	for k := range debugM {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		v := debugM[k]
+		if inner, ok := tryToM(v); ok {
+			enc.AddObject(k, inner)
+			continue
+		}
+		zap.Any(k, v).AddTo(enc)
+	}
+	return nil
+}
+
+// Format implements fmt.Formatter
+func (m M) Format(f fmt.State, c rune) {
+	if f.Flag('+') || f.Flag('#') {
+		io.WriteString(f, m.String())
+		return
+	}
+
+	debugM := m.Clone()
+	config.ApplyLoggingMask(map[string]interface{}(debugM))
+
+	io.WriteString(f, debugM.String())
+}
+
+// Flatten flattens the given M and returns a flat M.
+//
+// Example:
+//   "hello": M{"world": "test" }
+//
+// This is converted to:
+//   "hello.world": "test"
+//
+// This can be useful for testing or logging.
+func (m M) Flatten() M {
+	return flatten("", m, M{})
+}
+
+// flatten is a helper for Flatten. See docs for Flatten. For convenience the
+// out parameter is returned.
+func flatten(prefix string, in, out M) M {
+	for k, v := range in {
+		var fullKey string
+		if prefix == "" {
+			fullKey = k
+		} else {
+			fullKey = prefix + "." + k
+		}
+
+		if m, ok := tryToM(v); ok {
+			flatten(fullKey, m, out)
+		} else {
+			out[fullKey] = v
+		}
+	}
+	return out
+}
+
+// MUnion creates a new M containing the union of the
+// key-value pairs of the two maps. If the same key is present in
+// both, the key-value pairs from dict2 overwrite the ones from dict1.
+func MUnion(dict1 M, dict2 M) M {
+	dict := M{}
+
+	for k, v := range dict1 {
+		dict[k] = v
+	}
+
+	for k, v := range dict2 {
+		dict[k] = v
+	}
+	return dict
+}
+
+// MergeFields merges the top-level keys and values in each source map (it does
+// not perform a deep merge). If the same key exists in both, the value in
+// fields takes precedence. If underRoot is true then the contents of the fields
+// M is merged with the value of the 'fields' key in target.
+//
+// An error is returned if underRoot is true and the value of ms.fields is not a
+// M.
+func MergeFields(target, from M, underRoot bool) error {
+	if target == nil || len(from) == 0 {
+		return nil
+	}
+
+	destMap, err := mergeFieldsGetDestMap(target, from, underRoot)
+	if err != nil {
+		return err
+	}
+
+	// Add fields and override.
+	for k, v := range from {
+		destMap[k] = v
+	}
+
+	return nil
+}
+
+// MergeFieldsDeep recursively merges the keys and values from `from` into `target`, either
+// into ms itself (if underRoot == true) or into ms["fields"] (if underRoot == false). If
+// the same key exists in `from` and the destination map, the value in fields takes precedence.
+//
+// An error is returned if underRoot is true and the value of ms["fields"] is not a
+// M.
+func MergeFieldsDeep(target, from M, underRoot bool) error {
+	if target == nil || len(from) == 0 {
+		return nil
+	}
+
+	destMap, err := mergeFieldsGetDestMap(target, from, underRoot)
+	if err != nil {
+		return err
+	}
+
+	destMap.DeepUpdate(from)
+	return nil
+}
+
+func mergeFieldsGetDestMap(target, from M, underRoot bool) (M, error) {
+	destMap := target
+	if !underRoot {
+		f, ok := target[FieldsKey]
+		if !ok {
+			destMap = make(M, len(from))
+			target[FieldsKey] = destMap
+		} else {
+			// Use existing 'fields' value.
+			var err error
+			destMap, err = toM(f)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return destMap, nil
+}
+
+// AddTags appends a tag to the tags field of ms. If the tags field does not
+// exist then it will be created. If the tags field exists and is not a []string
+// then an error will be returned. It does not deduplicate the list of tags.
+func AddTags(ms M, tags []string) error {
+	return AddTagsWithKey(ms, TagsKey, tags)
+}
+
+// AddTagsWithKey appends a tag to the key field of ms. If the field does not
+// exist then it will be created. If the field exists and is not a []string
+// then an error will be returned. It does not deduplicate the list.
+func AddTagsWithKey(ms M, key string, tags []string) error {
+	if ms == nil || len(tags) == 0 {
+		return nil
+	}
+
+	k, subMap, oldTags, present, err := mapFind(key, ms, true)
+	if err != nil {
+		return err
+	}
+
+	if !present {
+		subMap[k] = tags
+		return nil
+	}
+
+	switch arr := oldTags.(type) {
+	case []string:
+		subMap[k] = append(arr, tags...)
+	case []interface{}:
+		for _, tag := range tags {
+			arr = append(arr, tag)
+		}
+		subMap[k] = arr
+	default:
+		return errors.Errorf("expected string array by type is %T", oldTags)
+
+	}
+	return nil
+}
+
+// toM performs a type assertion on v and returns a M. v can be either
+// a M or a map[string]interface{}. If it's any other type or nil then
+// an error is returned.
+func toM(v interface{}) (M, error) {
+	m, ok := tryToM(v)
+	if !ok {
+		return nil, errors.Errorf("expected map but type is %T", v)
+	}
+	return m, nil
+}
+
+func tryToM(v interface{}) (M, bool) {
+	switch m := v.(type) {
+	case M:
+		return m, true
+	case map[string]interface{}:
+		return M(m), true
+	default:
+		return nil, false
+	}
+}
+
+// mapFind iterates a M based on a the given dotted key, finding the final
+// subMap and subKey to operate on.
+// An error is returned if some intermediate is no map or the key doesn't exist.
+// If createMissing is set to true, intermediate maps are created.
+// The final map and un-dotted key to run further operations on are returned in
+// subKey and subMap. The subMap already contains a value for subKey, the
+// present flag is set to true and the oldValue return will hold
+// the original value.
+func mapFind(
+	key string,
+	data M,
+	createMissing bool,
+) (subKey string, subMap M, oldValue interface{}, present bool, err error) {
+	// XXX `safemapstr.mapFind` mimics this implementation, both should be updated to have similar behavior
+
+	for {
+		// Fast path, key is present as is.
+		if v, exists := data[key]; exists {
+			return key, data, v, true, nil
+		}
+
+		idx := strings.IndexRune(key, '.')
+		if idx < 0 {
+			return key, data, nil, false, nil
+		}
+
+		k := key[:idx]
+		d, exists := data[k]
+		if !exists {
+			if createMissing {
+				d = M{}
+				data[k] = d
+			} else {
+				return "", nil, nil, false, ErrKeyNotFound
+			}
+		}
+
+		v, err := toM(d)
+		if err != nil {
+			return "", nil, nil, false, err
+		}
+
+		// advance to sub-map
+		key = key[idx+1:]
+		data = v
+	}
+}

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -19,12 +19,12 @@ package mapstr
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"sort"
 	"strings"
 
-	"github.com/pkg/errors"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 
@@ -410,7 +410,7 @@ func AddTagsWithKey(ms M, key string, tags []string) error {
 		}
 		subMap[k] = arr
 	default:
-		return errors.Errorf("expected string array by type is %T", oldTags)
+		return fmt.Errorf("expected string array by type is %T", oldTags)
 
 	}
 	return nil
@@ -422,7 +422,7 @@ func AddTagsWithKey(ms M, key string, tags []string) error {
 func toMapStr(v interface{}) (M, error) {
 	m, ok := tryToMapStr(v)
 	if !ok {
-		return nil, errors.Errorf("expected map but type is %T", v)
+		return nil, fmt.Errorf("expected map but type is %T", v)
 	}
 	return m, nil
 }

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -221,7 +221,7 @@ func (m M) String() string {
 }
 
 // MarshalLogObject implements the zapcore.ObjectMarshaler interface and allows
-// for more efficient marshaling of M in structured logging.
+// for more efficient marshaling of mapstr.M in structured logging.
 func (m M) MarshalLogObject(enc zapcore.ObjectEncoder) error {
 	if len(m) == 0 {
 		return nil

--- a/mapstr/mapstr_pointer.go
+++ b/mapstr/mapstr_pointer.go
@@ -1,0 +1,51 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapstr
+
+import (
+	"sync/atomic"
+	"unsafe"
+)
+
+// Pointer stores a pointer to atomically get/set a mapstr.M object
+// This should give faster access for use cases with lots of reads and a few
+// changes.
+// It's important to note that modifying the map is not thread safe, only fully
+// replacing it.
+type Pointer struct {
+	p *unsafe.Pointer
+}
+
+// NewMPointer initializes and returns a pointer to the given M
+func NewPointer(m M) Pointer {
+	pointer := unsafe.Pointer(&m)
+	return Pointer{p: &pointer}
+}
+
+// Get returns the M stored under this pointer
+func (m Pointer) Get() M {
+	if m.p == nil {
+		return nil
+	}
+	return *(*M)(atomic.LoadPointer(m.p))
+}
+
+// Set stores a pointer the given M, replacing any previous one
+func (m *Pointer) Set(p M) {
+	atomic.StorePointer(m.p, unsafe.Pointer(&p))
+}

--- a/mapstr/mapstr_pointer_test.go
+++ b/mapstr/mapstr_pointer_test.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package mapstr
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPointer(t *testing.T) {
+	data := M{
+		"foo": "bar",
+	}
+
+	p := NewPointer(data)
+	assert.Equal(t, p.Get(), data)
+
+	newData := M{
+		"new": "data",
+	}
+	p.Set(newData)
+	assert.Equal(t, p.Get(), newData)
+}
+
+func BenchmarkPointer(b *testing.B) {
+	p := NewPointer(M{"counter": 0})
+	go func() {
+		counter := 0
+		for {
+			counter++
+			p.Set(M{"counter": counter})
+			time.Sleep(10 * time.Millisecond)
+		}
+	}()
+
+	for n := 0; n < b.N; n++ {
+		_ = p.Get()
+	}
+}

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -27,12 +27,13 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"go.uber.org/zap/zapcore"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func TestMUpdate(t *testing.T) {
+func TestMapStrUpdate(t *testing.T) {
 	assert := assert.New(t)
 
 	a := M{
@@ -49,7 +50,7 @@ func TestMUpdate(t *testing.T) {
 	assert.Equal(a, M{"a": 1, "b": 3, "c": 4})
 }
 
-func TestMDeepUpdate(t *testing.T) {
+func TestMapStrDeepUpdate(t *testing.T) {
 	tests := []struct {
 		a, b, expected M
 	}{
@@ -106,7 +107,7 @@ func TestMDeepUpdate(t *testing.T) {
 	}
 }
 
-func TestMUnion(t *testing.T) {
+func TestMapStrUnion(t *testing.T) {
 	assert := assert.New(t)
 
 	a := M{
@@ -118,12 +119,12 @@ func TestMUnion(t *testing.T) {
 		"c": 4,
 	}
 
-	c := MUnion(a, b)
+	c := Union(a, b)
 
 	assert.Equal(c, M{"a": 1, "b": 3, "c": 4})
 }
 
-func TestMCopyFieldsTo(t *testing.T) {
+func TestMapStrCopyFieldsTo(t *testing.T) {
 	assert := assert.New(t)
 
 	m := M{
@@ -164,7 +165,7 @@ func TestMCopyFieldsTo(t *testing.T) {
 	assert.Equal(M{"a": M{"a1": 2, "a2": 3}, "c": M{"c1": 1, "c3": M{"c32": 2}}, "b": 2}, c)
 }
 
-func TestMDelete(t *testing.T) {
+func TestMapStrDelete(t *testing.T) {
 	assert := assert.New(t)
 
 	m := M{
@@ -269,7 +270,7 @@ func TestMPut(t *testing.T) {
 	assert.Equal(t, M{"subMap": M{"newMap": M{"a": 1}}}, m)
 }
 
-func TestMGetValue(t *testing.T) {
+func TestMapStrGetValue(t *testing.T) {
 
 	tests := []struct {
 		input  M
@@ -852,7 +853,7 @@ func TestFlatten(t *testing.T) {
 	}
 }
 
-func BenchmarkMFlatten(b *testing.B) {
+func BenchmarkMapStrFlatten(b *testing.B) {
 	m := M{
 		"test": 15,
 		"hello": M{
@@ -871,9 +872,10 @@ func BenchmarkMFlatten(b *testing.B) {
 	}
 }
 
-// Ensure the M is marshaled in logs the same way it is by json.Marshal.
-func TestMJSONLog(t *testing.T) {
-	logp.DevelopmentSetup(logp.ToObserverOutput())
+// Ensure the MapStr is marshaled in logs the same way it is by json.Marshal.
+func TestMapStrJSONLog(t *testing.T) {
+	err := logp.DevelopmentSetup(logp.ToObserverOutput())
+	require.Nil(t, err)
 
 	m := M{
 		"test": 15,
@@ -908,12 +910,13 @@ func TestMJSONLog(t *testing.T) {
 		// Zap adds a newline to end the JSON object.
 		actualJSON := strings.TrimSpace(buf.String())
 
-		assert.Equal(t, string(expectedJSON), actualJSON)
+		assert.Equal(t, expectedJSON, actualJSON)
 	}
 }
 
-func BenchmarkMLogging(b *testing.B) {
-	logp.DevelopmentSetup(logp.ToDiscardOutput())
+func BenchmarkMapStrLogging(b *testing.B) {
+	err := logp.DevelopmentSetup(logp.ToDiscardOutput())
+	require.Nil(b, err)
 	logger := logp.NewLogger("benchtest")
 
 	m := M{
@@ -948,7 +951,7 @@ func BenchmarkWalkMap(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			globalM.GetValue("test.world.ok")
+			_, _ = globalM.GetValue("test.world.ok")
 		}
 	})
 
@@ -963,7 +966,7 @@ func BenchmarkWalkMap(b *testing.B) {
 				},
 			}
 
-			m.Put("hello.world.new", 17)
+			_, _ = m.Put("hello.world.new", 17)
 		}
 	})
 
@@ -972,7 +975,7 @@ func BenchmarkWalkMap(b *testing.B) {
 		for i := 0; i < b.N; i++ {
 			m := M{}
 
-			m.Put("a.b.c", 17)
+			_, _ = m.Put("a.b.c", 17)
 		}
 	})
 
@@ -980,8 +983,8 @@ func BenchmarkWalkMap(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			globalM.HasKey("hello.world.ok")
-			globalM.HasKey("hello.world.no_ok")
+			_, _ = globalM.HasKey("hello.world.ok")
+			_, _ = globalM.HasKey("hello.world.no_ok")
 		}
 	})
 
@@ -989,7 +992,7 @@ func BenchmarkWalkMap(b *testing.B) {
 		b.ResetTimer()
 
 		for i := 0; i < b.N; i++ {
-			globalM.HasKey("hello")
+			_, _ = globalM.HasKey("hello")
 		}
 	})
 
@@ -1004,7 +1007,7 @@ func BenchmarkWalkMap(b *testing.B) {
 					},
 				},
 			}
-			m.Put("hello.world.test", 17)
+			_, _ = m.Put("hello.world.test", 17)
 		}
 	})
 }

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1,0 +1,1033 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !integration
+// +build !integration
+
+package mapstr
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/zap/zapcore"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestMUpdate(t *testing.T) {
+	assert := assert.New(t)
+
+	a := M{
+		"a": 1,
+		"b": 2,
+	}
+	b := M{
+		"b": 3,
+		"c": 4,
+	}
+
+	a.Update(b)
+
+	assert.Equal(a, M{"a": 1, "b": 3, "c": 4})
+}
+
+func TestMDeepUpdate(t *testing.T) {
+	tests := []struct {
+		a, b, expected M
+	}{
+		{
+			M{"a": 1},
+			M{"b": 2},
+			M{"a": 1, "b": 2},
+		},
+		{
+			M{"a": 1},
+			M{"a": 2},
+			M{"a": 2},
+		},
+		{
+			M{"a": 1},
+			M{"a": M{"b": 1}},
+			M{"a": M{"b": 1}},
+		},
+		{
+			M{"a": M{"b": 1}},
+			M{"a": M{"c": 2}},
+			M{"a": M{"b": 1, "c": 2}},
+		},
+		{
+			M{"a": M{"b": 1}},
+			M{"a": 1},
+			M{"a": 1},
+		},
+		{
+			M{"a.b": 1},
+			M{"a": 1},
+			M{"a": 1, "a.b": 1},
+		},
+		{
+			M{"a": 1},
+			M{"a.b": 1},
+			M{"a": 1, "a.b": 1},
+		},
+		{
+			M{"a": (M)(nil)},
+			M{"a": M{"b": 1}},
+			M{"a": M{"b": 1}},
+		},
+	}
+
+	for i, test := range tests {
+		a, b, expected := test.a, test.b, test.expected
+		name := fmt.Sprintf("%v: %v + %v = %v", i, a, b, expected)
+
+		t.Run(name, func(t *testing.T) {
+			a.DeepUpdate(b)
+			assert.Equal(t, expected, a)
+		})
+	}
+}
+
+func TestMUnion(t *testing.T) {
+	assert := assert.New(t)
+
+	a := M{
+		"a": 1,
+		"b": 2,
+	}
+	b := M{
+		"b": 3,
+		"c": 4,
+	}
+
+	c := MUnion(a, b)
+
+	assert.Equal(c, M{"a": 1, "b": 3, "c": 4})
+}
+
+func TestMCopyFieldsTo(t *testing.T) {
+	assert := assert.New(t)
+
+	m := M{
+		"a": M{
+			"a1": 2,
+			"a2": 3,
+		},
+		"b": 2,
+		"c": M{
+			"c1": 1,
+			"c2": 2,
+			"c3": M{
+				"c31": 1,
+				"c32": 2,
+			},
+		},
+	}
+	c := M{}
+
+	err := m.CopyFieldsTo(c, "dd")
+	assert.Error(err)
+	assert.Equal(M{}, c)
+
+	err = m.CopyFieldsTo(c, "a")
+	assert.Equal(nil, err)
+	assert.Equal(M{"a": M{"a1": 2, "a2": 3}}, c)
+
+	err = m.CopyFieldsTo(c, "c.c1")
+	assert.Equal(nil, err)
+	assert.Equal(M{"a": M{"a1": 2, "a2": 3}, "c": M{"c1": 1}}, c)
+
+	err = m.CopyFieldsTo(c, "b")
+	assert.Equal(nil, err)
+	assert.Equal(M{"a": M{"a1": 2, "a2": 3}, "c": M{"c1": 1}, "b": 2}, c)
+
+	err = m.CopyFieldsTo(c, "c.c3.c32")
+	assert.Equal(nil, err)
+	assert.Equal(M{"a": M{"a1": 2, "a2": 3}, "c": M{"c1": 1, "c3": M{"c32": 2}}, "b": 2}, c)
+}
+
+func TestMDelete(t *testing.T) {
+	assert := assert.New(t)
+
+	m := M{
+		"c": M{
+			"c1": 1,
+			"c2": 2,
+			"c3": M{
+				"c31": 1,
+				"c32": 2,
+			},
+		},
+	}
+
+	err := m.Delete("c.c2")
+	assert.Equal(nil, err)
+	assert.Equal(M{"c": M{"c1": 1, "c3": M{"c31": 1, "c32": 2}}}, m)
+
+	err = m.Delete("c.c2.c21")
+	assert.NotEqual(nil, err)
+	assert.Equal(M{"c": M{"c1": 1, "c3": M{"c31": 1, "c32": 2}}}, m)
+
+	err = m.Delete("c.c3.c31")
+	assert.Equal(nil, err)
+	assert.Equal(M{"c": M{"c1": 1, "c3": M{"c32": 2}}}, m)
+
+	err = m.Delete("c")
+	assert.Equal(nil, err)
+	assert.Equal(M{}, m)
+}
+
+func TestHasKey(t *testing.T) {
+	assert := assert.New(t)
+
+	m := M{
+		"c": M{
+			"c1": 1,
+			"c2": 2,
+			"c3": M{
+				"c31": 1,
+				"c32": 2,
+			},
+			"c4.f": 19,
+		},
+		"d.f": 1,
+	}
+
+	hasKey, err := m.HasKey("c.c2")
+	assert.Equal(nil, err)
+	assert.Equal(true, hasKey)
+
+	hasKey, err = m.HasKey("c.c4")
+	assert.Equal(nil, err)
+	assert.Equal(false, hasKey)
+
+	hasKey, err = m.HasKey("c.c3.c32")
+	assert.Equal(nil, err)
+	assert.Equal(true, hasKey)
+
+	hasKey, err = m.HasKey("dd")
+	assert.Equal(nil, err)
+	assert.Equal(false, hasKey)
+
+	hasKey, err = m.HasKey("d.f")
+	assert.Equal(nil, err)
+	assert.Equal(true, hasKey)
+
+	hasKey, err = m.HasKey("c.c4.f")
+	assert.Equal(nil, err)
+	assert.Equal(true, hasKey)
+}
+
+func TestMPut(t *testing.T) {
+	m := M{
+		"subMap": M{
+			"a": 1,
+		},
+	}
+
+	// Add new value to the top-level.
+	v, err := m.Put("a", "ok")
+	assert.NoError(t, err)
+	assert.Nil(t, v)
+	assert.Equal(t, M{"a": "ok", "subMap": M{"a": 1}}, m)
+
+	// Add new value to subMap.
+	v, err = m.Put("subMap.b", 2)
+	assert.NoError(t, err)
+	assert.Nil(t, v)
+	assert.Equal(t, M{"a": "ok", "subMap": M{"a": 1, "b": 2}}, m)
+
+	// Overwrite a value in subMap.
+	v, err = m.Put("subMap.a", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, 1, v)
+	assert.Equal(t, M{"a": "ok", "subMap": M{"a": 2, "b": 2}}, m)
+
+	// Add value to map that does not exist.
+	m = M{}
+	v, err = m.Put("subMap.newMap.a", 1)
+	assert.NoError(t, err)
+	assert.Nil(t, v)
+	assert.Equal(t, M{"subMap": M{"newMap": M{"a": 1}}}, m)
+}
+
+func TestMGetValue(t *testing.T) {
+
+	tests := []struct {
+		input  M
+		key    string
+		output interface{}
+		error  bool
+	}{
+		{
+			M{"a": 1},
+			"a",
+			1,
+			false,
+		},
+		{
+			M{"a": M{"b": 1}},
+			"a",
+			M{"b": 1},
+			false,
+		},
+		{
+			M{"a": M{"b": 1}},
+			"a.b",
+			1,
+			false,
+		},
+		{
+			M{"a": M{"b.c": 1}},
+			"a",
+			M{"b.c": 1},
+			false,
+		},
+		{
+			M{"a": M{"b.c": 1}},
+			"a.b",
+			nil,
+			true,
+		},
+		{
+			M{"a.b": M{"c": 1}},
+			"a.b",
+			M{"c": 1},
+			false,
+		},
+		{
+			M{"a.b": M{"c": 1}},
+			"a.b.c",
+			nil,
+			true,
+		},
+		{
+			M{"a": M{"b.c": 1}},
+			"a.b.c",
+			1,
+			false,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := test.input.GetValue(test.key)
+		if test.error {
+			assert.Error(t, err)
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, test.output, v)
+
+	}
+}
+
+func TestClone(t *testing.T) {
+	assert := assert.New(t)
+
+	m := M{
+		"c1": 1,
+		"c2": 2,
+		"c3": M{
+			"c31": 1,
+			"c32": 2,
+		},
+	}
+
+	c := m.Clone()
+	assert.Equal(M{"c31": 1, "c32": 2}, c["c3"])
+}
+
+func TestString(t *testing.T) {
+	type io struct {
+		Input  M
+		Output string
+	}
+	tests := []io{
+		{
+			Input: M{
+				"a": "b",
+			},
+			Output: `{"a":"b"}`,
+		},
+		{
+			Input: M{
+				"a": []int{1, 2, 3},
+			},
+			Output: `{"a":[1,2,3]}`,
+		},
+	}
+	for _, test := range tests {
+		assert.Equal(t, test.Output, test.Input.String())
+	}
+}
+
+// Smoke test. The method has no observable outputs so this
+// is only verifying there are no panics.
+func TestStringToPrint(t *testing.T) {
+	m := M{}
+
+	assert.Equal(t, "{}", m.StringToPrint())
+	assert.Equal(t, true, len(m.StringToPrint()) > 0)
+}
+
+func TestMergeFields(t *testing.T) {
+	type io struct {
+		UnderRoot bool
+		Event     M
+		Fields    M
+		Output    M
+		Err       string
+	}
+	tests := []io{
+		// underRoot = true, merges
+		{
+			UnderRoot: true,
+			Event: M{
+				"a": "1",
+			},
+			Fields: M{
+				"b": 2,
+			},
+			Output: M{
+				"a": "1",
+				"b": 2,
+			},
+		},
+
+		// underRoot = true, overwrites existing
+		{
+			UnderRoot: true,
+			Event: M{
+				"a": "1",
+			},
+			Fields: M{
+				"a": 2,
+			},
+			Output: M{
+				"a": 2,
+			},
+		},
+
+		// underRoot = false, adds new 'fields' when it doesn't exist
+		{
+			UnderRoot: false,
+			Event: M{
+				"a": "1",
+			},
+			Fields: M{
+				"a": 2,
+			},
+			Output: M{
+				"a": "1",
+				"fields": M{
+					"a": 2,
+				},
+			},
+		},
+
+		// underRoot = false, merge with existing 'fields' and overwrites existing keys
+		{
+			UnderRoot: false,
+			Event: M{
+				"fields": M{
+					"a": "1",
+					"b": 2,
+				},
+			},
+			Fields: M{
+				"a": 3,
+				"c": 4,
+			},
+			Output: M{
+				"fields": M{
+					"a": 3,
+					"b": 2,
+					"c": 4,
+				},
+			},
+		},
+
+		// underRoot = false, error when 'fields' is wrong type
+		{
+			UnderRoot: false,
+			Event: M{
+				"fields": "not a M",
+			},
+			Fields: M{
+				"a": 3,
+			},
+			Output: M{
+				"fields": "not a M",
+			},
+			Err: "expected map",
+		},
+	}
+
+	for _, test := range tests {
+		err := MergeFields(test.Event, test.Fields, test.UnderRoot)
+		assert.Equal(t, test.Output, test.Event)
+		if test.Err != "" {
+			assert.Contains(t, err.Error(), test.Err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestMergeFieldsDeep(t *testing.T) {
+	type io struct {
+		UnderRoot bool
+		Event     M
+		Fields    M
+		Output    M
+		Err       string
+	}
+	tests := []io{
+		// underRoot = true, merges
+		{
+			UnderRoot: true,
+			Event: M{
+				"a": "1",
+			},
+			Fields: M{
+				"b": 2,
+			},
+			Output: M{
+				"a": "1",
+				"b": 2,
+			},
+		},
+
+		// underRoot = true, overwrites existing
+		{
+			UnderRoot: true,
+			Event: M{
+				"a": "1",
+			},
+			Fields: M{
+				"a": 2,
+			},
+			Output: M{
+				"a": 2,
+			},
+		},
+
+		// underRoot = false, adds new 'fields' when it doesn't exist
+		{
+			UnderRoot: false,
+			Event: M{
+				"a": "1",
+			},
+			Fields: M{
+				"a": 2,
+			},
+			Output: M{
+				"a": "1",
+				"fields": M{
+					"a": 2,
+				},
+			},
+		},
+
+		// underRoot = false, merge with existing 'fields' and overwrites existing keys
+		{
+			UnderRoot: false,
+			Event: M{
+				"fields": M{
+					"a": "1",
+					"b": 2,
+				},
+			},
+			Fields: M{
+				"a": 3,
+				"c": 4,
+			},
+			Output: M{
+				"fields": M{
+					"a": 3,
+					"b": 2,
+					"c": 4,
+				},
+			},
+		},
+
+		// underRoot = false, error when 'fields' is wrong type
+		{
+			UnderRoot: false,
+			Event: M{
+				"fields": "not a M",
+			},
+			Fields: M{
+				"a": 3,
+			},
+			Output: M{
+				"fields": "not a M",
+			},
+			Err: "expected map",
+		},
+
+		// underRoot = true, merges recursively
+		{
+			UnderRoot: true,
+			Event: M{
+				"my": M{
+					"field1": "field1",
+				},
+			},
+			Fields: M{
+				"my": M{
+					"field2": "field2",
+					"field3": "field3",
+				},
+			},
+			Output: M{
+				"my": M{
+					"field1": "field1",
+					"field2": "field2",
+					"field3": "field3",
+				},
+			},
+		},
+
+		// underRoot = true, merges recursively and overrides
+		{
+			UnderRoot: true,
+			Event: M{
+				"my": M{
+					"field1": "field1",
+					"field2": "field2",
+				},
+			},
+			Fields: M{
+				"my": M{
+					"field2": "fieldTWO",
+					"field3": "field3",
+				},
+			},
+			Output: M{
+				"my": M{
+					"field1": "field1",
+					"field2": "fieldTWO",
+					"field3": "field3",
+				},
+			},
+		},
+
+		// underRoot = false, merges recursively under existing 'fields'
+		{
+			UnderRoot: false,
+			Event: M{
+				"fields": M{
+					"my": M{
+						"field1": "field1",
+					},
+				},
+			},
+			Fields: M{
+				"my": M{
+					"field2": "field2",
+					"field3": "field3",
+				},
+			},
+			Output: M{
+				"fields": M{
+					"my": M{
+						"field1": "field1",
+						"field2": "field2",
+						"field3": "field3",
+					},
+				},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		err := MergeFieldsDeep(test.Event, test.Fields, test.UnderRoot)
+		assert.Equal(t, test.Output, test.Event)
+		if test.Err != "" {
+			assert.Contains(t, err.Error(), test.Err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestAddTag(t *testing.T) {
+	type io struct {
+		Event  M
+		Tags   []string
+		Output M
+		Err    string
+	}
+	tests := []io{
+		// No existing tags, creates new tag array
+		{
+			Event: M{},
+			Tags:  []string{"json"},
+			Output: M{
+				"tags": []string{"json"},
+			},
+		},
+		// Existing tags is a []string, appends
+		{
+			Event: M{
+				"tags": []string{"json"},
+			},
+			Tags: []string{"docker"},
+			Output: M{
+				"tags": []string{"json", "docker"},
+			},
+		},
+		// Existing tags is a []interface{}, appends
+		{
+			Event: M{
+				"tags": []interface{}{"json"},
+			},
+			Tags: []string{"docker"},
+			Output: M{
+				"tags": []interface{}{"json", "docker"},
+			},
+		},
+		// Existing tags is not a []string or []interface{}
+		{
+			Event: M{
+				"tags": "not a slice",
+			},
+			Tags: []string{"docker"},
+			Output: M{
+				"tags": "not a slice",
+			},
+			Err: "expected string array",
+		},
+	}
+
+	for _, test := range tests {
+		err := AddTags(test.Event, test.Tags)
+		assert.Equal(t, test.Output, test.Event)
+		if test.Err != "" {
+			assert.Contains(t, err.Error(), test.Err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestAddTagsWithKey(t *testing.T) {
+	type io struct {
+		Event  M
+		Key    string
+		Tags   []string
+		Output M
+		Err    string
+	}
+	tests := []io{
+		// No existing tags, creates new tag array
+		{
+			Event: M{},
+			Key:   "tags",
+			Tags:  []string{"json"},
+			Output: M{
+				"tags": []string{"json"},
+			},
+		},
+		// Existing tags is a []string, appends
+		{
+			Event: M{
+				"tags": []string{"json"},
+			},
+			Key:  "tags",
+			Tags: []string{"docker"},
+			Output: M{
+				"tags": []string{"json", "docker"},
+			},
+		},
+		// Existing tags are in submap and is a []interface{}, appends
+		{
+			Event: M{
+				"log": M{
+					"flags": []interface{}{"json"},
+				},
+			},
+			Key:  "log.flags",
+			Tags: []string{"docker"},
+			Output: M{
+				"log": M{
+					"flags": []interface{}{"json", "docker"},
+				},
+			},
+		},
+		// Existing tags are in a submap and is not a []string or []interface{}
+		{
+			Event: M{
+				"log": M{
+					"flags": "not a slice",
+				},
+			},
+			Key:  "log.flags",
+			Tags: []string{"docker"},
+			Output: M{
+				"log": M{
+					"flags": "not a slice",
+				},
+			},
+			Err: "expected string array",
+		},
+	}
+
+	for _, test := range tests {
+		err := AddTagsWithKey(test.Event, test.Key, test.Tags)
+		assert.Equal(t, test.Output, test.Event)
+		if test.Err != "" {
+			assert.Contains(t, err.Error(), test.Err)
+		} else {
+			assert.NoError(t, err)
+		}
+	}
+}
+
+func TestFlatten(t *testing.T) {
+	type data struct {
+		Event    M
+		Expected M
+	}
+	tests := []data{
+		{
+			Event: M{
+				"hello": M{
+					"world": 15,
+				},
+			},
+			Expected: M{
+				"hello.world": 15,
+			},
+		},
+		{
+			Event: M{
+				"test": 15,
+			},
+			Expected: M{
+				"test": 15,
+			},
+		},
+		{
+			Event: M{
+				"test": 15,
+				"hello": M{
+					"world": M{
+						"ok": "test",
+					},
+				},
+				"elastic": M{
+					"for": "search",
+				},
+			},
+			Expected: M{
+				"test":           15,
+				"hello.world.ok": "test",
+				"elastic.for":    "search",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		assert.Equal(t, test.Expected, test.Event.Flatten())
+	}
+}
+
+func BenchmarkMFlatten(b *testing.B) {
+	m := M{
+		"test": 15,
+		"hello": M{
+			"world": M{
+				"ok": "test",
+			},
+		},
+		"elastic": M{
+			"for": "search",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = m.Flatten()
+	}
+}
+
+// Ensure the M is marshaled in logs the same way it is by json.Marshal.
+func TestMJSONLog(t *testing.T) {
+	logp.DevelopmentSetup(logp.ToObserverOutput())
+
+	m := M{
+		"test": 15,
+		"hello": M{
+			"world": M{
+				"ok": "test",
+			},
+		},
+		"elastic": M{
+			"for": "search",
+		},
+	}
+
+	data, err := json.Marshal(M{"m": m})
+	if err != nil {
+		t.Fatal(err)
+	}
+	expectedJSON := string(data)
+
+	logp.NewLogger("test").Infow("msg", "m", m)
+	logs := logp.ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		log := logs[0]
+
+		// Encode like zap does.
+		e := zapcore.NewJSONEncoder(zapcore.EncoderConfig{})
+		buf, err := e.EncodeEntry(log.Entry, log.Context)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		// Zap adds a newline to end the JSON object.
+		actualJSON := strings.TrimSpace(buf.String())
+
+		assert.Equal(t, string(expectedJSON), actualJSON)
+	}
+}
+
+func BenchmarkMLogging(b *testing.B) {
+	logp.DevelopmentSetup(logp.ToDiscardOutput())
+	logger := logp.NewLogger("benchtest")
+
+	m := M{
+		"test": 15,
+		"hello": M{
+			"world": M{
+				"ok": "test",
+			},
+		},
+		"elastic": M{
+			"for": "search",
+		},
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		logger.Infow("test", "mapstr", m)
+	}
+}
+
+func BenchmarkWalkMap(b *testing.B) {
+
+	globalM := M{
+		"hello": M{
+			"world": M{
+				"ok": "test",
+			},
+		},
+	}
+
+	b.Run("Get", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			globalM.GetValue("test.world.ok")
+		}
+	})
+
+	b.Run("Put", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			m := M{
+				"hello": M{
+					"world": M{
+						"ok": "test",
+					},
+				},
+			}
+
+			m.Put("hello.world.new", 17)
+		}
+	})
+
+	b.Run("PutMissing", func(b *testing.B) {
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			m := M{}
+
+			m.Put("a.b.c", 17)
+		}
+	})
+
+	b.Run("HasKey", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			globalM.HasKey("hello.world.ok")
+			globalM.HasKey("hello.world.no_ok")
+		}
+	})
+
+	b.Run("HasKeyFirst", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			globalM.HasKey("hello")
+		}
+	})
+
+	b.Run("Delete", func(b *testing.B) {
+		b.ResetTimer()
+
+		for i := 0; i < b.N; i++ {
+			m := M{
+				"hello": M{
+					"world": M{
+						"ok": "test",
+					},
+				},
+			}
+			m.Put("hello.world.test", 17)
+		}
+	})
+}
+
+func TestFormat(t *testing.T) {
+	input := M{
+		"foo":      "bar",
+		"password": "SUPER_SECURE",
+	}
+
+	tests := map[string]string{
+		"%v":  `{"foo":"bar","password":"xxxxx"}`,
+		"%+v": `{"foo":"bar","password":"SUPER_SECURE"}`,
+		"%#v": `{"foo":"bar","password":"SUPER_SECURE"}`,
+		"%s":  `{"foo":"bar","password":"xxxxx"}`,
+		"%+s": `{"foo":"bar","password":"SUPER_SECURE"}`,
+		"%#s": `{"foo":"bar","password":"SUPER_SECURE"}`,
+	}
+
+	for verb, expected := range tests {
+		t.Run(verb, func(t *testing.T) {
+			actual := fmt.Sprintf(verb, input)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}

--- a/safemapstr/safemapstr.go
+++ b/safemapstr/safemapstr.go
@@ -1,0 +1,113 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package safemapstr
+
+import (
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+const alternativeKey = "value"
+
+// Put This method implements a way to put dotted keys into a M while
+// ensuring they don't override each other. For example:
+//
+//  a := M{}
+//  safemapstr.Put(a, "com.docker.swarm.task", "x")
+//  safemapstr.Put(a, "com.docker.swarm.task.id", 1)
+//  safemapstr.Put(a, "com.docker.swarm.task.name", "foobar")
+//
+// Will result in `{"com":{"docker":{"swarm":{"task":{"id":1,"name":"foobar","value":"x"}}}}}`
+//
+// Put detects this scenario and renames the common base key, by appending
+// `.value`
+func Put(data mapstr.M, key string, value interface{}) error {
+	// XXX This implementation mimics `mapstr.M.Put`, both should be updated to have similar behavior
+
+	d, k := mapFind(data, key, alternativeKey)
+	d[k] = value
+	return nil
+}
+
+// mapFind walk the map based on the given dotted key and returns the final map
+// and key to operate on. This function adds intermediate maps, if the key is
+// missing from the original map.
+
+// mapFind iterates a M based on the given dotted key, finding the final
+// subMap and subKey to operate on.
+// If a key is already used, but the used value is no map, an intermediate map will be inserted and
+// the old value will be stored using the 'alternativeKey' in a new map.
+// If the old value found under key is already an dictionary, subMap will be
+// the old value and subKey will be set to alternativeKey.
+func mapFind(data mapstr.M, key, alternativeKey string) (subMap mapstr.M, subKey string) {
+	// XXX This implementation mimics `common.mapFind`, both should be updated to have similar behavior
+
+	for {
+		if oldValue, exists := data[key]; exists {
+			if oldMap, ok := tryToM(oldValue); ok {
+				return oldMap, alternativeKey
+			}
+			return data, key
+		}
+
+		idx := strings.IndexRune(key, '.')
+		if idx < 0 {
+			// if old value exists and is a dictionary, return the old dictionary and
+			// make sure we store the new value using the 'alternativeKey'
+			if oldValue, exists := data[key]; exists {
+				if oldMap, ok := tryToM(oldValue); ok {
+					return oldMap, alternativeKey
+				}
+			}
+
+			return data, key
+		}
+
+		// Check if first sub-key exists. Create an intermediate map if not.
+		k := key[:idx]
+		d, exists := data[k]
+		if !exists {
+			d = mapstr.M{}
+			data[k] = d
+		}
+
+		// store old value under 'alternativeKey' if the old value is no map.
+		// Do not overwrite old value.
+		v, ok := tryToM(d)
+		if !ok {
+			v = mapstr.M{alternativeKey: d}
+			data[k] = v
+		}
+
+		// advance into sub-map
+		key = key[idx+1:]
+		data = v
+	}
+}
+
+func tryToM(v interface{}) (mapstr.M, bool) {
+	switch m := v.(type) {
+	case mapstr.M:
+		return m, true
+	case map[string]interface{}:
+		return mapstr.M(m), true
+	default:
+		return nil, false
+	}
+}

--- a/safemapstr/safemapstr_test.go
+++ b/safemapstr/safemapstr_test.go
@@ -1,0 +1,82 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package safemapstr
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/mapstr"
+)
+
+func TestPut(t *testing.T) {
+	m := mapstr.M{
+		"subMap": mapstr.M{
+			"a": 1,
+		},
+	}
+
+	// Add new value to the top-level.
+	err := Put(m, "a", "ok")
+	assert.NoError(t, err)
+	assert.Equal(t, mapstr.M{"a": "ok", "subMap": mapstr.M{"a": 1}}, m)
+
+	// Add new value to subMap.
+	err = Put(m, "subMap.b", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, mapstr.M{"a": "ok", "subMap": mapstr.M{"a": 1, "b": 2}}, m)
+
+	// Overwrite a value in subMap.
+	err = Put(m, "subMap.a", 2)
+	assert.NoError(t, err)
+	assert.Equal(t, mapstr.M{"a": "ok", "subMap": mapstr.M{"a": 2, "b": 2}}, m)
+
+	// Add value to map that does not exist.
+	m = mapstr.M{}
+	err = Put(m, "subMap.newMap.a", 1)
+	assert.NoError(t, err)
+	assert.Equal(t, mapstr.M{"subMap": mapstr.M{"newMap": mapstr.M{"a": 1}}}, m)
+}
+
+func TestPutRenames(t *testing.T) {
+	assert := assert.New(t)
+
+	a := mapstr.M{}
+	Put(a, "com.docker.swarm.task", "x")
+	Put(a, "com.docker.swarm.task.id", 1)
+	Put(a, "com.docker.swarm.task.name", "foobar")
+	assert.Equal(mapstr.M{"com": mapstr.M{"docker": mapstr.M{"swarm": mapstr.M{
+		"task": mapstr.M{
+			"id":    1,
+			"name":  "foobar",
+			"value": "x",
+		}}}}}, a)
+
+	// order is not important:
+	b := mapstr.M{}
+	Put(b, "com.docker.swarm.task.id", 1)
+	Put(b, "com.docker.swarm.task.name", "foobar")
+	Put(b, "com.docker.swarm.task", "x")
+	assert.Equal(mapstr.M{"com": mapstr.M{"docker": mapstr.M{"swarm": mapstr.M{
+		"task": mapstr.M{
+			"id":    1,
+			"name":  "foobar",
+			"value": "x",
+		}}}}}, b)
+}

--- a/safemapstr/safemapstr_test.go
+++ b/safemapstr/safemapstr_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/mapstr"
 )
@@ -58,9 +59,12 @@ func TestPutRenames(t *testing.T) {
 	assert := assert.New(t)
 
 	a := mapstr.M{}
-	Put(a, "com.docker.swarm.task", "x")
-	Put(a, "com.docker.swarm.task.id", 1)
-	Put(a, "com.docker.swarm.task.name", "foobar")
+	err := Put(a, "com.docker.swarm.task", "x")
+	require.Nil(t, err)
+	err = Put(a, "com.docker.swarm.task.id", 1)
+	require.Nil(t, err)
+	err = Put(a, "com.docker.swarm.task.name", "foobar")
+	require.Nil(t, err)
 	assert.Equal(mapstr.M{"com": mapstr.M{"docker": mapstr.M{"swarm": mapstr.M{
 		"task": mapstr.M{
 			"id":    1,
@@ -70,9 +74,12 @@ func TestPutRenames(t *testing.T) {
 
 	// order is not important:
 	b := mapstr.M{}
-	Put(b, "com.docker.swarm.task.id", 1)
-	Put(b, "com.docker.swarm.task.name", "foobar")
-	Put(b, "com.docker.swarm.task", "x")
+	err = Put(b, "com.docker.swarm.task.id", 1)
+	require.Nil(t, err)
+	err = Put(b, "com.docker.swarm.task.name", "foobar")
+	require.Nil(t, err)
+	err = Put(b, "com.docker.swarm.task", "x")
+	require.Nil(t, err)
 	assert.Equal(mapstr.M{"com": mapstr.M{"docker": mapstr.M{"swarm": mapstr.M{
 		"task": mapstr.M{
 			"id":    1,


### PR DESCRIPTION
This PR moves the struct `MapStr` from `github.com/elastic/beats/v7/libbeat/common`. I put the type under a new package and renamed it to `mapstr.M` to avoid stuttering. I am open to keeping the original type name `mapstr.MapStr`, I just felt it is more idiomatic. Given that we have to rename it everywhere in beats and agent, it does not really matter how we rename it.