### PR TITLE
Move `cloudid` package

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository is the home to the common libraries used by Elastic Agent and Beats.
 
 Provided packages:
+* `github.com/elastic/elastic-agent-libs/cloudid` is used for parsing `cloud.id` and `cloud.auth` when connecting to the Elastic stack.
 * `github.com/elastic/elastic-agent-libs/config` the previous `config.go` file from `github.com/elastic/beats/v7/libbeat/common`. A minimal wrapper around `github.com/elastic/go-ucfg`. It contains helpers for merging and accessing configuration objects and flags.
 * `github.com/elastic/elastic-agent-libs/str` the previous `stringset.go` file from `github.com/elastic/beats/v7/libbeat/common`. It provides a string set implementation. 
 * `github.com/elastic/elastic-agent-libs/file` is responsible for rotating and writing input and output files.

--- a/cloudid/cloudid.go
+++ b/cloudid/cloudid.go
@@ -1,0 +1,224 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+// Package cloudid contains functions for parsing the cloud.id and cloud.auth
+// settings and modifying the configuration to take them into account.
+package cloudid
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/pkg/errors"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+const defaultCloudPort = "443"
+
+// CloudID encapsulates the encoded (i.e. raw) and decoded parts of Elastic Cloud ID.
+type CloudID struct {
+	id     string
+	esURL  string
+	kibURL string
+
+	auth     string
+	username string
+	password string
+}
+
+// NewCloudID constructs a new CloudID object by decoding the given cloud ID and cloud auth.
+func NewCloudID(cloudID string, cloudAuth string) (*CloudID, error) {
+	cid := CloudID{
+		id:   cloudID,
+		auth: cloudAuth,
+	}
+
+	if err := cid.decode(); err != nil {
+		return nil, err
+	}
+
+	return &cid, nil
+}
+
+// ElasticsearchURL returns the Elasticsearch URL decoded from the cloud ID.
+func (c *CloudID) ElasticsearchURL() string {
+	return c.esURL
+}
+
+// KibanaURL returns the Kibana URL decoded from the cloud ID.
+func (c *CloudID) KibanaURL() string {
+	return c.kibURL
+}
+
+// Username returns the username decoded from the cloud auth.
+func (c *CloudID) Username() string {
+	return c.username
+}
+
+// Password returns the password decoded from the cloud auth.
+func (c *CloudID) Password() string {
+	return c.password
+}
+
+func (c *CloudID) decode() error {
+	var err error
+	if err = c.decodeCloudID(); err != nil {
+		return errors.Wrapf(err, "invalid cloud id '%v'", c.id)
+	}
+
+	if c.auth != "" {
+		if err = c.decodeCloudAuth(); err != nil {
+			return errors.Wrap(err, "invalid cloud auth")
+		}
+	}
+
+	return nil
+}
+
+// decodeCloudID decodes the c.id into c.esURL and c.kibURL
+func (c *CloudID) decodeCloudID() error {
+	cloudID := c.id
+
+	// 1. Ignore anything before `:`.
+	idx := strings.LastIndex(cloudID, ":")
+	if idx >= 0 {
+		cloudID = cloudID[idx+1:]
+	}
+
+	// 2. base64 decode
+	decoded, err := base64.StdEncoding.DecodeString(cloudID)
+	if err != nil {
+		return errors.Wrapf(err, "base64 decoding failed on %s", cloudID)
+	}
+
+	// 3. separate based on `$`
+	words := strings.Split(string(decoded), "$")
+	if len(words) < 3 {
+		return errors.Errorf("Expected at least 3 parts in %s", string(decoded))
+	}
+
+	// 4. extract port from the ES and Kibana host, or use 443 as the default
+	host, port := extractPortFromName(words[0], defaultCloudPort)
+	esID, esPort := extractPortFromName(words[1], port)
+	kbID, kbPort := extractPortFromName(words[2], port)
+
+	// 5. form the URLs
+	esURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", esID, host, esPort)}
+	kibanaURL := url.URL{Scheme: "https", Host: fmt.Sprintf("%s.%s:%s", kbID, host, kbPort)}
+
+	c.esURL = esURL.String()
+	c.kibURL = kibanaURL.String()
+
+	return nil
+}
+
+// decodeCloudAuth splits the c.auth into c.username and c.password.
+func (c *CloudID) decodeCloudAuth() error {
+	cloudAuth := c.auth
+	idx := strings.Index(cloudAuth, ":")
+	if idx < 0 {
+		return errors.New("cloud.auth setting doesn't contain `:` to split between username and password")
+	}
+
+	c.username = cloudAuth[0:idx]
+	c.password = cloudAuth[idx+1:]
+	return nil
+}
+
+// OverwriteSettings modifies the received config object by overwriting the
+// output.elasticsearch.hosts, output.elasticsearch.username, output.elasticsearch.password,
+// setup.kibana.host settings based on values derived from the cloud.id and cloud.auth
+// settings.
+func OverwriteSettings(cfg *config.C) error {
+
+	logger := logp.NewLogger("cloudid")
+	cloudID, _ := cfg.String("cloud.id", -1)
+	cloudAuth, _ := cfg.String("cloud.auth", -1)
+
+	if cloudID == "" && cloudAuth == "" {
+		// nothing to hack
+		return nil
+	}
+
+	logger.Debugf("cloud.id: %s, cloud.auth: %s", cloudID, cloudAuth)
+	if cloudID == "" {
+		return errors.New("cloud.auth specified but cloud.id is empty. Please specify both")
+	}
+
+	// cloudID overwrites
+	cid, err := NewCloudID(cloudID, cloudAuth)
+	if err != nil {
+		return errors.Errorf("Error decoding cloud.id: %v", err)
+	}
+
+	logger.Infof("Setting Elasticsearch and Kibana URLs based on the cloud id: output.elasticsearch.hosts=%s and setup.kibana.host=%s", cid.esURL, cid.kibURL)
+
+	esURLConfig, err := config.NewConfigFrom([]string{cid.ElasticsearchURL()})
+	if err != nil {
+		return err
+	}
+
+	// Before enabling the ES output, check that no other output is enabled
+	tmp := struct {
+		Output config.Namespace `config:"output"`
+	}{}
+	if err := cfg.Unpack(&tmp); err != nil {
+		return err
+	}
+	if out := tmp.Output; out.IsSet() && out.Name() != "elasticsearch" {
+		return errors.Errorf("The cloud.id setting enables the Elasticsearch output, but you already have the %s output enabled in the config", out.Name())
+	}
+
+	err = cfg.SetChild("output.elasticsearch.hosts", -1, esURLConfig)
+	if err != nil {
+		return err
+	}
+
+	err = cfg.SetString("setup.kibana.host", -1, cid.KibanaURL())
+	if err != nil {
+		return err
+	}
+
+	if cloudAuth != "" {
+		// cloudAuth overwrites
+		err = cfg.SetString("output.elasticsearch.username", -1, cid.Username())
+		if err != nil {
+			return err
+		}
+
+		err = cfg.SetString("output.elasticsearch.password", -1, cid.Password())
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// extractPortFromName takes a string in the form `id:port` and returns the
+// ID and the port. If there's no `:`, the default port is returned
+func extractPortFromName(word string, defaultPort string) (id, port string) {
+	idx := strings.LastIndex(word, ":")
+	if idx >= 0 {
+		return word[:idx], word[idx+1:]
+	}
+	return word, defaultPort
+}

--- a/cloudid/cloudid.go
+++ b/cloudid/cloudid.go
@@ -21,11 +21,10 @@ package cloudid
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"net/url"
 	"strings"
-
-	"github.com/pkg/errors"
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -81,12 +80,12 @@ func (c *CloudID) Password() string {
 func (c *CloudID) decode() error {
 	var err error
 	if err = c.decodeCloudID(); err != nil {
-		return errors.Wrapf(err, "invalid cloud id '%v'", c.id)
+		return fmt.Errorf("invalid cloud id '%v': %w", c.id, err)
 	}
 
 	if c.auth != "" {
 		if err = c.decodeCloudAuth(); err != nil {
-			return errors.Wrap(err, "invalid cloud auth")
+			return fmt.Errorf("invalid cloud auth: %w", err)
 		}
 	}
 
@@ -106,13 +105,13 @@ func (c *CloudID) decodeCloudID() error {
 	// 2. base64 decode
 	decoded, err := base64.StdEncoding.DecodeString(cloudID)
 	if err != nil {
-		return errors.Wrapf(err, "base64 decoding failed on %s", cloudID)
+		return fmt.Errorf("base64 decoding failed on %s: %w", cloudID, err)
 	}
 
 	// 3. separate based on `$`
 	words := strings.Split(string(decoded), "$")
 	if len(words) < 3 {
-		return errors.Errorf("Expected at least 3 parts in %s", string(decoded))
+		return fmt.Errorf("expected at least 3 parts in %s", string(decoded))
 	}
 
 	// 4. extract port from the ES and Kibana host, or use 443 as the default
@@ -166,7 +165,7 @@ func OverwriteSettings(cfg *config.C) error {
 	// cloudID overwrites
 	cid, err := NewCloudID(cloudID, cloudAuth)
 	if err != nil {
-		return errors.Errorf("Error decoding cloud.id: %v", err)
+		return fmt.Errorf("error decoding cloud.id: %w", err)
 	}
 
 	logger.Infof("Setting Elasticsearch and Kibana URLs based on the cloud id: output.elasticsearch.hosts=%s and setup.kibana.host=%s", cid.esURL, cid.kibURL)
@@ -184,7 +183,7 @@ func OverwriteSettings(cfg *config.C) error {
 		return err
 	}
 	if out := tmp.Output; out.IsSet() && out.Name() != "elasticsearch" {
-		return errors.Errorf("The cloud.id setting enables the Elasticsearch output, but you already have the %s output enabled in the config", out.Name())
+		return fmt.Errorf("the cloud.id setting enables the Elasticsearch output, but you already have the %s output enabled in the config", out.Name())
 	}
 
 	err = cfg.SetChild("output.elasticsearch.hosts", -1, esURLConfig)

--- a/cloudid/cloudid_test.go
+++ b/cloudid/cloudid_test.go
@@ -1,0 +1,251 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package cloudid
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+func TestDecode(t *testing.T) {
+	tests := []struct {
+		cloudID           string
+		expectedEsURL     string
+		expectedKibanaURL string
+	}{
+		{
+			cloudID:           "staging:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==",
+			expectedEsURL:     "https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443",
+			expectedKibanaURL: "https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443",
+		},
+		{
+			cloudID:           "dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==",
+			expectedEsURL:     "https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443",
+			expectedKibanaURL: "https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443",
+		},
+		{
+			cloudID:           ":dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==",
+			expectedEsURL:     "https://cec6f261a74bf24ce33bb8811b84294f.us-east-1.aws.found.io:443",
+			expectedKibanaURL: "https://c6c2ca6d042249af0cc7d7a9e9625743.us-east-1.aws.found.io:443",
+		},
+		{
+			cloudID:           "gcp-cluster:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZmNlJDBjZDVjZDU2OGVlYmU1M2M4OWViN2NhZTViYWM4YjM3",
+			expectedEsURL:     "https://8a0283af041f195f7729bc04c66a0fce.us-central1.gcp.cloud.es.io:443",
+			expectedKibanaURL: "https://0cd5cd568eebe53c89eb7cae5bac8b37.us-central1.gcp.cloud.es.io:443",
+		},
+		{
+			cloudID:           "custom-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA=",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9243",
+		},
+		{
+			cloudID:           "different-es-kb-port:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2OjkyNDMkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244",
+		},
+		{
+			cloudID:           "only-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwOjkyNDQ=",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244",
+		},
+		{
+			cloudID:           "host-and-kb-set:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvOjkyNDMkYWMzMWViYjkwMjQxNzczMTU3MDQzYzM0ZmQyNmZkNDYkYTRjMDYyMzBlNDhjOGZjZTdiZTg4YTA3NGEzYmIzZTA6OTI0NA==",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:9243",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:9244",
+		},
+		{
+			cloudID:           "extra-items:dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJGFjMzFlYmI5MDI0MTc3MzE1NzA0M2MzNGZkMjZmZDQ2JGE0YzA2MjMwZTQ4YzhmY2U3YmU4OGEwNzRhM2JiM2UwJGFub3RoZXJpZCRhbmRhbm90aGVy",
+			expectedEsURL:     "https://ac31ebb90241773157043c34fd26fd46.us-central1.gcp.cloud.es.io:443",
+			expectedKibanaURL: "https://a4c06230e48c8fce7be88a074a3bb3e0.us-central1.gcp.cloud.es.io:443",
+		},
+	}
+
+	for _, test := range tests {
+		cid, err := NewCloudID(test.cloudID, "")
+		assert.NoError(t, err, test.cloudID)
+
+		assert.Equal(t, cid.ElasticsearchURL(), test.expectedEsURL, test.cloudID)
+		assert.Equal(t, cid.KibanaURL(), test.expectedKibanaURL, test.cloudID)
+	}
+}
+
+func TestDecodeError(t *testing.T) {
+	tests := []struct {
+		cloudID  string
+		errorMsg string
+	}{
+		{
+			cloudID:  "staging:garbagedXMtZWFzdC0xLmF3cy5mb3VuZC5pbyRjZWM2ZjI2MWE3NGJmMjRjZTMzYmI4ODExYjg0Mjk0ZiRjNmMyY2E2ZDA0MjI0OWFmMGNjN2Q3YTllOTYyNTc0Mw==",
+			errorMsg: "base64 decoding failed",
+		},
+		{
+			cloudID:  "dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZg==",
+			errorMsg: "Expected at least 3 parts",
+		},
+	}
+
+	for _, test := range tests {
+		_, err := NewCloudID(test.cloudID, "")
+		assert.Error(t, err, test.cloudID)
+		assert.Contains(t, err.Error(), test.errorMsg, test.cloudID)
+	}
+}
+
+func TestOverwriteSettings(t *testing.T) {
+	tests := []struct {
+		name   string
+		inCfg  map[string]interface{}
+		outCfg map[string]interface{}
+	}{
+		{
+			name: "No cloud-id specified, nothing should change",
+			inCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": "localhost:9200",
+			},
+			outCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": "localhost:9200",
+			},
+		},
+		{
+			name: "cloudid realistic example",
+			inCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": "localhost:9200",
+				"cloud.id":                   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+				"cloud.auth":                 "elastic:changeme",
+			},
+			outCfg: map[string]interface{}{
+				"output.elasticsearch.hosts":    []interface{}{"https://249f3af1f4eee24a84e3b401e68a1b2a.us-east-1.aws.found.io:443"},
+				"output.elasticsearch.username": "elastic",
+				"output.elasticsearch.password": "changeme",
+				"setup.kibana.host":             "https://d4ac7559d4674b7c91abe10856d84304.us-east-1.aws.found.io:443",
+				"cloud.id":                      "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+				"cloud.auth":                    "elastic:changeme",
+			},
+		},
+		{
+			name: "only cloudid specified",
+			inCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": "localhost:9200",
+				"cloud.id":                   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+			},
+			outCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": []interface{}{"https://249f3af1f4eee24a84e3b401e68a1b2a.us-east-1.aws.found.io:443"},
+				"setup.kibana.host":          "https://d4ac7559d4674b7c91abe10856d84304.us-east-1.aws.found.io:443",
+				"cloud.id":                   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+			},
+		},
+		{
+			name: "no output defined",
+			inCfg: map[string]interface{}{
+				"cloud.id": "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+			},
+			outCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": []interface{}{"https://249f3af1f4eee24a84e3b401e68a1b2a.us-east-1.aws.found.io:443"},
+				"setup.kibana.host":          "https://d4ac7559d4674b7c91abe10856d84304.us-east-1.aws.found.io:443",
+				"cloud.id":                   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+			},
+		},
+		{
+			name: "multiple hosts to overwrite",
+			inCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": []string{"localhost:9200", "test", "test1"},
+				"cloud.id":                   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+			},
+			outCfg: map[string]interface{}{
+				"output.elasticsearch.hosts": []interface{}{"https://249f3af1f4eee24a84e3b401e68a1b2a.us-east-1.aws.found.io:443"},
+				"setup.kibana.host":          "https://d4ac7559d4674b7c91abe10856d84304.us-east-1.aws.found.io:443",
+				"cloud.id":                   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Executing test: %s", test.name)
+
+		cfg, err := config.NewConfigFrom(test.inCfg)
+		assert.NoError(t, err)
+
+		err = OverwriteSettings(cfg)
+		assert.NoError(t, err)
+
+		var res map[string]interface{}
+		err = cfg.Unpack(&res)
+		assert.NoError(t, err)
+
+		var expected map[string]interface{}
+		expectedCfg, err := config.NewConfigFrom(test.outCfg)
+		assert.NoError(t, err)
+		err = expectedCfg.Unpack(&expected)
+		assert.NoError(t, err)
+
+		assert.Equal(t, res, expected)
+	}
+}
+
+func TestOverwriteErrors(t *testing.T) {
+	tests := []struct {
+		name   string
+		inCfg  map[string]interface{}
+		errMsg string
+	}{
+		{
+			name: "cloud.auth specified but cloud.id not",
+			inCfg: map[string]interface{}{
+				"cloud.auth": "elastic:changeme",
+			},
+			errMsg: "cloud.auth specified but cloud.id is empty",
+		},
+		{
+			name: "invalid cloud.id",
+			inCfg: map[string]interface{}{
+				"cloud.id": "blah",
+			},
+			errMsg: "Error decoding cloud.id",
+		},
+		{
+			name: "invalid cloud.auth",
+			inCfg: map[string]interface{}{
+				"cloud.id":   "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+				"cloud.auth": "blah",
+			},
+			errMsg: "cloud.auth setting doesn't contain `:`",
+		},
+		{
+			name: "logstash output enabled",
+			inCfg: map[string]interface{}{
+				"cloud.id":              "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
+				"output.logstash.hosts": "localhost:544",
+			},
+			errMsg: "The cloud.id setting enables the Elasticsearch output, but you already have the logstash output enabled",
+		},
+	}
+
+	for _, test := range tests {
+		t.Logf("Executing test: %s", test.name)
+
+		cfg, err := config.NewConfigFrom(test.inCfg)
+		assert.NoError(t, err)
+
+		err = OverwriteSettings(cfg)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), test.errMsg)
+	}
+}

--- a/cloudid/cloudid_test.go
+++ b/cloudid/cloudid_test.go
@@ -98,7 +98,7 @@ func TestDecodeError(t *testing.T) {
 		},
 		{
 			cloudID:  "dXMtY2VudHJhbDEuZ2NwLmNsb3VkLmVzLmlvJDhhMDI4M2FmMDQxZjE5NWY3NzI5YmMwNGM2NmEwZg==",
-			errorMsg: "Expected at least 3 parts",
+			errorMsg: "expected at least 3 parts",
 		},
 	}
 
@@ -218,7 +218,7 @@ func TestOverwriteErrors(t *testing.T) {
 			inCfg: map[string]interface{}{
 				"cloud.id": "blah",
 			},
-			errMsg: "Error decoding cloud.id",
+			errMsg: "error decoding cloud.id",
 		},
 		{
 			name: "invalid cloud.auth",
@@ -234,7 +234,7 @@ func TestOverwriteErrors(t *testing.T) {
 				"cloud.id":              "cloudidtest:dXMtZWFzdC0xLmF3cy5mb3VuZC5pbyQyNDlmM2FmMWY0ZWVlMjRhODRlM2I0MDFlNjhhMWIyYSRkNGFjNzU1OWQ0Njc0YjdjOTFhYmUxMDg1NmQ4NDMwNA==",
 				"output.logstash.hosts": "localhost:544",
 			},
-			errMsg: "The cloud.id setting enables the Elasticsearch output, but you already have the logstash output enabled",
+			errMsg: "the cloud.id setting enables the Elasticsearch output, but you already have the logstash output enabled",
 		},
 	}
 


### PR DESCRIPTION
`cloudid` is used for parsing credentials from `cloud.id` and `cloud.auth` settings. It is required for moving the `monitoring` package to the library.