### PR TITLE
Add SetLevel functionality to logp package

### DIFF
--- a/logp/core.go
+++ b/logp/core.go
@@ -279,8 +279,11 @@ func storeLogger(l *coreLogger) {
 }
 
 func SetLevel(lvl zapcore.Level) {
-	coreLogger := loadLogger()
-	coreLogger.level.SetLevel(lvl)
+	loadLogger().level.SetLevel(lvl)
+}
+
+func GetLevel() zapcore.Level {
+	return loadLogger().level.Level()
 }
 
 // newMultiCore creates a sink that sends to multiple cores.

--- a/logp/core_test.go
+++ b/logp/core_test.go
@@ -57,7 +57,7 @@ func TestLogger(t *testing.T) {
 
 func TestLoggerLevel(t *testing.T) {
 	if err := DevelopmentSetup(ToObserverOutput()); err != nil {
-		t.Fatal(err)
+		t.Fatalf("cannot initialise logger on development mode: %+v", err)
 	}
 
 	const loggerName = "tester"

--- a/logp/core_test.go
+++ b/logp/core_test.go
@@ -96,6 +96,36 @@ func TestLoggerLevel(t *testing.T) {
 	}
 }
 
+func TestLoggerSetLevel(t *testing.T) {
+	if err := DevelopmentSetup(ToObserverOutput()); err != nil {
+		t.Fatal(err)
+	}
+
+	const loggerName = "tester"
+	logger := NewLogger(loggerName)
+
+	logger.Debug("debug")
+	logs := ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.DebugLevel, logs[0].Level)
+		assert.Equal(t, loggerName, logs[0].LoggerName)
+		assert.Equal(t, "debug", logs[0].Message)
+	}
+
+	SetLevel(zap.InfoLevel)
+	logger.Info("info")
+	logs = ObserverLogs().TakeAll()
+	if assert.Len(t, logs, 1) {
+		assert.Equal(t, zap.InfoLevel, logs[0].Level)
+		assert.Equal(t, loggerName, logs[0].LoggerName)
+		assert.Equal(t, "info", logs[0].Message)
+	}
+
+	logger.Debug("debug")
+	logs = ObserverLogs().TakeAll()
+	assert.Empty(t, logs, 1)
+}
+
 func TestL(t *testing.T) {
 	if err := DevelopmentSetup(ToObserverOutput()); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR exposes a global `logp.SetLevel` that changes the minimal level of logging for all of the loggers that were created through `logp.NewLogger`.
Ideally, it should be able to change the log level of a running agent without having to restart it.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

