### PR TITLE
Add CODEOWNERS, marking data plane as owners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# GitHub CODEOWNERS definition
+# See: https://help.github.com/articles/about-codeowners/
+* @elastic/elastic-agent-data-plane


### PR DESCRIPTION
This will assign the data plane team as a reviewer, and auto-assign two randomly chosen members like in beats.