### PR TITLE
ci: change labels to match the OS version

### DIFF
--- a/.ci/Jenkinsfile
+++ b/.ci/Jenkinsfile
@@ -58,7 +58,7 @@ pipeline {
         axes {
           axis {
             name 'PLATFORM'
-            values 'ubuntu-20.04 && immutable', 'windows-2019 && windows-immutable', 'darwin && orka && x86_64'
+            values 'ubuntu-20.04 && immutable', 'windows-2019 && windows-immutable', 'x86_64 && macos11'
           }
         }
         stages {


### PR DESCRIPTION
`orka` is deprecated in favour of `macos<version>`