### PR TITLE
Bump golangci version to v1.45.2

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -43,7 +43,7 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.44.2
+          version: v1.45.2
 
           # Give the job more time to execute.
           # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,

--- a/dev-tools/mage/linter.go
+++ b/dev-tools/mage/linter.go
@@ -37,7 +37,7 @@ const (
 	linterInstallURL             = "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
 	linterInstallFilename        = "./build/intall-golang-ci.sh"
 	linterBinaryFilename         = "./build/golangci-lint"
-	linterVersion                = "v1.44.0"
+	linterVersion                = "v1.45.2"
 	linterConfigFilename         = "./.golangci.yml"
 	linterConfigTemplateFilename = "./dev-tools/templates/.golangci.yml"
 )


### PR DESCRIPTION
#### Description
Bump golangci version to v1.45.2 to support properly Apple M1.
Related to https://github.com/elastic/beats/issues/31300

Signed-off-by: Adrien Mannocci <adrien.mannocci@elastic.co>