### PR TITLE
Add Core function to logp.Logger to allow access to backing zapcore.Core.

### DIFF
--- a/logp/logger.go
+++ b/logp/logger.go
@@ -224,6 +224,11 @@ func (l *Logger) Sync() error {
 	return l.logger.Sync()
 }
 
+// Core returns the backend zapcore.Core for the logger.
+func (l *Logger) Core() zapcore.Core {
+	return l.logger.Core()
+}
+
 // L returns an unnamed global logger.
 func L() *Logger {
 	return loadLogger().logger


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds the ability to retrieve the `zapcore.Core` from the `logp.Logger`. This allows the ability to write entries directly into the logger bypassing any log levels settings.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This is needed for the work on https://github.com/elastic/elastic-agent/issues/221. The `io.Writer` connected to `stdout` and `stderr` from the spawned subprocesses will read the output from the process and output it directly to the `zapcore.Core`. That is required because each component and unit can have its own log level different from the Elastic Agent log level. Because of that design it requires that log messages bypass the log level settings for the logger used by Elastic Agent.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- [ ] I have added an entry in `CHANGELOG.md`

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/221

