### PR TITLE
ci: use fleet-ci

### DIFF
--- a/.ci/jobs/defaults.yml
+++ b/.ci/jobs/defaults.yml
@@ -4,7 +4,7 @@
 ##### GLOBAL METADATA
 
 - meta:
-    cluster: beats-ci
+    cluster: fleet-ci
 
 ##### JOB DEFAULTS
 

--- a/.ci/jobs/elastic-agent-libs-mbp.yml
+++ b/.ci/jobs/elastic-agent-libs-mbp.yml
@@ -12,7 +12,7 @@
           discover-pr-forks-trust: permission
           discover-pr-origin: merge-current
           discover-tags: true
-          notification-context: 'beats-ci'
+          notification-context: 'fleet-ci'
           head-filter-regex: '(main|\.\d+\.\d+|PR-.*|v\d+\.\d+\.\d+)'
           repo: elastic-agent-libs
           repo-owner: elastic
@@ -40,4 +40,4 @@
             timeout: 100
           timeout: '15'
           use-author: true
-          wipe-workspace: 'True'
+          wipe-workspace: true


### PR DESCRIPTION
## What is the problem this PR solves?

Use `fleet-ci`  to scale horizontally the CI.


## Why

In order to distribute the load and reduce a single point of failure,

## Actions

- [ ] Agree when to merge
- [ ] Create webhook to point to `fleet-ci`