### PR TITLE
Move dialer helpers from `metricbeat/helper/dialer` to `transport` package

### DIFF
--- a/transport/dialer/dialer.go
+++ b/transport/dialer/dialer.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package dialer
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/transport"
+)
+
+// Builder is a dialer builder.
+type Builder interface {
+	fmt.Stringer
+	Make(time.Duration) (transport.Dialer, error)
+}
+
+// DefaultDialerBuilder create a builder to dialer over TCP and UDP.
+type DefaultDialerBuilder struct{}
+
+// Make creates a dialer.
+func (t *DefaultDialerBuilder) Make(timeout time.Duration) (transport.Dialer, error) {
+	return transport.NetDialer(timeout), nil
+}
+
+func (t *DefaultDialerBuilder) String() string {
+	return "TCP/UDP"
+}
+
+// NewDefaultDialerBuilder creates a DefaultDialerBuilder.
+func NewDefaultDialerBuilder() *DefaultDialerBuilder {
+	return &DefaultDialerBuilder{}
+}
+
+// NewNpipeDialerBuilder creates a NpipeDialerBuilder.
+func NewNpipeDialerBuilder(path string) *NpipeDialerBuilder {
+	return &NpipeDialerBuilder{Path: path}
+}
+
+// NewUnixDialerBuilder returns a new TransportUnix instance that will allow the HTTP client to communicate
+// over a unix domain socket it require a valid path to the socket on the filesystem.
+func NewUnixDialerBuilder(path string) *UnixDialerBuilder {
+	return &UnixDialerBuilder{Path: path}
+}

--- a/transport/dialer/dialer_posix.go
+++ b/transport/dialer/dialer_posix.go
@@ -1,0 +1,57 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !windows
+// +build !windows
+
+package dialer
+
+import (
+	"errors"
+	"strings"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/transport"
+)
+
+// UnixDialerBuilder creates a builder to dial over unix domain socket.
+type UnixDialerBuilder struct {
+	Path string
+}
+
+// Make creates a dialer.
+func (t *UnixDialerBuilder) Make(timeout time.Duration) (transport.Dialer, error) {
+	return transport.UnixDialer(timeout, strings.TrimSuffix(t.Path, "/")), nil
+}
+
+func (t *UnixDialerBuilder) String() string {
+	return "Unix: " + t.Path
+}
+
+// NpipeDialerBuilder creates a builder to dial over a named pipe.
+type NpipeDialerBuilder struct {
+	Path string
+}
+
+// Make creates a dialer.
+func (t *NpipeDialerBuilder) Make(_ time.Duration) (transport.Dialer, error) {
+	return nil, errors.New("cannot the URI, named pipes are only supported on Windows")
+}
+
+func (t *NpipeDialerBuilder) String() string {
+	return "Npipe: " + t.Path
+}

--- a/transport/dialer/dialer_windows.go
+++ b/transport/dialer/dialer_windows.go
@@ -1,0 +1,71 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build windows
+// +build windows
+
+package dialer
+
+import (
+	"errors"
+	"net"
+	"strings"
+	"time"
+
+	winio "github.com/Microsoft/go-winio"
+
+	"github.com/elastic/elastic-agent-libs/api/npipe"
+	"github.com/elastic/elastic-agent-libs/transport"
+)
+
+// UnixDialerBuilder creates a builder to dial over a unix domain socket.
+type UnixDialerBuilder struct {
+	Path string
+}
+
+// Make creates a dialer.
+func (t *UnixDialerBuilder) Make(_ time.Duration) (transport.Dialer, error) {
+	return nil, errors.New(
+		"cannot use the URI, unix sockets are not supported on Windows, use npipe instead",
+	)
+}
+
+func (t *UnixDialerBuilder) String() string {
+	return "Unix: " + t.Path
+}
+
+// NpipeDialerBuilder creates a builder to dial over a named pipe.
+type NpipeDialerBuilder struct {
+	Path string
+}
+
+func (t *NpipeDialerBuilder) String() string {
+	return "Npipe: " + t.Path
+}
+
+// Make creates a dialer.
+func (t *NpipeDialerBuilder) Make(timeout time.Duration) (transport.Dialer, error) {
+	to := timeout
+	return transport.DialerFunc(
+		func(_, _ string) (net.Conn, error) {
+			return winio.DialPipe(
+				strings.TrimSuffix(npipe.TransformString(t.Path), "/"),
+				&to,
+			)
+		},
+	), nil
+}


### PR DESCRIPTION
It is required for removing the remaining Metricbeat dependencies from Agent.