### PR TITLE
Support ssl.peer_name configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - dev-tools: added GoImports target #74
+- transport/tlscommon: New ssl.peer_name config option #86
 
 ### Changed
 

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -51,9 +51,13 @@ func TestTLSDialer(
 			return nil, fmt.Errorf("unsupported network type %v", network)
 		}
 
-		host, _, err := net.SplitHostPort(address)
-		if err != nil {
-			return nil, err
+		host := config.PeerName
+		if host == "" {
+			var err error
+			host, _, err = net.SplitHostPort(address)
+			if err != nil {
+				return nil, err
+			}
 		}
 
 		var tlsConfig *tls.Config

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -40,6 +40,7 @@ type Config struct {
 	Renegotiation        TLSRenegotiationSupport `config:"renegotiation" yaml:"renegotiation"`
 	CASha256             []string                `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
 	CATrustedFingerprint string                  `config:"ca_trusted_fingerprint" yaml:"ca_trusted_fingerprint,omitempty"`
+	PeerName             string                  `config:"peer_name" yaml:"peer_name,omitempty"`
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys
@@ -92,6 +93,7 @@ func LoadTLSConfig(config *Config) (*TLSConfig, error) {
 		Renegotiation:        tls.RenegotiationSupport(config.Renegotiation),
 		CASha256:             config.CASha256,
 		CATrustedFingerprint: config.CATrustedFingerprint,
+		PeerName:             config.PeerName,
 	}, nil
 }
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -83,6 +83,9 @@ type TLSConfig struct {
 	// time returns the current time as the number of seconds since the epoch.
 	// If time is nil, TLS uses time.Now.
 	time func() time.Time
+
+	// PeerName specifies the SAN name or IP that must be present in the peer certificate.
+	PeerName string
 }
 
 var (
@@ -117,6 +120,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		ClientAuth:         c.ClientAuth,
 		Time:               c.time,
 		VerifyConnection:   makeVerifyConnection(c),
+		ServerName:         c.PeerName,
 	}
 }
 
@@ -134,7 +138,9 @@ func (c *TLSConfig) BuildModuleClientConfig(host string) *tls.Config {
 	}
 
 	config := c.ToConfig()
-	config.ServerName = host
+	if host != "" {
+		config.ServerName = host
+	}
 	return config
 }
 
@@ -152,7 +158,9 @@ func (c *TLSConfig) BuildServerConfig(host string) *tls.Config {
 	}
 
 	config := c.ToConfig()
-	config.ServerName = host
+	if host != "" {
+		config.ServerName = host
+	}
 	config.VerifyConnection = makeVerifyServerConnection(c)
 	return config
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds support for setting the peer certificate name in the config with `ssl.peer_name`. When set, this will configure the `TestTLSDialer` to use the given name rather than extracting it from the peer address.

The change is fully backwards-compatible.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->


## Why is it important?

Allows the use of endpoints for which the SAN name doesn't match the address used to connect to them.
<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
- [x] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

