### PR TITLE
ci: use github actions macos

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -54,7 +54,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'macosx && x86_64', 'ubuntu-20.04 && immutable', 'windows-2019 && windows-immutable'
+            values 'ubuntu-20.04 && immutable', 'windows-2019 && windows-immutable'
           }
           axis {
             name 'GO_VERSION'

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -1,0 +1,27 @@
+name: macos
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    branches:
+      - main
+
+  macos:
+    runs-on: macos-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: get go version
+      run: |
+        gv=$(cat .go-version)
+        echo "::set-output name=go::$gv"
+      id: version
+
+    - name: install Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: "${{steps.version.outputs.go}}"
+
+    - name: Run test
+      run: go test -v ./...


### PR DESCRIPTION
We are in the transition to use ephemeral workers, but until then there is a requirement to decommission the existing MacOS workers. For such this proposal uses GitHub actions for MacOS until we can use the ephemeral workers.