### PR TITLE
file: allow configuration of log filename extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- Add option to `file.NewFileRotator` to allow setting file extension. #68
+
 ### Changed
 
 ### Deprecated
@@ -13,6 +15,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Removed
 
 ### Fixed
+
+- Fix filename logging in `file.NewFileRotator`. #68
 
 ## [0.2.9]
 

--- a/file/rotator.go
+++ b/file/rotator.go
@@ -190,6 +190,7 @@ func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error)
 	if r.log != nil {
 		r.log.Debugw("Initialized file rotator",
 			"filename", r.filename,
+			"extension", r.extension,
 			"max_size_bytes", r.maxSizeBytes,
 			"max_backups", r.maxBackups,
 			"permissions", r.permissions,

--- a/file/rotator.go
+++ b/file/rotator.go
@@ -18,6 +18,7 @@
 package file
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -25,8 +26,6 @@ import (
 	"strconv"
 	"sync"
 	"time"
-
-	"errors"
 )
 
 const (
@@ -55,6 +54,7 @@ type Rotator struct {
 	triggers []trigger
 
 	filename        string
+	extension       string
 	maxSizeBytes    uint
 	maxBackups      uint
 	interval        time.Duration
@@ -81,6 +81,14 @@ type RotatorOption func(r *Rotator)
 func MaxSizeBytes(n uint) RotatorOption {
 	return func(r *Rotator) {
 		r.maxSizeBytes = n
+	}
+}
+
+// Extension configures the file extension to use for the log file.
+// The default is "ndjson".
+func Extension(ext string) RotatorOption {
+	return func(r *Rotator) {
+		r.extension = ext
 	}
 }
 
@@ -142,6 +150,8 @@ func WithClock(clock clock) RotatorOption {
 // NewFileRotator returns a new Rotator.
 func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error) {
 	r := &Rotator{
+		filename:        filename,
+		extension:       "ndjson",
 		maxSizeBytes:    10 * 1024 * 1024, // 10 MiB
 		maxBackups:      7,
 		permissions:     0600,
@@ -168,7 +178,7 @@ func NewFileRotator(filename string, options ...RotatorOption) (*Rotator, error)
 		return nil, errors.New("the minimum time interval for log rotation is 1 second")
 	}
 
-	r.rot = newDateRotater(r.log, filename, r.clock)
+	r.rot = newDateRotater(r.log, filename, r.extension, r.clock)
 
 	shouldRotateOnStart := r.rotateOnStartup
 	if _, err := os.Stat(r.rot.ActiveFile()); os.IsNotExist(err) {
@@ -408,12 +418,12 @@ type dateRotator struct {
 	logOrderCache map[string]logOrder
 }
 
-func newDateRotater(log Logger, filename string, clock clock) rotater {
+func newDateRotater(log Logger, filename, extension string, clock clock) rotater {
 	d := &dateRotator{
 		log:            log,
 		clock:          clock,
 		filenamePrefix: filename + "-",
-		extension:      ".ndjson",
+		extension:      "." + extension,
 		format:         DateFormat,
 		logOrderCache:  make(map[string]logOrder),
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This adds the ability to configure the filename extension for logs in `file.NewFileRotator` and fixes a bug in the logging.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Not all logs are ndjson and currently the debug log in `NewFileRotator` will not include the filename.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For elastic/beats#32412

