### PR TITLE
mapstr: optimyze Clone

### DIFF
--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -152,13 +152,13 @@ func (m M) CopyFieldsTo(to M, key string) error {
 // Clone returns a copy of the M. It recursively makes copies of inner
 // maps.
 func (m M) Clone() M {
-	result := M{}
+	result := make(M, len(m))
 
-	for k, v := range m {
-		if innerMap, ok := tryToMapStr(v); ok {
-			v = innerMap.Clone()
+	for k := range m {
+		if innerMap, ok := (m[k]).(M); ok {
+			result[k] = innerMap.Clone()
 		}
-		result[k] = v
+		result[k] = m[k]
 	}
 
 	return result

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -356,6 +356,37 @@ func TestClone(t *testing.T) {
 	assert.Equal(M{"c31": 1, "c32": 2}, c["c3"])
 }
 
+func BenchmarkClone(b *testing.B) {
+	assert := assert.New(b)
+
+	m := M{
+		"c1": 1,
+		"c2": 2,
+		"c3": M{
+			"c31": 1,
+			"c32": 2,
+			"c33": 3,
+			"c34": 4,
+			"c35": 5,
+			"c36": 6,
+			"c37": 7,
+			"c38": 8,
+			"c39": 9,
+		},
+		"c4": 4,
+		"c5": 5,
+		"c6": 6,
+		"c7": 7,
+		"c8": 8,
+		"c9": 9,
+	}
+
+	for i := 0; i < b.N; i++ {
+		c := m.Clone()
+		assert.Equal(m, c)
+	}
+}
+
 func TestString(t *testing.T) {
 	type io struct {
 		Input  M


### PR DESCRIPTION
Reduce the ammount of allocations when using `Clone()`.
```
name     old time/op    new time/op    delta
Clone-8    8.95µs ± 0%    5.51µs ± 0%   ~     (p=1.000 n=1+1)

name     old alloc/op   new alloc/op   delta
Clone-8    4.99kB ± 0%    2.50kB ± 0%   ~     (p=1.000 n=1+1)

name     old allocs/op  new allocs/op  delta
Clone-8      64.0 ± 0%      33.0 ± 0%   ~     (p=1.000 n=1+1)
```

---------------------------------------------------------------------------------------------------------------------------

Type of change: `Enhancement`

## What does this PR do?

When profiling `filebeat` I have noticed heavy use of `MapStr.Clone()` operations that resulted in many `runtime.mallocgc()`. Looking at the code, I did see that the resulting `M` was not sized properly even if its resulting size is known in advance.

As the added benchmark demonstrates, there is a noticeable reduction of memory allocation even for small `MapStr` when using `Clone()` now.

## Why is it important?

Incremental resizing of `MapStr`, as it is done when `MapStr` is not properly sized in advance, will give the garbage collector more work to do. So this change does not only reduce the number of allocations but also reduces the work that needs to be done by the garbage collector.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
      As there is only a minimal code change, I have skipped this one. Please let me know, if you want more comments.
- [x] I have added ~~tests~~ _benchmarks_ that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
      For users of this package there is no "visible" change. So I did not add something.