### PR TITLE
Restore original Clone() type conversion behvavior.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+## [0.2.9]
+
+### Changed
+
+- Fix breaking change to mapstr type conversions during Clone(). #66
+
 ## [0.2.8]
 
 ### Changed

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -155,7 +155,7 @@ func (m M) Clone() M {
 	result := make(M, len(m))
 
 	for k := range m {
-		if innerMap, ok := (m[k]).(M); ok {
+		if innerMap, ok := tryToMapStr(m[k]); ok {
 			result[k] = innerMap.Clone()
 		} else {
 			result[k] = m[k]


### PR DESCRIPTION
The switch from `tryToMapStr(m[k])` to `(m[k]).(M)` in https://github.com/elastic/elastic-agent-libs/pull/64 broke a large number of tests in Beats because of different types being returned.

This restores the original conversion results. The test coverage for `mapstr` isn't quite good enough it seems.