### PR TITLE
Enable linting whole files in Github action

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -52,7 +52,7 @@ jobs:
           # which can lead to some frustration from developers who would like to
           # fix a single line in an existing codebase and the linter would force them
           # into fixing all linting issues in the whole file instead
-          args: --timeout=5m --whole-files
+          args: --timeout=30m --whole-files
 
           # Optional: if set to true then the action will use pre-installed Go.
           skip-go-installation: true

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -46,7 +46,13 @@ jobs:
           version: v1.44.2
 
           # Give the job more time to execute.
-          args: --timeout=5m
+          # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,
+          # for some reason, it's very unreliable this way - sometimes it does not report any or some
+          # issues without linting the whole files, so we have to use `--whole-files`
+          # which can lead to some frustration from developers who would like to
+          # fix a single line in an existing codebase and the linter would force them
+          # into fixing all linting issues in the whole file instead
+          args: --timeout=5m --whole-files
 
           # Optional: if set to true then the action will use pre-installed Go.
           skip-go-installation: true


### PR DESCRIPTION
The linter is supposed to support linting of a changed patch only but,
for some reason, it's very unreliable this way - sometimes it does not report any or some
issues without linting the whole files, so we have to use `--whole-files`

For details see https://github.com/elastic/elastic-agent-libs/pull/30