### PR TITLE
Make the NewX() monitoring variables safe to re-register

### DIFF
--- a/monitoring/metrics_test.go
+++ b/monitoring/metrics_test.go
@@ -45,17 +45,3 @@ func TestNilReg(t *testing.T) {
 	require.NotNil(t, testUint)
 
 }
-
-func TestTypeMismatch(t *testing.T) {
-	valName := "testmetric"
-	testReg := Default.NewRegistry("safe_registry")
-	testUint := NewUint(testReg, valName)
-	require.NotNil(t, testUint)
-	defer func() {
-		recErr := recover()
-		require.NotNil(t, recErr)
-		t.Logf("Got expected error: %v", recErr)
-	}()
-	NewFloat(testReg, valName)
-
-}

--- a/monitoring/metrics_test.go
+++ b/monitoring/metrics_test.go
@@ -1,0 +1,61 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package monitoring
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSafeVars(t *testing.T) {
+	uintValName := "testUint"
+	testReg := Default.NewRegistry("safe_registry")
+	testUint := NewUint(testReg, uintValName)
+	testUint.Set(5)
+	// Add the first time
+	require.NotNil(t, testUint)
+
+	// Add the metric a second time
+	testSecondUint := NewUint(testReg, uintValName)
+	require.NotNil(t, testSecondUint)
+	// make sure we fetch the same unit
+	require.Equal(t, uint64(5), testSecondUint.Get())
+}
+
+func TestNilReg(t *testing.T) {
+	uintValName := "testUint"
+	// This can also just panic if there's a bug
+	testUint := NewUint(nil, uintValName)
+	require.NotNil(t, testUint)
+
+}
+
+func TestTypeMismatch(t *testing.T) {
+	valName := "testmetric"
+	testReg := Default.NewRegistry("safe_registry")
+	testUint := NewUint(testReg, valName)
+	require.NotNil(t, testUint)
+	defer func() {
+		recErr := recover()
+		require.NotNil(t, recErr)
+		t.Logf("Got expected error: %v", recErr)
+	}()
+	NewFloat(testReg, valName)
+
+}


### PR DESCRIPTION
## What does this PR do?

Fixes https://github.com/elastic/beats/issues/33125

Because this problem makes me a tad paranoid, I decided to implement the fix on a more global level. Specifically, this changes the behavior of the `NewX()` monitoring functions so they don't panic when a variable of the same name and type is re-registered. This fix is a tad opinionated, and I'd like to hear input from others on a few things:

- Instead of panicking when a variable is re-registered, we return the existing variable. My concern is that this is a tad implicit, and code might be assuming that a call to `NewX()` will create a new monitoring variable with a zero value. Should we zero out the underlying metric, and then return?
- If someone tries to re-register a variable with options, we just revert to a panic. I figured this was the most understandable behavior, as certain options, such as expvar exporting, can't really be modified. Should we attempt to merge or reset variables where possible?


## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
