### PR TITLE
Modify npipe to directly get the user SID

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Modify npipe package to directly get the user SID.
+
 ### Deprecated
 
 ### Removed

--- a/api/npipe/listener_windows.go
+++ b/api/npipe/listener_windows.go
@@ -24,11 +24,14 @@ import (
 	"context"
 	"fmt"
 	"net"
-	"os/user"
 	"strings"
+	"syscall"
 
-	winio "github.com/Microsoft/go-winio"
+	"github.com/Microsoft/go-winio"
 )
+
+// ntAuthoritySystemSID is a well-known SID used by the NT AUTHORITY\SYSTEM account.
+const ntAuthoritySystemSID = "S-1-5-18"
 
 // NewListener creates a new Listener receiving events over a named pipe.
 func NewListener(name, sd string) (net.Listener, error) {
@@ -44,16 +47,12 @@ func NewListener(name, sd string) (net.Listener, error) {
 	return l, nil
 }
 
-// TransformString takes an input type name defined as a URI like `npipe:///hello` and transform it into
-// `\\.\pipe\hello`
+// TransformString takes an input type name defined as a URI like
+// `npipe:///hello` and transforms it into // `\\.\pipe\hello`
 func TransformString(name string) string {
 	if strings.HasPrefix(name, "npipe:///") {
 		path := strings.TrimPrefix(name, "npipe:///")
 		return `\\.\pipe\` + path
-	}
-
-	if strings.HasPrefix(name, `\\.\pipe\`) {
-		return name
 	}
 
 	return name
@@ -73,24 +72,14 @@ func Dial(npipe string) func(string, string) (net.Conn, error) {
 	}
 }
 
-// DefaultSD returns a default SecurityDescriptor which is the minimal required permissions to be
+// DefaultSD returns a default SecurityDescriptor that specifies the minimal required permissions to be
 // able to write to the named pipe. The security descriptor is returned in SDDL format.
 //
 // Docs: https://docs.microsoft.com/en-us/windows/win32/secauthz/security-descriptor-string-format
 func DefaultSD(forUser string) (string, error) {
-	var u *user.User
-	var err error
-	// No user configured we fallback to the current running user.
-	if len(forUser) == 0 {
-		u, err = user.Current()
-		if err != nil {
-			return "", fmt.Errorf("failed to retrieve the current user: %w", err)
-		}
-	} else {
-		u, err = user.Lookup(forUser)
-		if err != nil {
-			return "", fmt.Errorf("failed to retrieve the user %s: %w", forUser, err)
-		}
+	sid, err := lookupSID(forUser)
+	if err != nil {
+		return "", err
 	}
 
 	// Named pipe security and access rights.
@@ -98,12 +87,55 @@ func DefaultSD(forUser string) (string, error) {
 	// See docs: https://docs.microsoft.com/en-us/windows/win32/ipc/named-pipe-security-and-access-rights
 	// String definition: https://docs.microsoft.com/en-us/windows/win32/secauthz/ace-strings
 	// Give generic read/write access to the specified user.
-	descriptor := "D:P(A;;GA;;;" + u.Uid + ")"
-	if u.Username == "NT AUTHORITY\\SYSTEM" {
+	descriptor := "D:P(A;;GA;;;" + sid + ")"
+	if sid == ntAuthoritySystemSID {
 		// running as SYSTEM, include Administrators group so Administrators can talk over
 		// the named pipe to the running Elastic Agent system process
 		// https://support.microsoft.com/en-us/help/243330/well-known-security-identifiers-in-windows-operating-systems
 		descriptor += "(A;;GA;;;S-1-5-32-544)" // Administrators group
 	}
 	return descriptor, nil
+}
+
+// lookupSID returns the SID of the specified username. If username is empty the
+// SID of the current user is returned.
+func lookupSID(username string) (string, error) {
+	if username == "" {
+		sid, err := currentUserSID()
+		if err != nil {
+			return "", fmt.Errorf("failed to lookup the SID of current user: %w", err)
+		}
+		return sid, nil
+	}
+
+	sid, _, _, err := syscall.LookupSID("", username)
+	if err != nil {
+		return "", fmt.Errorf("failed to lookup the SID for user %q: %w", username, err)
+	}
+	sidString, err := sid.String()
+	if err != nil {
+		return "", fmt.Errorf("failed to convert the SID for user %q to string: %w", username, err)
+	}
+	return sidString, nil
+}
+
+// currentUserSID returns the SID of the user running the current process.
+func currentUserSID() (string, error) {
+	t, err := syscall.OpenCurrentProcessToken()
+	if err != nil {
+		return "", err
+	}
+	defer t.Close()
+
+	u, err := t.GetTokenUser()
+	if err != nil {
+		return "", err
+	}
+
+	sid, err := u.User.Sid.String()
+	if err != nil {
+		return "", err
+	}
+
+	return sid, nil
 }


### PR DESCRIPTION
## What does this PR do?

Porting over https://github.com/elastic/beats/commit/1fcdee6925248401217a8d6b98230eb5e13ac4fa

Remove the dependency on user.Current(). It fetches more information than
is required to configure the named pipe. This only needs to know the SID
in order to build the SDDL.

This avoids the possibility of lengthy delays fetching the unnecessary
metadata about the current user.

Relates elastic/beats#31810
