### PR TITLE
Upgrade golangci-lint and fix new lint warnings with Go 1.18

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -26,24 +26,24 @@ jobs:
           GOOS: ${{ matrix.GOOS }}
         run: echo Go GOOS=$GOOS
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       # Uses Go version from the repository.
       - name: Read .go-version file
         id: goversion
         run: echo "::set-output name=version::$(cat .go-version)"
 
-      - uses: actions/setup-go@v2
+      - uses: actions/setup-go@v3
         with:
           go-version: "${{ steps.goversion.outputs.version }}"
 
       - name: golangci-lint
         env:
           GOOS: ${{ matrix.GOOS }}
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Optional: version of golangci-lint to use in form of v1.2 or v1.2.3 or `latest` to use the latest version
-          version: v1.45.2
+          version: v1.47.2
 
           # Give the job more time to execute.
           # Regarding `--whole-files`, the linter is supposed to support linting of changed a patch only but,

--- a/dev-tools/mage/linter.go
+++ b/dev-tools/mage/linter.go
@@ -35,9 +35,9 @@ import (
 
 const (
 	linterInstallURL             = "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
-	linterInstallFilename        = "./build/intall-golang-ci.sh"
+	linterInstallFilename        = "./build/install-golang-ci.sh"
 	linterBinaryFilename         = "./build/golangci-lint"
-	linterVersion                = "v1.45.2"
+	linterVersion                = "v1.47.2"
 	linterConfigFilename         = "./.golangci.yml"
 	linterConfigTemplateFilename = "./dev-tools/templates/.golangci.yml"
 )
@@ -100,6 +100,16 @@ func (Linter) CheckConfig() error {
 // using the official installation script downloaded from GitHub.
 // If the linter binary already exists does nothing.
 func (Linter) Install() error {
+	return install(false)
+}
+
+// ForceInstall force installs the linter regardless of whether it exists or not.
+// Useful primarily when the linter version should be updated.
+func (Linter) ForceInstall() error {
+	return install(true)
+}
+
+func install(force bool) error {
 	dirPath := filepath.Dir(linterBinaryFilename)
 	err := os.MkdirAll(dirPath, 0700)
 	if err != nil {
@@ -107,11 +117,11 @@ func (Linter) Install() error {
 	}
 
 	_, err = os.Stat(linterBinaryFilename)
-	if err == nil {
+	if !force && err == nil {
 		log.Println("The linter has been already installed, skipping...")
 		return nil
 	}
-	if !errors.Is(err, os.ErrNotExist) {
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return fmt.Errorf("failed check if file %q exists: %w", linterBinaryFilename, err)
 	}
 

--- a/transport/client.go
+++ b/transport/client.go
@@ -206,7 +206,7 @@ func (c *Client) handleError(err error) error {
 		c.log.Debugf("handle error: %+v", err)
 
 		var nerr net.Error
-		if errors.As(err, &nerr) && !(nerr.Temporary() || nerr.Timeout()) {
+		if errors.As(err, &nerr) && !nerr.Timeout() {
 			_ = c.Close()
 		}
 	}

--- a/transport/httpcommon/proxy_headers.go
+++ b/transport/httpcommon/proxy_headers.go
@@ -75,7 +75,7 @@ func (p *ProxyHeaders) UnmarshalYAML(unmarshal func(interface{}) error) error {
 // URI returns conventional url.URL structure.
 func (p ProxyHeaders) Headers() http.Header {
 	var httpHeaders http.Header
-	if p != nil && len(p) > 0 {
+	if len(p) > 0 {
 		httpHeaders = http.Header{}
 		for k, v := range p {
 			httpHeaders.Add(k, v)

--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -105,7 +105,7 @@ func TestCAPinning(t *testing.T) {
 
 				l, err := net.Listen("tcp", addr)
 
-				server := &http.Server{
+				server := &http.Server{ //nolint:gosec // testing
 					Handler: mux,
 					TLSConfig: &tls.Config{ //nolint:gosec // testing
 						Certificates: []tls.Certificate{
@@ -191,7 +191,7 @@ func TestCAPinning(t *testing.T) {
 		// RootCAs will trust the intermediate, intermediate will trust the server.
 		serverCert.Certificate = append(serverCert.Certificate, intermediate.Certificate...)
 
-		server := &http.Server{
+		server := &http.Server{ //nolint:gosec // testing
 			Handler: mux,
 			TLSConfig: &tls.Config{ //nolint:gosec // testing
 				Certificates: []tls.Certificate{
@@ -265,7 +265,7 @@ func TestCAPinning(t *testing.T) {
 		// RootCAs will trust the intermediate, intermediate will trust the server.
 		serverCert.Certificate = append(serverCert.Certificate, intermediate.Certificate...)
 
-		server := &http.Server{
+		server := &http.Server{ //nolint:gosec // testing
 			Handler: mux,
 			TLSConfig: &tls.Config{ //nolint:gosec // testing
 				Certificates: []tls.Certificate{


### PR DESCRIPTION
Part of https://github.com/elastic/beats/issues/32328

Upgrade the golangci-lint version to ensure we use linters with updated Go 1.18 support, and fix some new lint warnings from upgrading to Go 1.18.