### PR TITLE
Extract function `SyncParent` to reuse in elastic agent 

### DIFF
--- a/file/helper_aix.go
+++ b/file/helper_aix.go
@@ -24,7 +24,6 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string) error {
-	parent := filepath.Dir(path)
 
 	if e := os.Rename(tempfile, path); e != nil {
 		return e
@@ -35,6 +34,14 @@ func SafeFileRotate(path, tempfile string) error {
 	// contain the new file being rotated in.
 	// On AIX, fsync will fail if the file is opened in read-only mode,
 	// which is the case with os.Open.
+	return SyncParent(path)
+
+}
+
+// SyncParent fsyncs parent directory
+func SyncParent(path string) error {
+	parent := filepath.Dir(path)
+
 	f, err := os.OpenFile(parent, os.O_RDWR, 0)
 	if err != nil {
 		return nil // ignore error

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -22,6 +22,7 @@ package file
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -22,12 +22,10 @@ package file
 
 import (
 	"os"
-	"path/filepath"
 )
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string) error {
-	parent := filepath.Dir(path)
 
 	if e := os.Rename(tempfile, path); e != nil {
 		return e
@@ -36,6 +34,12 @@ func SafeFileRotate(path, tempfile string) error {
 	// best-effort fsync on parent directory. The fsync is required by some
 	// filesystems, so to update the parents directory metadata to actually
 	// contain the new file being rotated in.
+	return SyncParent(path)
+}
+
+// SyncParent fsyncs parent directory
+func SyncParent(path string) error {
+	parent := filepath.Dir(path)
 	f, err := os.Open(parent)
 
 	// nolint: nilerr // ignore error

--- a/file/helper_windows.go
+++ b/file/helper_windows.go
@@ -42,10 +42,21 @@ func SafeFileRotate(path, tempfile string) error {
 	}
 
 	// sync all files
+	return SyncParent(path)
+}
+
+// SyncParent fsyncs parent directory
+func SyncParent(path string) error {
 	parent := filepath.Dir(path)
 	if f, err := os.OpenFile(parent, os.O_SYNC|os.O_RDWR, 0755); err == nil {
-		_ = f.Sync()
-		f.Close()
+		err := f.Sync()
+		if err != nil {
+			return err
+		}
+		err = f.Close()
+		if err != nil {
+			return err
+		}
 	}
 
 	return nil

--- a/file/helper_windows.go
+++ b/file/helper_windows.go
@@ -41,6 +41,9 @@ func SafeFileRotate(path, tempfile string) error {
 		return e
 	}
 
+	// .old file will still exist if path file is already there, it should be removed
+	_ = os.Remove(old)
+
 	// sync all files
 	return SyncParent(path)
 }


### PR DESCRIPTION
Related to https://github.com/elastic/elastic-agent/issues/98

We need to sync parent after file is synced, this does not happen in function https://github.com/elastic/elastic-agent/blob/main/internal/pkg/agent/storage/replace_store.go#L107