### PR TITLE
Move kibana client

### DIFF
--- a/kibana/client.go
+++ b/kibana/client.go
@@ -1,0 +1,418 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"mime"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"path"
+	"strings"
+
+	"github.com/joeshaw/multierror"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
+	"github.com/elastic/beats/v7/libbeat/common/useragent"
+	"github.com/elastic/beats/v7/libbeat/logp"
+)
+
+var (
+	// We started using Saved Objects API in 7.15. But to help integration
+	// developers migrate their dashboards we are more lenient.
+	MinimumRequiredVersionSavedObjects = common.MustNewVersion("7.14.0")
+)
+
+type Connection struct {
+	URL          string
+	Username     string
+	Password     string
+	APIKey       string
+	ServiceToken string
+	Headers      http.Header
+
+	HTTP    *http.Client
+	Version common.Version
+}
+
+type Client struct {
+	Connection
+	log *logp.Logger
+}
+
+func addToURL(_url, _path string, params url.Values) string {
+	if len(params) == 0 {
+		return _url + _path
+	}
+
+	return strings.Join([]string{_url, _path, "?", params.Encode()}, "")
+}
+
+func extractError(result []byte) error {
+	var kibanaResult struct {
+		Message    string
+		Attributes struct {
+			Objects []struct {
+				Id    string
+				Error struct {
+					Message string
+				}
+			}
+		}
+	}
+	if err := json.Unmarshal(result, &kibanaResult); err != nil {
+		return err
+	}
+	var errs multierror.Errors
+	if kibanaResult.Message != "" {
+		for _, err := range kibanaResult.Attributes.Objects {
+			errs = append(errs, fmt.Errorf("id: %s, message: %s", err.Id, err.Error.Message))
+		}
+		return fmt.Errorf("%s: %+v", kibanaResult.Message, errs.Err())
+	}
+	return nil
+}
+
+func extractMessage(result []byte) error {
+	var kibanaResult struct {
+		Success bool
+		Errors  []struct {
+			Id    string
+			Type  string
+			Error struct {
+				Type       string
+				References []struct {
+					Type string
+					Id   string
+				}
+			}
+		}
+	}
+	if err := json.Unmarshal(result, &kibanaResult); err != nil {
+		return nil
+	}
+
+	if !kibanaResult.Success {
+		var errs multierror.Errors
+		for _, err := range kibanaResult.Errors {
+			errs = append(errs, fmt.Errorf("error: %s, asset ID=%s; asset type=%s; references=%+v", err.Error.Type, err.Id, err.Type, err.Error.References))
+		}
+		return errs.Err()
+	}
+
+	return nil
+}
+
+// NewKibanaClient builds and returns a new Kibana client
+func NewKibanaClient(cfg *common.Config, beatname string) (*Client, error) {
+	config := DefaultClientConfig()
+	if err := cfg.Unpack(&config); err != nil {
+		return nil, err
+	}
+
+	return NewClientWithConfig(&config, beatname)
+}
+
+// NewClientWithConfig creates and returns a kibana client using the given config
+func NewClientWithConfig(config *ClientConfig, beatname string) (*Client, error) {
+	return NewClientWithConfigDefault(config, 5601, beatname)
+}
+
+// NewClientWithConfig creates and returns a kibana client using the given config
+func NewClientWithConfigDefault(config *ClientConfig, defaultPort int, beatname string) (*Client, error) {
+	if err := config.Validate(); err != nil {
+		return nil, err
+	}
+
+	p := config.Path
+	if config.SpaceID != "" {
+		p = path.Join(p, "s", config.SpaceID)
+	}
+	kibanaURL, err := common.MakeURL(config.Protocol, p, config.Host, defaultPort)
+	if err != nil {
+		return nil, fmt.Errorf("invalid Kibana host: %v", err)
+	}
+
+	u, err := url.Parse(kibanaURL)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse the Kibana URL: %v", err)
+	}
+
+	username := config.Username
+	password := config.Password
+
+	if u.User != nil {
+		username = u.User.Username()
+		password, _ = u.User.Password()
+		u.User = nil
+
+		if config.APIKey != "" && (username != "" || password != "") {
+			return nil, fmt.Errorf("cannot set api_key with username/password in Kibana URL")
+		}
+
+		// Re-write URL without credentials.
+		kibanaURL = u.String()
+	}
+
+	log := logp.NewLogger("kibana")
+	log.Infof("Kibana url: %s", kibanaURL)
+
+	headers := make(http.Header)
+	for k, v := range config.Headers {
+		headers.Set(k, v)
+	}
+
+	if beatname == "" {
+		beatname = "Libbeat"
+	}
+	userAgent := useragent.UserAgent(beatname)
+	rt, err := config.Transport.Client(httpcommon.WithHeaderRoundTripper(map[string]string{"User-Agent": userAgent}))
+	if err != nil {
+		return nil, err
+	}
+
+	client := &Client{
+		Connection: Connection{
+			URL:          kibanaURL,
+			Username:     username,
+			Password:     password,
+			APIKey:       config.APIKey,
+			ServiceToken: config.ServiceToken,
+			Headers:      headers,
+			HTTP:         rt,
+		},
+		log: log,
+	}
+
+	if !config.IgnoreVersion {
+		if err = client.readVersion(); err != nil {
+			return nil, fmt.Errorf("fail to get the Kibana version: %v", err)
+		}
+	}
+
+	return client, nil
+}
+
+func (conn *Connection) Request(method, extraPath string,
+	params url.Values, headers http.Header, body io.Reader) (int, []byte, error) {
+
+	resp, err := conn.Send(method, extraPath, params, headers, body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("fail to execute the HTTP %s request: %v", method, err)
+	}
+	defer resp.Body.Close()
+
+	var retError error
+	if resp.StatusCode >= 300 {
+		retError = fmt.Errorf("%v", resp.Status)
+	}
+
+	result, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, fmt.Errorf("fail to read response %s", err)
+	}
+
+	if resp.StatusCode >= 300 {
+		retError = extractError(result)
+	} else {
+		retError = extractMessage(result)
+	}
+	return resp.StatusCode, result, retError
+}
+
+// Sends an application/json request to Kibana with appropriate kbn headers
+func (conn *Connection) Send(method, extraPath string,
+	params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
+
+	return conn.SendWithContext(context.Background(), method, extraPath, params, headers, body)
+}
+
+// SendWithContext sends an application/json request to Kibana with appropriate kbn headers and the given context.
+func (conn *Connection) SendWithContext(ctx context.Context, method, extraPath string,
+	params url.Values, headers http.Header, body io.Reader) (*http.Response, error) {
+
+	reqURL := addToURL(conn.URL, extraPath, params)
+
+	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
+	if err != nil {
+		return nil, fmt.Errorf("fail to create the HTTP %s request: %+v", method, err)
+	}
+
+	if conn.Username != "" || conn.Password != "" {
+		req.SetBasicAuth(conn.Username, conn.Password)
+	}
+	if conn.APIKey != "" {
+		v := "ApiKey " + base64.StdEncoding.EncodeToString([]byte(conn.APIKey))
+		req.Header.Set("Authorization", v)
+	}
+	if conn.ServiceToken != "" {
+		v := "Bearer " + conn.ServiceToken
+		req.Header.Set("Authorization", v)
+	}
+
+	addHeaders(req.Header, conn.Headers)
+	addHeaders(req.Header, headers)
+
+	contentType := req.Header.Get("Content-Type")
+	contentType, _, _ = mime.ParseMediaType(contentType)
+	if contentType != "multipart/form-data" && contentType != "application/ndjson" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("kbn-xsrf", "1")
+
+	return conn.RoundTrip(req)
+}
+
+func addHeaders(out, in http.Header) {
+	for k, vs := range in {
+		for _, v := range vs {
+			out.Add(k, v)
+		}
+	}
+}
+
+// Implements RoundTrip interface
+func (conn *Connection) RoundTrip(r *http.Request) (*http.Response, error) {
+	return conn.HTTP.Do(r)
+}
+
+func (client *Client) readVersion() error {
+	type kibanaVersionResponse struct {
+		Name    string `json:"name"`
+		Version struct {
+			Number   string `json:"number"`
+			Snapshot bool   `json:"build_snapshot"`
+		} `json:"version"`
+	}
+
+	type kibanaVersionResponse5x struct {
+		Name    string `json:"name"`
+		Version string `json:"version"`
+	}
+
+	code, result, err := client.Connection.Request("GET", "/api/status", nil, nil, nil)
+	if err != nil || code >= 400 {
+		return fmt.Errorf("HTTP GET request to %s/api/status fails: %v. Response: %s.",
+			client.Connection.URL, err, truncateString(result))
+	}
+
+	var versionString string
+
+	var kibanaVersion kibanaVersionResponse
+	err = json.Unmarshal(result, &kibanaVersion)
+	if err != nil {
+		return fmt.Errorf("fail to unmarshal the response from GET %s/api/status. Response: %s. Kibana status api returns: %v",
+			client.Connection.URL, truncateString(result), err)
+	}
+
+	versionString = kibanaVersion.Version.Number
+
+	if kibanaVersion.Version.Snapshot {
+		// needed for the tests
+		versionString += "-SNAPSHOT"
+	}
+
+	version, err := common.NewVersion(versionString)
+	if err != nil {
+		return fmt.Errorf("fail to parse kibana version (%v): %+v", versionString, err)
+	}
+
+	client.Version = *version
+	return nil
+}
+
+// GetVersion returns the version read from kibana. The version is not set if
+// IgnoreVersion was set when creating the client.
+func (client *Client) GetVersion() common.Version { return client.Version }
+
+func (client *Client) ImportMultiPartFormFile(url string, params url.Values, filename string, contents string) error {
+	buf := &bytes.Buffer{}
+	w := multipart.NewWriter(buf)
+
+	pHeaders := textproto.MIMEHeader{}
+	pHeaders.Add("Content-Disposition", fmt.Sprintf(`form-data; name="file"; filename="%s"`, filename))
+	pHeaders.Add("Content-Type", "application/ndjson")
+
+	p, err := w.CreatePart(pHeaders)
+	if err != nil {
+		return fmt.Errorf("failed to create multipart writer for payload: %+v", err)
+	}
+	_, err = io.Copy(p, strings.NewReader(contents))
+	if err != nil {
+		return fmt.Errorf("failed to copy contents of the object: %+v", err)
+	}
+	w.Close()
+
+	headers := http.Header{}
+	headers.Add("Content-Type", w.FormDataContentType())
+	statusCode, response, err := client.Connection.Request("POST", url, params, headers, buf)
+	if err != nil || statusCode >= 300 {
+		return fmt.Errorf("returned %d to import file: %v. Response: %s", statusCode, err, response)
+	}
+
+	client.log.Debugf("Imported multipart file to %s with params %v", url, params)
+	return nil
+}
+
+func (client *Client) Close() error { return nil }
+
+// GetDashboard returns the dashboard with the given id with the index pattern removed
+func (client *Client) GetDashboard(id string) ([]byte, error) {
+	if client.Version.LessThan(MinimumRequiredVersionSavedObjects) {
+		return nil, fmt.Errorf("Kibana version must be at least " + MinimumRequiredVersionSavedObjects.String())
+	}
+
+	body := fmt.Sprintf(`{"objects": [{"type": "dashboard", "id": "%s" }], "includeReferencesDeep": true, "excludeExportDetails": true}`, id)
+	statusCode, response, err := client.Request("POST", "/api/saved_objects/_export", nil, nil, strings.NewReader(body))
+	if err != nil || statusCode >= 300 {
+		return nil, fmt.Errorf("error exporting dashboard: %+v, code: %d", err, statusCode)
+	}
+
+	result, err := RemoveIndexPattern(response)
+	if err != nil {
+		return nil, fmt.Errorf("error removing index pattern: %+v", err)
+	}
+
+	return result, nil
+}
+
+// truncateString returns a truncated string if the length is greater than 250
+// runes. If the string is truncated "... (truncated)" is appended. Newlines are
+// replaced by spaces in the returned string.
+//
+// This function is useful for logging raw HTTP responses with errors when those
+// responses can be very large (such as an HTML page with CSS content).
+func truncateString(b []byte) string {
+	const maxLength = 250
+	runes := bytes.Runes(b)
+	if len(runes) > maxLength {
+		runes = append(runes[:maxLength], []rune("... (truncated)")...)
+	}
+
+	return strings.Replace(string(runes), "\n", " ", -1)
+}

--- a/kibana/client_config.go
+++ b/kibana/client_config.go
@@ -1,0 +1,66 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"fmt"
+
+	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
+)
+
+// ClientConfig to connect to Kibana
+type ClientConfig struct {
+	Protocol     string `config:"protocol" yaml:"protocol,omitempty"`
+	Host         string `config:"host" yaml:"host,omitempty"`
+	Path         string `config:"path" yaml:"path,omitempty"`
+	SpaceID      string `config:"space.id" yaml:"space.id,omitempty"`
+	Username     string `config:"username" yaml:"username,omitempty"`
+	Password     string `config:"password" yaml:"password,omitempty"`
+	APIKey       string `config:"api_key" yaml:"api_key,omitempty"`
+	ServiceToken string `config:"service_token" yaml:"service_token,omitempty"`
+
+	// Headers holds headers to include in every request sent to Kibana.
+	Headers map[string]string `config:"headers" yaml:"headers,omitempty"`
+
+	IgnoreVersion bool
+
+	Transport httpcommon.HTTPTransportSettings `config:",inline" yaml:",inline"`
+}
+
+// DefaultClientConfig connects to a locally running kibana over HTTP
+func DefaultClientConfig() ClientConfig {
+	return ClientConfig{
+		Protocol:     "http",
+		Host:         "localhost:5601",
+		Path:         "",
+		SpaceID:      "",
+		Username:     "",
+		Password:     "",
+		APIKey:       "",
+		ServiceToken: "",
+		Transport:    httpcommon.DefaultHTTPTransportSettings(),
+	}
+}
+
+func (c *ClientConfig) Validate() error {
+	if c.APIKey != "" && (c.Username != "" || c.Password != "") {
+		return fmt.Errorf("cannot set both api_key and username/password")
+	}
+
+	return nil
+}

--- a/kibana/client_config.go
+++ b/kibana/client_config.go
@@ -20,7 +20,7 @@ package kibana
 import (
 	"fmt"
 
-	"github.com/elastic/beats/v7/libbeat/common/transport/httpcommon"
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
 // ClientConfig to connect to Kibana

--- a/kibana/client_config_test.go
+++ b/kibana/client_config_test.go
@@ -1,0 +1,76 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestClientConfigValdiate(t *testing.T) {
+	tests := []struct {
+		name string
+		c    *ClientConfig
+		err  error
+	}{{
+		name: "empty params",
+		c:    &ClientConfig{},
+		err:  nil,
+	}, {
+		name: "username and password",
+		c: &ClientConfig{
+			Username: "user",
+			Password: "pass",
+		},
+		err: nil,
+	}, {
+		name: "api_key",
+		c: &ClientConfig{
+			APIKey: "api-key",
+		},
+		err: nil,
+	}, {
+		name: "service_token",
+		c: &ClientConfig{
+			ServiceToken: "service_token",
+		},
+		err: nil,
+	}, {
+		name: "username and api_key",
+		c: &ClientConfig{
+			Username: "user",
+			APIKey:   "apiKey",
+		},
+		err: fmt.Errorf("cannot set both api_key and username/password"),
+	}}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.c.Validate()
+			if tt.err == nil {
+				assert.Nil(t, err)
+			} else {
+				assert.EqualError(t, err, tt.err.Error())
+			}
+		})
+	}
+
+}

--- a/kibana/client_test.go
+++ b/kibana/client_test.go
@@ -1,0 +1,185 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/beats/v7/libbeat/common"
+)
+
+func TestErrorJson(t *testing.T) {
+	// also common 200: {"objects":[{"id":"apm-*","type":"index-pattern","error":{"message":"[doc][index-pattern:test-*]: version conflict, document already exists (current version [1])"}}]}
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message": "Cannot export dashboard", "attributes":{"objects":[{"id":"test-*","type":"index-pattern","error":{"message":"action [indices:data/write/bulk[s]] is unauthorized for user [test]"}}]}}`))
+	}))
+	defer kibanaTs.Close()
+
+	conn := Connection{
+		URL:  kibanaTs.URL,
+		HTTP: http.DefaultClient,
+	}
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
+	assert.Equal(t, http.StatusUnauthorized, code)
+	assert.Error(t, err)
+}
+
+func TestErrorBadJson(t *testing.T) {
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusGone)
+		w.Write([]byte(`{`))
+	}))
+	defer kibanaTs.Close()
+
+	conn := Connection{
+		URL:  kibanaTs.URL,
+		HTTP: http.DefaultClient,
+	}
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
+	assert.Equal(t, http.StatusGone, code)
+	assert.Error(t, err)
+}
+
+func TestErrorJsonWithHTTPOK(t *testing.T) {
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"successCount":0,"success":false,"warnings":[],"errors":[{"id":"abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs","type":"dashboard","title":"[Filebeat MongoDB] Overview ECS","meta":{"title":"[Filebeat MongoDB] Overview ECS","icon":"dashboardApp"},"error":{"type":"missing_references","references":[{"type":"search","id":"e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs"},{"type":"search","id":"bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs"}]}}]}`))
+	}))
+	defer kibanaTs.Close()
+
+	conn := Connection{
+		URL:  kibanaTs.URL,
+		HTTP: http.DefaultClient,
+	}
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Error(t, err)
+}
+
+func TestSuccess(t *testing.T) {
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{"objects":[{"id":"test-*","type":"index-pattern","updated_at":"2018-01-24T19:04:13.371Z","version":1}]}`))
+
+		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
+		assert.Equal(t, "bar", r.Header.Get("foo"))
+	}))
+	defer kibanaTs.Close()
+
+	conn := Connection{
+		URL:  kibanaTs.URL,
+		HTTP: http.DefaultClient,
+	}
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+}
+
+func TestServiceToken(t *testing.T) {
+	serviceToken := "fakeservicetoken"
+
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`{}`))
+
+		assert.Equal(t, "Bearer "+serviceToken, r.Header.Get("Authorization"))
+	}))
+	defer kibanaTs.Close()
+
+	conn := Connection{
+		URL:          kibanaTs.URL,
+		HTTP:         http.DefaultClient,
+		ServiceToken: serviceToken,
+	}
+	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
+	assert.Equal(t, http.StatusOK, code)
+	assert.NoError(t, err)
+}
+
+func TestNewKibanaClient(t *testing.T) {
+	var requests []*http.Request
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r)
+		if r.URL.Path == "/api/status" {
+			w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
+		}
+	}))
+	defer kibanaTs.Close()
+
+	client, err := NewKibanaClient(common.MustNewConfigFrom(fmt.Sprintf(`
+protocol: http
+host: %s
+headers:
+  key: value
+  content-type: text/plain
+  accept: text/plain
+  kbn-xsrf: 0
+`, kibanaTs.Listener.Addr().String())), "Testbeat")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+
+	// NewKibanaClient issues a request to /api/status to fetch the version.
+	require.Len(t, requests, 2)
+	assert.Equal(t, "/api/status", requests[0].URL.Path)
+	assert.Equal(t, []string{"value"}, requests[0].Header.Values("key"))
+	assert.Equal(t, "1.2.3-beta-SNAPSHOT", client.Version.String())
+
+	// Headers specified in cient.Request are added to those defined in config.
+	//
+	// Content-Type, Accept, and kbn-xsrf cannot be overridden.
+	assert.Equal(t, "/foo", requests[1].URL.Path)
+	assert.Equal(t, []string{"value", "another_value"}, requests[1].Header.Values("key"))
+	assert.Equal(t, []string{"application/json"}, requests[1].Header.Values("Content-Type"))
+	assert.Equal(t, []string{"application/json"}, requests[1].Header.Values("Accept"))
+	assert.Equal(t, []string{"1"}, requests[1].Header.Values("kbn-xsrf"))
+
+}
+
+func TestNewKibanaClientWithMultipartData(t *testing.T) {
+	var requests []*http.Request
+	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests = append(requests, r)
+		if r.URL.Path == "/api/status" {
+			w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
+		}
+	}))
+	defer kibanaTs.Close()
+
+	client, err := NewKibanaClient(common.MustNewConfigFrom(fmt.Sprintf(`
+protocol: http
+host: %s
+headers:
+  content-type: multipart/form-data; boundary=46bea21be603a2c2ea6f51571a5e1baf5ea3be8ebd7101199320607b36ff
+  accept: text/plain
+  kbn-xsrf: 0
+`, kibanaTs.Listener.Addr().String())), "Testbeat")
+	require.NoError(t, err)
+	require.NotNil(t, client)
+
+	client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+
+	assert.Equal(t, []string{"multipart/form-data; boundary=46bea21be603a2c2ea6f51571a5e1baf5ea3be8ebd7101199320607b36ff"}, requests[1].Header.Values("Content-Type"))
+
+}

--- a/kibana/client_test.go
+++ b/kibana/client_test.go
@@ -39,63 +39,56 @@ const (
 
 func TestErrorJson(t *testing.T) {
 	// also common 200: {"objects":[{"id":"apm-*","type":"index-pattern","error":{"message":"[doc][index-pattern:test-*]: version conflict, document already exists (current version [1])"}}]}
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusUnauthorized)
-		w.Write([]byte(`{"message": "Cannot export dashboard", "attributes":{"objects":[{"id":"test-*","type":"index-pattern","error":{"message":"action [indices:data/write/bulk[s]] is unauthorized for user [test]"}}]}}`))
+		_, _ = w.Write([]byte(`{"message": "Cannot export dashboard", "attributes":{"objects":[{"id":"test-*","type":"index-pattern","error":{"message":"action [indices:data/write/bulk[s]] is unauthorized for user [test]"}}]}}`))
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
+	assertConnection(t, kibanaTS.URL, http.StatusUnauthorized)
+}
+
+func assertConnection(t *testing.T, URL string, expectedStatusCode int) {
 	conn := Connection{
-		URL:  kibanaTs.URL,
+		URL:  URL,
 		HTTP: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
-	assert.Equal(t, http.StatusUnauthorized, code)
+	assert.Equal(t, expectedStatusCode, code)
 	assert.Error(t, err)
+
 }
 
 func TestErrorBadJson(t *testing.T) {
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusGone)
-		w.Write([]byte(`{`))
+		_, _ = w.Write([]byte(`{`))
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
-	conn := Connection{
-		URL:  kibanaTs.URL,
-		HTTP: http.DefaultClient,
-	}
-	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
-	assert.Equal(t, http.StatusGone, code)
-	assert.Error(t, err)
+	assertConnection(t, kibanaTS.URL, http.StatusGone)
 }
 
 func TestErrorJsonWithHTTPOK(t *testing.T) {
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"successCount":0,"success":false,"warnings":[],"errors":[{"id":"abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs","type":"dashboard","title":"[Filebeat MongoDB] Overview ECS","meta":{"title":"[Filebeat MongoDB] Overview ECS","icon":"dashboardApp"},"error":{"type":"missing_references","references":[{"type":"search","id":"e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs"},{"type":"search","id":"bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs"}]}}]}`))
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"successCount":0,"success":false,"warnings":[],"errors":[{"id":"abcf35b0-0a82-11e8-bffe-ff7d4f68cf94-ecs","type":"dashboard","title":"[Filebeat MongoDB] Overview ECS","meta":{"title":"[Filebeat MongoDB] Overview ECS","icon":"dashboardApp"},"error":{"type":"missing_references","references":[{"type":"search","id":"e49fe000-0a7e-11e8-bffe-ff7d4f68cf94-ecs"},{"type":"search","id":"bfc96a60-0a80-11e8-bffe-ff7d4f68cf94-ecs"}]}}]}`))
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
-	conn := Connection{
-		URL:  kibanaTs.URL,
-		HTTP: http.DefaultClient,
-	}
-	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, nil, nil)
-	assert.Equal(t, http.StatusOK, code)
-	assert.Error(t, err)
+	assertConnection(t, kibanaTS.URL, http.StatusOK)
 }
 
 func TestSuccess(t *testing.T) {
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{"objects":[{"id":"test-*","type":"index-pattern","updated_at":"2018-01-24T19:04:13.371Z","version":1}]}`))
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{"objects":[{"id":"test-*","type":"index-pattern","updated_at":"2018-01-24T19:04:13.371Z","version":1}]}`))
 
 		assert.Equal(t, "application/json", r.Header.Get("Content-Type"))
 		assert.Equal(t, "bar", r.Header.Get("foo"))
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
 	conn := Connection{
-		URL:  kibanaTs.URL,
+		URL:  kibanaTS.URL,
 		HTTP: http.DefaultClient,
 	}
 	code, _, err := conn.Request(http.MethodPost, "", url.Values{}, http.Header{"foo": []string{"bar"}}, nil)
@@ -106,15 +99,15 @@ func TestSuccess(t *testing.T) {
 func TestServiceToken(t *testing.T) {
 	serviceToken := "fakeservicetoken"
 
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write([]byte(`{}`))
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(`{}`))
 
 		assert.Equal(t, "Bearer "+serviceToken, r.Header.Get("Authorization"))
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
 	conn := Connection{
-		URL:          kibanaTs.URL,
+		URL:          kibanaTS.URL,
 		HTTP:         http.DefaultClient,
 		ServiceToken: serviceToken,
 	}
@@ -125,13 +118,13 @@ func TestServiceToken(t *testing.T) {
 
 func TestNewKibanaClient(t *testing.T) {
 	var requests []*http.Request
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests = append(requests, r)
-		if r.URL.Path == "/api/status" {
-			w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
+		if r.URL.Path == statusAPI {
+			_, _ = w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
 		}
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
 	client, err := NewKibanaClient(config.MustNewConfigFrom(fmt.Sprintf(`
 protocol: http
@@ -141,15 +134,16 @@ headers:
   content-type: text/plain
   accept: text/plain
   kbn-xsrf: 0
-`, kibanaTs.Listener.Addr().String())), binaryName, v, commit, buildTime)
+`, kibanaTS.Listener.Addr().String())), binaryName, v, commit, buildTime)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+	_, _, err = client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+	require.NoError(t, err)
 
 	// NewKibanaClient issues a request to /api/status to fetch the version.
 	require.Len(t, requests, 2)
-	assert.Equal(t, "/api/status", requests[0].URL.Path)
+	assert.Equal(t, statusAPI, requests[0].URL.Path)
 	assert.Equal(t, []string{"value"}, requests[0].Header.Values("key"))
 	assert.Equal(t, "1.2.3-beta-SNAPSHOT", client.Version.String())
 
@@ -166,13 +160,13 @@ headers:
 
 func TestNewKibanaClientWithMultipartData(t *testing.T) {
 	var requests []*http.Request
-	kibanaTs := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		requests = append(requests, r)
-		if r.URL.Path == "/api/status" {
-			w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
+		if r.URL.Path == statusAPI {
+			_, _ = w.Write([]byte(`{"version":{"number":"1.2.3-beta","build_snapshot":true}}`))
 		}
 	}))
-	defer kibanaTs.Close()
+	defer kibanaTS.Close()
 
 	client, err := NewKibanaClient(config.MustNewConfigFrom(fmt.Sprintf(`
 protocol: http
@@ -181,11 +175,12 @@ headers:
   content-type: multipart/form-data; boundary=46bea21be603a2c2ea6f51571a5e1baf5ea3be8ebd7101199320607b36ff
   accept: text/plain
   kbn-xsrf: 0
-`, kibanaTs.Listener.Addr().String())), binaryName, v, commit, buildTime)
+`, kibanaTS.Listener.Addr().String())), binaryName, v, commit, buildTime)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+	_, _, err = client.Request(http.MethodPost, "/foo", url.Values{}, http.Header{"key": []string{"another_value"}}, nil)
+	require.NoError(t, err)
 
 	assert.Equal(t, []string{"multipart/form-data; boundary=46bea21be603a2c2ea6f51571a5e1baf5ea3be8ebd7101199320607b36ff"}, requests[1].Header.Values("Content-Type"))
 

--- a/kibana/client_test.go
+++ b/kibana/client_test.go
@@ -27,7 +27,14 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/elastic/beats/v7/libbeat/common"
+	"github.com/elastic/elastic-agent-libs/config"
+)
+
+const (
+	binaryName = "Testbeat"
+	v          = "9.9.9"
+	commit     = "1234abcd"
+	buildTime  = "20001212"
 )
 
 func TestErrorJson(t *testing.T) {
@@ -126,7 +133,7 @@ func TestNewKibanaClient(t *testing.T) {
 	}))
 	defer kibanaTs.Close()
 
-	client, err := NewKibanaClient(common.MustNewConfigFrom(fmt.Sprintf(`
+	client, err := NewKibanaClient(config.MustNewConfigFrom(fmt.Sprintf(`
 protocol: http
 host: %s
 headers:
@@ -134,7 +141,7 @@ headers:
   content-type: text/plain
   accept: text/plain
   kbn-xsrf: 0
-`, kibanaTs.Listener.Addr().String())), "Testbeat")
+`, kibanaTs.Listener.Addr().String())), binaryName, v, commit, buildTime)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
@@ -167,14 +174,14 @@ func TestNewKibanaClientWithMultipartData(t *testing.T) {
 	}))
 	defer kibanaTs.Close()
 
-	client, err := NewKibanaClient(common.MustNewConfigFrom(fmt.Sprintf(`
+	client, err := NewKibanaClient(config.MustNewConfigFrom(fmt.Sprintf(`
 protocol: http
 host: %s
 headers:
   content-type: multipart/form-data; boundary=46bea21be603a2c2ea6f51571a5e1baf5ea3be8ebd7101199320607b36ff
   accept: text/plain
   kbn-xsrf: 0
-`, kibanaTs.Listener.Addr().String())), "Testbeat")
+`, kibanaTs.Listener.Addr().String())), binaryName, v, commit, buildTime)
 	require.NoError(t, err)
 	require.NotNil(t, client)
 

--- a/kibana/url.go
+++ b/kibana/url.go
@@ -1,0 +1,121 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package common
+
+import (
+	"fmt"
+	"net"
+	"net/url"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var hasScheme = regexp.MustCompile(`^([a-z][a-z0-9+\-.]*)://`)
+
+// MakeURL creates the url based on the url configuration.
+// Adds missing parts with defaults (scheme, host, port)
+func MakeURL(defaultScheme string, defaultPath string, rawURL string, defaultPort int) (string, error) {
+	if defaultScheme == "" {
+		defaultScheme = "http"
+	}
+
+	if !hasScheme.MatchString(rawURL) {
+		rawURL = fmt.Sprintf("%v://%v", defaultScheme, rawURL)
+	}
+
+	addr, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+
+	scheme := addr.Scheme
+	host := addr.Host
+	port := ""
+	if defaultPort > 0 {
+		port = strconv.Itoa(defaultPort)
+	}
+
+	if host == "" {
+		host = "localhost"
+	} else {
+
+		// split host and optional port
+		if splitHost, splitPort, err := net.SplitHostPort(host); err == nil {
+			host = splitHost
+			port = splitPort
+		}
+
+		// Check if ipv6
+		if strings.Count(host, ":") > 1 && strings.Count(host, "]") == 0 {
+			host = "[" + host + "]"
+		}
+	}
+
+	// Assign default path if not set
+	if addr.Path == "" {
+		addr.Path = defaultPath
+	}
+
+	// reconstruct url
+	addr.Scheme = scheme
+	addr.Host = host
+	if port != "" {
+		addr.Host += ":" + port
+	}
+
+	return addr.String(), nil
+}
+
+func EncodeURLParams(url string, params url.Values) string {
+	if len(params) == 0 {
+		return url
+	}
+
+	return strings.Join([]string{url, "?", params.Encode()}, "")
+}
+
+type ParseHint func(raw string) string
+
+// ParseURL tries to parse a URL and return the parsed result.
+func ParseURL(raw string, hints ...ParseHint) (*url.URL, error) {
+	if raw == "" {
+		return nil, nil
+	}
+
+	if len(hints) == 0 {
+		hints = append(hints, WithDefaultScheme("http"))
+	}
+
+	if strings.Index(raw, "://") == -1 {
+		for _, hint := range hints {
+			raw = hint(raw)
+		}
+	}
+
+	return url.Parse(raw)
+}
+
+func WithDefaultScheme(scheme string) ParseHint {
+	return func(raw string) string {
+		if !strings.Contains(raw, "://") {
+			return scheme + "://" + raw
+		}
+		return raw
+	}
+}

--- a/kibana/url.go
+++ b/kibana/url.go
@@ -102,7 +102,7 @@ func ParseURL(raw string, hints ...ParseHint) (*url.URL, error) {
 		hints = append(hints, WithDefaultScheme("http"))
 	}
 
-	if strings.Index(raw, "://") == -1 {
+	if !strings.Contains(raw, "://") {
 		for _, hint := range hints {
 			raw = hint(raw)
 		}

--- a/kibana/url.go
+++ b/kibana/url.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package kibana
 
 import (
 	"fmt"

--- a/kibana/url_test.go
+++ b/kibana/url_test.go
@@ -1,0 +1,170 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !integration
+// +build !integration
+
+package common
+
+import (
+	"fmt"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetUrl(t *testing.T) {
+	// List of inputs / outputs that must match after fetching url
+	// Setting a path without a scheme is not allowed. Example: 192.168.1.1:9200/hello
+	inputOutput := map[string]string{
+
+		"":                     "http://localhost:9200",
+		"http://localhost":     "http://localhost:9200",
+		"http://localhost:80":  "http://localhost:80",
+		"http://localhost:80/": "http://localhost:80/",
+		"http://localhost/":    "http://localhost:9200/",
+
+		// no schema + hostname
+		"33f3600fd5c1bb599af557c36a4efb08.host":       "http://33f3600fd5c1bb599af557c36a4efb08.host:9200",
+		"33f3600fd5c1bb599af557c36a4efb08.host:12345": "http://33f3600fd5c1bb599af557c36a4efb08.host:12345",
+		"localhost":        "http://localhost:9200",
+		"localhost:80":     "http://localhost:80",
+		"localhost:80/":    "http://localhost:80/",
+		"localhost/":       "http://localhost:9200/",
+		"localhost/mypath": "http://localhost:9200/mypath",
+
+		// shema + ipv4
+		"http://192.168.1.1:80":        "http://192.168.1.1:80",
+		"https://192.168.1.1:80/hello": "https://192.168.1.1:80/hello",
+		"http://192.168.1.1":           "http://192.168.1.1:9200",
+		"http://192.168.1.1/hello":     "http://192.168.1.1:9200/hello",
+
+		// no schema + ipv4
+		"192.168.1.1":          "http://192.168.1.1:9200",
+		"192.168.1.1:80":       "http://192.168.1.1:80",
+		"192.168.1.1/hello":    "http://192.168.1.1:9200/hello",
+		"192.168.1.1:80/hello": "http://192.168.1.1:80/hello",
+
+		// schema + ipv6
+		"http://[2001:db8::1]:80":                              "http://[2001:db8::1]:80",
+		"http://[2001:db8::1]":                                 "http://[2001:db8::1]:9200",
+		"https://[2001:db8::1]:9200":                           "https://[2001:db8::1]:9200",
+		"http://FE80:0000:0000:0000:0202:B3FF:FE1E:8329":       "http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:9200",
+		"http://[2001:db8::1]:80/hello":                        "http://[2001:db8::1]:80/hello",
+		"http://[2001:db8::1]/hello":                           "http://[2001:db8::1]:9200/hello",
+		"https://[2001:db8::1]:9200/hello":                     "https://[2001:db8::1]:9200/hello",
+		"http://FE80:0000:0000:0000:0202:B3FF:FE1E:8329/hello": "http://[FE80:0000:0000:0000:0202:B3FF:FE1E:8329]:9200/hello",
+
+		// no schema + ipv6
+		"2001:db8::1":            "http://[2001:db8::1]:9200",
+		"[2001:db8::1]:80":       "http://[2001:db8::1]:80",
+		"[2001:db8::1]":          "http://[2001:db8::1]:9200",
+		"2001:db8::1/hello":      "http://[2001:db8::1]:9200/hello",
+		"[2001:db8::1]:80/hello": "http://[2001:db8::1]:80/hello",
+		"[2001:db8::1]/hello":    "http://[2001:db8::1]:9200/hello",
+	}
+
+	for input, output := range inputOutput {
+		urlNew, err := MakeURL("", "", input, 9200)
+		assert.NoError(t, err)
+		assert.Equal(t, output, urlNew, fmt.Sprintf("input: %v", input))
+	}
+
+	inputOutputWithDefaults := map[string]string{
+		"http://localhost":                          "http://localhost:9200/hello",
+		"http://localhost/test":                     "http://localhost:9200/test",
+		"192.156.4.5":                               "https://192.156.4.5:9200/hello",
+		"http://username:password@es.found.io:9324": "http://username:password@es.found.io:9324/hello",
+	}
+
+	for input, output := range inputOutputWithDefaults {
+		urlNew, err := MakeURL("https", "/hello", input, 9200)
+		assert.NoError(t, err)
+		assert.Equal(t, output, urlNew)
+	}
+}
+
+func TestURLParamsEncode(t *testing.T) {
+	inputOutputWithParams := map[string]string{
+		"http://localhost": "http://localhost:5601?dashboard=first&dashboard=second",
+	}
+
+	params := url.Values{}
+	params.Add("dashboard", "first")
+	params.Add("dashboard", "second")
+
+	for input, output := range inputOutputWithParams {
+		urlNew, err := MakeURL("", "", input, 5601)
+		urlWithParams := EncodeURLParams(urlNew, params)
+		assert.NoError(t, err)
+		assert.Equal(t, output, urlWithParams)
+	}
+}
+
+func TestParseURL(t *testing.T) {
+	tests := map[string]struct {
+		input           string
+		hints           []ParseHint
+		expected        string
+		errorAssertFunc require.ErrorAssertionFunc
+	}{
+		"http": {
+			"http://host:1234/path",
+			nil,
+			"http://host:1234/path",
+			require.NoError,
+		},
+		"https": {
+			"https://host:1234/path",
+			nil,
+			"https://host:1234/path",
+			require.NoError,
+		},
+		"no_scheme": {
+			"host:1234/path",
+			nil,
+			"http://host:1234/path",
+			require.NoError,
+		},
+		"default_scheme_https": {
+			"host:1234/path",
+			[]ParseHint{WithDefaultScheme("https")},
+			"https://host:1234/path",
+			require.NoError,
+		},
+		"invalid": {
+			"foobar:port",
+			nil,
+			"",
+			require.Error,
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			u, err := ParseURL(test.input, test.hints...)
+			test.errorAssertFunc(t, err)
+			if test.expected != "" {
+				require.Equal(t, test.expected, u.String())
+			} else {
+				require.Nil(t, u)
+			}
+		})
+	}
+}

--- a/kibana/url_test.go
+++ b/kibana/url_test.go
@@ -18,7 +18,7 @@
 //go:build !integration
 // +build !integration
 
-package common
+package kibana
 
 import (
 	"fmt"

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -1,0 +1,47 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package useragent
+
+import (
+	"runtime"
+	"strings"
+
+	"github.com/elastic/beats/v7/libbeat/version"
+)
+
+// UserAgent takes the capitalized name of the current beat and returns
+// an RFC compliant user agent string for that beat.
+func UserAgent(beatNameCapitalized string, additionalComments ...string) string {
+	var builder strings.Builder
+	builder.WriteString("Elastic-" + beatNameCapitalized + "/" + version.GetDefaultVersion() + " ")
+	uaValues := []string{
+		runtime.GOOS,
+		runtime.GOARCH,
+		version.Commit(),
+		version.BuildTime().String(),
+	}
+	for _, val := range additionalComments {
+		if val != "" {
+			uaValues = append(uaValues, val)
+		}
+	}
+	builder.WriteByte('(')
+	builder.WriteString(strings.Join(uaValues, "; "))
+	builder.WriteByte(')')
+	return builder.String()
+}

--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -20,20 +20,18 @@ package useragent
 import (
 	"runtime"
 	"strings"
-
-	"github.com/elastic/beats/v7/libbeat/version"
 )
 
 // UserAgent takes the capitalized name of the current beat and returns
 // an RFC compliant user agent string for that beat.
-func UserAgent(beatNameCapitalized string, additionalComments ...string) string {
+func UserAgent(binaryNameCapitalized string, version, commit, buildTime string, additionalComments ...string) string {
 	var builder strings.Builder
-	builder.WriteString("Elastic-" + beatNameCapitalized + "/" + version.GetDefaultVersion() + " ")
+	builder.WriteString("Elastic-" + binaryNameCapitalized + "/" + version + " ")
 	uaValues := []string{
 		runtime.GOOS,
 		runtime.GOARCH,
-		version.Commit(),
-		version.BuildTime().String(),
+		commit,
+		buildTime,
 	}
 	for _, val := range additionalComments {
 		if val != "" {

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -1,0 +1,33 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package useragent
+
+import (
+	"regexp"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestUserAgent(t *testing.T) {
+	ua := UserAgent("FakeBeat")
+	assert.Regexp(t, regexp.MustCompile("^Elastic-FakeBeat"), ua)
+
+	ua2 := UserAgent("FakeBeat", "integration_name/1.2.3")
+	assert.Regexp(t, regexp.MustCompile("; integration_name\\/1\\.2\\.3\\)$"), ua2)
+}

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -24,10 +24,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+const (
+	v         = "9.9.9"
+	commit    = "1234abcd"
+	buildTime = "20001212"
+)
+
 func TestUserAgent(t *testing.T) {
-	ua := UserAgent("FakeBeat")
+	ua := UserAgent("FakeBeat", v, commit, buildTime)
 	assert.Regexp(t, regexp.MustCompile("^Elastic-FakeBeat"), ua)
 
-	ua2 := UserAgent("FakeBeat", "integration_name/1.2.3")
+	ua2 := UserAgent("FakeBeat", v, commit, buildTime, "integration_name/1.2.3")
 	assert.Regexp(t, regexp.MustCompile("; integration_name\\/1\\.2\\.3\\)$"), ua2)
 }

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -32,8 +32,8 @@ const (
 
 func TestUserAgent(t *testing.T) {
 	ua := UserAgent("FakeBeat", v, commit, buildTime)
-	assert.Regexp(t, regexp.MustCompile("^Elastic-FakeBeat"), ua)
+	assert.Regexp(t, regexp.MustCompile(`^Elastic-FakeBeat`), ua)
 
 	ua2 := UserAgent("FakeBeat", v, commit, buildTime, "integration_name/1.2.3")
-	assert.Regexp(t, regexp.MustCompile("; integration_name\\/1\\.2\\.3\\)$"), ua2)
+	assert.Regexp(t, regexp.MustCompile(`; integration_name\/1\.2\.3\)$`), ua2)
 }

--- a/version/version.go
+++ b/version/version.go
@@ -1,0 +1,188 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package common
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+	"strings"
+)
+
+type Version struct {
+	version string
+	Major   int
+	Minor   int
+	Bugfix  int
+	Meta    string
+}
+
+// MustNewVersion creates a version from the given version string.
+// If the version string is invalid, MustNewVersion panics.
+func MustNewVersion(version string) *Version {
+	v, err := NewVersion(version)
+	if err != nil {
+		panic(err)
+	}
+	return v
+}
+
+// NewVersion expects a string in the format:
+// major.minor.bugfix(-meta)
+func NewVersion(version string) (*Version, error) {
+	v := Version{
+		version: version,
+	}
+
+	// Check for meta info
+	if strings.Contains(version, "-") {
+		tmp := strings.Split(version, "-")
+		version = tmp[0]
+		v.Meta = tmp[1]
+	}
+
+	versions := strings.Split(version, ".")
+	if len(versions) != 3 {
+		return nil, fmt.Errorf("Passed version is not semver: %s", version)
+	}
+
+	var err error
+	v.Major, err = strconv.Atoi(versions[0])
+	if err != nil {
+		return nil, fmt.Errorf("Could not convert major to integer: %s", versions[0])
+	}
+
+	v.Minor, err = strconv.Atoi(versions[1])
+	if err != nil {
+		return nil, fmt.Errorf("Could not convert minor to integer: %s", versions[1])
+	}
+
+	v.Bugfix, err = strconv.Atoi(versions[2])
+	if err != nil {
+		return nil, fmt.Errorf("Could not convert bugfix to integer: %s", versions[2])
+	}
+
+	return &v, nil
+}
+
+// IsValid returns true if the version object stores a successfully parsed version number.
+func (v *Version) IsValid() bool {
+	return v.version != ""
+}
+
+func (v *Version) IsMajor(major int) bool {
+	return major == v.Major
+}
+
+// LessThan returns true if v is strictly smaller than v1. When comparing, the major,
+// minor, bugfix and pre-release numbers are compared in order.
+func (v *Version) LessThanOrEqual(withMeta bool, v1 *Version) bool {
+	if withMeta && v.version == v1.version {
+		return true
+	}
+	if v.Major < v1.Major {
+		return true
+	}
+	if v.Major == v1.Major {
+		if v.Minor < v1.Minor {
+			return true
+		}
+		if v.Minor == v1.Minor {
+			if v.Bugfix < v1.Bugfix {
+				return true
+			}
+			if v.Bugfix == v1.Bugfix {
+				if withMeta {
+					return v.metaIsLessThanOrEqual(v1)
+				} else {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// LessThan returns true if v is strictly smaller than v1. When comparing, the major,
+// minor and bugfix numbers are compared in order. The meta part is not taken into account.
+func (v *Version) LessThan(v1 *Version) bool {
+	lessThan := v.LessThanMajorMinor(v1)
+	if lessThan {
+		return true
+	}
+
+	if v.Minor == v1.Minor {
+		if v.Bugfix < v1.Bugfix {
+			return true
+		}
+	}
+
+	return false
+}
+
+// LessThanMajorMinor returns true if v is smaller or equal to v1 based on the major and minor version. The bugfix version and meta part are not taken into account.
+// minor numbers are compared in order. The and bugfix version and meta part is not taken into account.
+func (v *Version) LessThanMajorMinor(v1 *Version) bool {
+	if v.Major < v1.Major {
+		return true
+	} else if v.Major == v1.Major {
+		if v.Minor < v1.Minor {
+			return true
+		}
+	}
+	return false
+}
+
+func (v *Version) String() string {
+	return v.version
+}
+
+func (v *Version) metaIsLessThanOrEqual(v1 *Version) bool {
+	if v.Meta == "" && v1.Meta == "" {
+		return true
+	}
+	if v.Meta == "" {
+		return false
+	}
+	if v1.Meta == "" {
+		return true
+	}
+	return v.Meta <= v1.Meta
+}
+
+// UnmarshalJSON unmarshals a JSON string version representation into a Version struct
+// Implements https://golang.org/pkg/encoding/json/#Unmarshaler
+func (v *Version) UnmarshalJSON(version []byte) error {
+	var versionStr string
+	err := json.Unmarshal(version, &versionStr)
+	if err != nil {
+		return err
+	}
+
+	ver, err := NewVersion(versionStr)
+	if err != nil {
+		return err
+	}
+
+	if ver == nil {
+		return fmt.Errorf("could not unmarshal version from JSON")
+	}
+
+	*v = *ver
+	return nil
+}

--- a/version/version.go
+++ b/version/version.go
@@ -58,23 +58,23 @@ func New(version string) (*V, error) {
 
 	versions := strings.Split(version, ".")
 	if len(versions) != 3 {
-		return nil, fmt.Errorf("Passed version is not semver: %s", version)
+		return nil, fmt.Errorf("passed version is not semver: %s", version)
 	}
 
 	var err error
 	v.Major, err = strconv.Atoi(versions[0])
 	if err != nil {
-		return nil, fmt.Errorf("Could not convert major to integer: %s", versions[0])
+		return nil, fmt.Errorf("could not convert major to integer: %s", versions[0])
 	}
 
 	v.Minor, err = strconv.Atoi(versions[1])
 	if err != nil {
-		return nil, fmt.Errorf("Could not convert minor to integer: %s", versions[1])
+		return nil, fmt.Errorf("could not convert minor to integer: %s", versions[1])
 	}
 
 	v.Bugfix, err = strconv.Atoi(versions[2])
 	if err != nil {
-		return nil, fmt.Errorf("Could not convert bugfix to integer: %s", versions[2])
+		return nil, fmt.Errorf("could not convert bugfix to integer: %s", versions[2])
 	}
 
 	return &v, nil

--- a/version/version.go
+++ b/version/version.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package version
 
 import (
 	"encoding/json"
@@ -24,7 +24,7 @@ import (
 	"strings"
 )
 
-type Version struct {
+type V struct {
 	version string
 	Major   int
 	Minor   int
@@ -32,20 +32,20 @@ type Version struct {
 	Meta    string
 }
 
-// MustNewVersion creates a version from the given version string.
-// If the version string is invalid, MustNewVersion panics.
-func MustNewVersion(version string) *Version {
-	v, err := NewVersion(version)
+// MustNew creates a version from the given version string.
+// If the version string is invalid, MustNew panics.
+func MustNew(version string) *V {
+	v, err := New(version)
 	if err != nil {
 		panic(err)
 	}
 	return v
 }
 
-// NewVersion expects a string in the format:
+// New expects a string in the format:
 // major.minor.bugfix(-meta)
-func NewVersion(version string) (*Version, error) {
-	v := Version{
+func New(version string) (*V, error) {
+	v := V{
 		version: version,
 	}
 
@@ -81,17 +81,17 @@ func NewVersion(version string) (*Version, error) {
 }
 
 // IsValid returns true if the version object stores a successfully parsed version number.
-func (v *Version) IsValid() bool {
+func (v *V) IsValid() bool {
 	return v.version != ""
 }
 
-func (v *Version) IsMajor(major int) bool {
+func (v *V) IsMajor(major int) bool {
 	return major == v.Major
 }
 
 // LessThan returns true if v is strictly smaller than v1. When comparing, the major,
 // minor, bugfix and pre-release numbers are compared in order.
-func (v *Version) LessThanOrEqual(withMeta bool, v1 *Version) bool {
+func (v *V) LessThanOrEqual(withMeta bool, v1 *V) bool {
 	if withMeta && v.version == v1.version {
 		return true
 	}
@@ -120,7 +120,7 @@ func (v *Version) LessThanOrEqual(withMeta bool, v1 *Version) bool {
 
 // LessThan returns true if v is strictly smaller than v1. When comparing, the major,
 // minor and bugfix numbers are compared in order. The meta part is not taken into account.
-func (v *Version) LessThan(v1 *Version) bool {
+func (v *V) LessThan(v1 *V) bool {
 	lessThan := v.LessThanMajorMinor(v1)
 	if lessThan {
 		return true
@@ -137,7 +137,7 @@ func (v *Version) LessThan(v1 *Version) bool {
 
 // LessThanMajorMinor returns true if v is smaller or equal to v1 based on the major and minor version. The bugfix version and meta part are not taken into account.
 // minor numbers are compared in order. The and bugfix version and meta part is not taken into account.
-func (v *Version) LessThanMajorMinor(v1 *Version) bool {
+func (v *V) LessThanMajorMinor(v1 *V) bool {
 	if v.Major < v1.Major {
 		return true
 	} else if v.Major == v1.Major {
@@ -148,11 +148,11 @@ func (v *Version) LessThanMajorMinor(v1 *Version) bool {
 	return false
 }
 
-func (v *Version) String() string {
+func (v *V) String() string {
 	return v.version
 }
 
-func (v *Version) metaIsLessThanOrEqual(v1 *Version) bool {
+func (v *V) metaIsLessThanOrEqual(v1 *V) bool {
 	if v.Meta == "" && v1.Meta == "" {
 		return true
 	}
@@ -167,14 +167,14 @@ func (v *Version) metaIsLessThanOrEqual(v1 *Version) bool {
 
 // UnmarshalJSON unmarshals a JSON string version representation into a Version struct
 // Implements https://golang.org/pkg/encoding/json/#Unmarshaler
-func (v *Version) UnmarshalJSON(version []byte) error {
+func (v *V) UnmarshalJSON(version []byte) error {
 	var versionStr string
 	err := json.Unmarshal(version, &versionStr)
 	if err != nil {
 		return err
 	}
 
-	ver, err := NewVersion(versionStr)
+	ver, err := New(versionStr)
 	if err != nil {
 		return err
 	}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -1,0 +1,258 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package common
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestVersion(t *testing.T) {
+	tests := []struct {
+		version string
+		err     bool
+		result  Version
+	}{
+		{
+			version: "1.2.3",
+			err:     false,
+			result:  Version{Major: 1, Minor: 2, Bugfix: 3, version: "1.2.3"},
+		},
+		{
+			version: "1.3.3",
+			err:     false,
+			result:  Version{Major: 1, Minor: 3, Bugfix: 3, version: "1.3.3"},
+		},
+		{
+			version: "1.3.2-alpha1",
+			err:     false,
+			result:  Version{Major: 1, Minor: 3, Bugfix: 2, version: "1.3.2-alpha1", Meta: "alpha1"},
+		},
+		{
+			version: "alpha1",
+			err:     true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		if test.err {
+			assert.Error(t, err)
+			continue
+		} else {
+			assert.NoError(t, err)
+		}
+		assert.Equal(t, *v, test.result)
+	}
+}
+
+func TestLessThanOrEqual(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		version1 string
+		meta     bool
+		result   bool
+	}{
+		{
+			name:     "5.4.3 < 6.4.3",
+			version:  "5.4.3",
+			version1: "6.4.3",
+			meta:     true,
+			result:   true,
+		},
+		{
+			name:     "5.7.3 < 5.8.3",
+			version:  "5.7.3",
+			version1: "5.8.2",
+			meta:     true,
+			result:   true,
+		},
+		{
+			name:     "5.4.3 > 5.4.2",
+			version:  "5.4.3",
+			version1: "5.4.2",
+			meta:     true,
+			result:   false,
+		},
+		{
+			name:     "5.4.3 = 5.4.3",
+			version:  "5.4.3",
+			version1: "5.4.3",
+			meta:     true,
+			result:   true,
+		},
+		{
+			name:     "1.2.3 > 1.2.3-alpha1",
+			version:  "1.2.3",
+			version1: "1.2.3-alpha1",
+			meta:     true,
+			result:   false,
+		},
+		{
+			name:     "1.2.3.alpha < 1.2.3",
+			version:  "1.2.3-alpha",
+			version1: "1.2.3",
+			meta:     true,
+			result:   true,
+		},
+		{
+			name:     "1.2.3.alpha < 1.2.3.beta",
+			version:  "1.2.3-alpha",
+			version1: "1.2.3-beta",
+			meta:     true,
+			result:   true,
+		},
+		{
+			name:     "1.2.3.rc1 < 1.2.3.rc2",
+			version:  "1.2.3-rc1",
+			version1: "1.2.3-rc2",
+			meta:     true,
+			result:   true,
+		},
+		{
+			name:     "5.4.3 = 5.4.3",
+			version:  "5.4.3",
+			version1: "5.4.3",
+			meta:     false,
+			result:   true,
+		},
+		{
+			name:     "1.2.3 = 1.2.3-alpha1",
+			version:  "1.2.3",
+			version1: "1.2.3-alpha1",
+			meta:     false,
+			result:   true,
+		},
+		{
+			name:     "1.2.3.beta1 = 1.2.3-beta2",
+			version:  "1.2.3-beta1",
+			version1: "1.2.3-beta2",
+			meta:     false,
+			result:   true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		assert.NoError(t, err)
+		v1, err := NewVersion(test.version1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, test.result, v.LessThanOrEqual(test.meta, v1), test.name)
+	}
+}
+
+func TestVersionLessThan(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		version1 string
+		result   bool
+	}{
+		{
+			name:     "1.2.3 < 2.0.0",
+			version:  "1.2.3",
+			version1: "2.0.0",
+			result:   true,
+		},
+		{
+			name:     "1.2.3 = 1.2.3-beta1",
+			version:  "1.2.3",
+			version1: "1.2.3-beta1",
+			result:   false,
+		},
+		{
+			name:     "5.4.1 < 5.4.2",
+			version:  "5.4.1",
+			version1: "5.4.2",
+			result:   true,
+		},
+		{
+			name:     "5.5.1 > 5.4.2",
+			version:  "5.5.1",
+			version1: "5.4.2",
+			result:   false,
+		},
+		{
+			name:     "6.1.1-alpha3 < 6.2.0",
+			version:  "6.1.1-alpha3",
+			version1: "6.2.0",
+			result:   true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		assert.NoError(t, err)
+		v1, err := NewVersion(test.version1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, v.LessThan(v1), test.result, test.name)
+	}
+}
+
+func TestVersionLessThanMajorMinor(t *testing.T) {
+	tests := []struct {
+		name     string
+		version  string
+		version1 string
+		result   bool
+	}{
+		{
+			name:     "1.2.x < 2.0.x",
+			version:  "1.2.3",
+			version1: "2.0.0",
+			result:   true,
+		},
+		{
+			name:     "1.2.3 = 1.2.3-beta1",
+			version:  "1.2.3",
+			version1: "1.2.3-beta1",
+			result:   false,
+		},
+		{
+			name:     "5.4.x == 5.4.x",
+			version:  "5.4.1",
+			version1: "5.4.2",
+			result:   false,
+		},
+		{
+			name:     "5.5.x > 5.4.x",
+			version:  "5.5.1",
+			version1: "5.4.2",
+			result:   false,
+		},
+		{
+			name:     "6.1.x < 6.2.x",
+			version:  "6.1.1-alpha3",
+			version1: "6.2.0",
+			result:   true,
+		},
+	}
+
+	for _, test := range tests {
+		v, err := NewVersion(test.version)
+		assert.NoError(t, err)
+		v1, err := NewVersion(test.version1)
+		assert.NoError(t, err)
+
+		assert.Equal(t, v.LessThanMajorMinor(v1), test.result, test.name)
+	}
+}

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-package common
+package version
 
 import (
 	"testing"
@@ -27,22 +27,22 @@ func TestVersion(t *testing.T) {
 	tests := []struct {
 		version string
 		err     bool
-		result  Version
+		result  V
 	}{
 		{
 			version: "1.2.3",
 			err:     false,
-			result:  Version{Major: 1, Minor: 2, Bugfix: 3, version: "1.2.3"},
+			result:  V{Major: 1, Minor: 2, Bugfix: 3, version: "1.2.3"},
 		},
 		{
 			version: "1.3.3",
 			err:     false,
-			result:  Version{Major: 1, Minor: 3, Bugfix: 3, version: "1.3.3"},
+			result:  V{Major: 1, Minor: 3, Bugfix: 3, version: "1.3.3"},
 		},
 		{
 			version: "1.3.2-alpha1",
 			err:     false,
-			result:  Version{Major: 1, Minor: 3, Bugfix: 2, version: "1.3.2-alpha1", Meta: "alpha1"},
+			result:  V{Major: 1, Minor: 3, Bugfix: 2, version: "1.3.2-alpha1", Meta: "alpha1"},
 		},
 		{
 			version: "alpha1",
@@ -51,7 +51,7 @@ func TestVersion(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := NewVersion(test.version)
+		v, err := New(test.version)
 		if test.err {
 			assert.Error(t, err)
 			continue
@@ -150,9 +150,9 @@ func TestLessThanOrEqual(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := NewVersion(test.version)
+		v, err := New(test.version)
 		assert.NoError(t, err)
-		v1, err := NewVersion(test.version1)
+		v1, err := New(test.version1)
 		assert.NoError(t, err)
 
 		assert.Equal(t, test.result, v.LessThanOrEqual(test.meta, v1), test.name)
@@ -199,9 +199,9 @@ func TestVersionLessThan(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := NewVersion(test.version)
+		v, err := New(test.version)
 		assert.NoError(t, err)
-		v1, err := NewVersion(test.version1)
+		v1, err := New(test.version1)
 		assert.NoError(t, err)
 
 		assert.Equal(t, v.LessThan(v1), test.result, test.name)
@@ -248,9 +248,9 @@ func TestVersionLessThanMajorMinor(t *testing.T) {
 	}
 
 	for _, test := range tests {
-		v, err := NewVersion(test.version)
+		v, err := New(test.version)
 		assert.NoError(t, err)
-		v1, err := NewVersion(test.version1)
+		v1, err := New(test.version1)
 		assert.NoError(t, err)
 
 		assert.Equal(t, v.LessThanMajorMinor(v1), test.result, test.name)

--- a/version/version_test.go
+++ b/version/version_test.go
@@ -15,6 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
+//nolint:dupl // equivalent tests with different expected values
 package version
 
 import (


### PR DESCRIPTION
This PR moves the base Kibana client. I left dashboard loading, index pattern generator, etc. in beats.

Commits containing only moving packages from beats are the following:
* [18db1a7](https://github.com/elastic/elastic-agent-libs/pull/32/commits/18db1a7d3b04f7d4ae392c7f28565bdf9307499d)
* [78ae6a3](https://github.com/elastic/elastic-agent-libs/pull/32/commits/78ae6a301faeb4f407ee828dae2682e02e63b856)

The other commits are up for review, they contain the changes I added on top of the beats code.
