### PR TITLE
Add new helper methods to opt types

### DIFF
--- a/opt/opt.go
+++ b/opt/opt.go
@@ -33,7 +33,7 @@ type Int struct {
 	value  int
 }
 
-// NewUintNone returns a new OptUint wrapper
+// NewIntNone returns a new OptUint wrapper
 func NewIntNone() Int {
 	return Int{
 		exists: false,
@@ -41,7 +41,7 @@ func NewIntNone() Int {
 	}
 }
 
-// UintWith returns a new OptUint wrapper with a given int
+// IntWith returns a new OptUint wrapper with a given int
 func IntWith(i int) Int {
 	return Int{
 		exists: true,
@@ -123,6 +123,30 @@ func (opt Uint) ValueOr(i uint64) uint64 {
 		return opt.value
 	}
 	return i
+}
+
+// MultUint64OrNone or will multiply the existing Uint value by a supplied uint64, and return None if either the Uint is none, or the supplied uint64 is zero.
+func (opt Uint) MultUint64OrNone(i uint64) Uint {
+	if !opt.exists {
+		return opt
+	}
+	if i == 0 {
+		return Uint{exists: false}
+	}
+	return Uint{exists: true, value: opt.value * i}
+}
+
+// SubtractOrNone will subtract the existing uint with the supplied uint64 value. If this would result in a value invalid for a uint (ie, a negative number), return None
+func (opt Uint) SubtractOrNone(i Uint) Uint {
+	if !opt.exists || !i.Exists() {
+		return opt
+	}
+
+	if i.ValueOr(0) > opt.value {
+		return Uint{exists: false}
+	}
+
+	return Uint{exists: true, value: opt.value - i.ValueOr(0)}
 }
 
 // SumOptUint sums a list of OptUint values


### PR DESCRIPTION
This is to unblock https://github.com/elastic/elastic-agent-system-metrics/pull/5 by adding a few helper functions used by that PR before it was moved from elastic/beats to elastic/elastic-agent-system-metrics.