### PR TITLE
Move linting to Github Actions

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -38,8 +38,6 @@ pipeline {
           dir("${BASE_DIR}"){
             withMageEnv(){
               sh(label: 'Mage check', script: 'mage -v check')
-              sh(label: 'Lint Last Change on Darwin', script: 'GOOS=darwin mage -v llc')
-              sh(label: 'Lint Last Change on Windows', script: 'GOOS=windows mage -v llc')
             }
           }
         }

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -1,0 +1,55 @@
+name: golangci-lint
+on:
+  #push:
+  #  branches:
+  #    - main
+  #    - 8.*
+  #    - 7.17
+  pull_request:
+permissions:
+  contents: read
+  # Optional: allow read access to pull request. Use with `only-new-issues` option.
+  pull-requests: read
+jobs:
+  golangci:
+    strategy:
+      matrix:
+        include:
+          - GOOS: windows
+          - GOOS: linux
+          - GOOS: darwin
+    name: lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Echo details
+        env:
+          GOOS: ${{ matrix.GOOS }}
+        run: echo Go GOOS=$GOOS
+
+      - uses: actions/checkout@v2
+
+      # Uses Go version from the repository.
+      - name: Read .go-version file
+        id: goversion
+        run: echo "::set-output name=version::$(cat .go-version)"
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: "${{ steps.goversion.outputs.version }}"
+
+      - name: golangci-lint
+        env:
+          GOOS: ${{ matrix.GOOS }}
+        uses: golangci/golangci-lint-action@v2
+        with:
+          # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
+          version: v1.44.2
+
+          # Give the job more time to execute.
+          args: --timeout=5m
+
+          # Optional: if set to true then the action will use pre-installed Go.
+          skip-go-installation: true
+
+          # Optional: show only new issues if it's a pull request. The default value is `false`.
+          only-new-issues: true

--- a/magefile.go
+++ b/magefile.go
@@ -36,6 +36,6 @@ var Aliases = map[string]interface{}{
 // Check runs all the checks
 // nolint: deadcode,unparam // it's used as a `mage` target and requires returning an error
 func Check() error {
-	mg.Deps(mage.Deps.CheckModuleTidy, mage.Linter.LastChange)
+	mg.Deps(mage.Deps.CheckModuleTidy)
 	return nil
 }


### PR DESCRIPTION
This will display all the issues in the diff on Github which gives
better developer experience.

Thanks to @ph we can run this Github action with multiple `GOOS`, which was one of the blockers from using the action instead of the mage target.
https://github.com/elastic/elastic-agent/pull/234