### PR TITLE
Migrate loader library from elastic-agent to here

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,4 @@ Provided packages:
 * `github.com/elastic/elastic-agent-libs/testing` Testing helpers for network communication and outputs.
 * `github.com/elastic/elastic-agent-libs/transport/tlscommon` TLS configuration and validation, CA pinning, etc.
 * `github.com/elastic/elastic-agent-libs/transport` Dialers for testing, TLS, etc.
+* `github.com/elastic/elastic-agent-libs/loader` Helpers for loading a main elastic-agent config file.

--- a/loader/config.go
+++ b/loader/config.go
@@ -1,0 +1,228 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader 
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+
+	"gopkg.in/yaml.v2" 
+
+	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/cfgutil"
+)
+
+// options hold the specified options
+type options struct {
+	skipKeys []string
+}
+
+// Option is an option type that modifies how loading configs work
+type Option func(*options)
+
+// VarSkipKeys prevents variable expansion for these keys.
+//
+// The provided keys only skip if the keys are top-level keys.
+func VarSkipKeys(keys ...string) Option {
+	return func(opts *options) {
+		opts.skipKeys = keys
+	}
+}
+
+// DefaultOptions defaults options used to read the configuration
+var DefaultOptions = []interface{}{
+	ucfg.PathSep("."),
+	ucfg.ResolveEnv,
+	ucfg.VarExp,
+	VarSkipKeys("inputs"),
+}
+
+// Config custom type over a ucfg.Config to add new methods on the object.
+type Config ucfg.Config
+
+// New creates a new empty config.
+func New() *Config {
+	return newConfigFrom(ucfg.New())
+}
+
+// NewConfigFrom takes a interface and read the configuration like it was YAML.
+func NewConfigFrom(from interface{}, opts ...interface{}) (*Config, error) {
+	if len(opts) == 0 {
+		opts = DefaultOptions
+	}
+	var ucfgOpts []ucfg.Option
+	var localOpts []Option
+	for _, o := range opts {
+		switch ot := o.(type) {
+		case ucfg.Option:
+			ucfgOpts = append(ucfgOpts, ot)
+		case Option:
+			localOpts = append(localOpts, ot)
+		default:
+			return nil, fmt.Errorf("unknown option type %T", o)
+		}
+	}
+	local := &options{}
+	for _, o := range localOpts {
+		o(local)
+	}
+
+	var data map[string]interface{}
+	var err error
+	if bytes, ok := from.([]byte); ok {
+		err = yaml.Unmarshal(bytes, &data)
+		if err != nil {
+			return nil, err
+		}
+	} else if str, ok := from.(string); ok {
+		err = yaml.Unmarshal([]byte(str), &data)
+		if err != nil {
+			return nil, err
+		}
+	} else if in, ok := from.(io.Reader); ok {
+		if closer, ok := from.(io.Closer); ok {
+			defer closer.Close()
+		}
+		fData, err := ioutil.ReadAll(in)
+		if err != nil {
+			return nil, err
+		}
+		err = yaml.Unmarshal(fData, &data)
+		if err != nil {
+			return nil, err
+		}
+	} else if contents, ok := from.(map[string]interface{}); ok {
+		data = contents
+	} else {
+		c, err := ucfg.NewFrom(from, ucfgOpts...)
+		return newConfigFrom(c), err
+	}
+
+	skippedKeys := map[string]interface{}{}
+	for _, skip := range local.skipKeys {
+		val, ok := data[skip]
+		if ok {
+			skippedKeys[skip] = val
+			delete(data, skip)
+		}
+	}
+	cfg, err := ucfg.NewFrom(data, ucfgOpts...)
+	if err != nil {
+		return nil, err
+	}
+	if len(skippedKeys) > 0 {
+		err = cfg.Merge(skippedKeys, ucfg.ResolveNOOP)
+
+		// we modified incoming object
+		// cleanup so skipped keys are not missing
+		for k, v := range skippedKeys {
+			data[k] = v
+		}
+	}
+	return newConfigFrom(cfg), err
+}
+
+// MustNewConfigFrom try to create a configuration based on the type passed as arguments and panic
+// on failures.
+func MustNewConfigFrom(from interface{}) *Config {
+	c, err := NewConfigFrom(from)
+	if err != nil {
+		panic(fmt.Sprintf("could not read configuration %+v", err))
+	}
+	return c
+}
+
+func newConfigFrom(in *ucfg.Config) *Config {
+	return (*Config)(in)
+}
+
+// Unpack unpacks a struct to Config.
+func (c *Config) Unpack(to interface{}, opts ...interface{}) error {
+	ucfgOpts, err := getUcfgOptions(opts...)
+	if err != nil {
+		return err
+	}
+	return c.access().Unpack(to, ucfgOpts...)
+}
+
+func (c *Config) access() *ucfg.Config {
+	return (*ucfg.Config)(c)
+}
+
+// Merge merges two configuration together.
+func (c *Config) Merge(from interface{}, opts ...interface{}) error {
+	ucfgOpts, err := getUcfgOptions(opts...)
+	if err != nil {
+		return err
+	}
+	return c.access().Merge(from, ucfgOpts...)
+}
+
+// ToMapStr takes the config and transform it into a map[string]interface{}
+func (c *Config) ToMapStr() (map[string]interface{}, error) {
+	var m map[string]interface{}
+	if err := c.Unpack(&m); err != nil {
+		return nil, err
+	}
+	return m, nil
+}
+
+// Enabled return the configured enabled value or true by default.
+func (c *Config) Enabled() bool {
+	testEnabled := struct {
+		Enabled bool `config:"enabled"`
+	}{true}
+
+	if c == nil {
+		return false
+	}
+	if err := c.Unpack(&testEnabled); err != nil {
+		// if unpacking fails, expect 'enabled' being set to default value
+		return true
+	}
+	return testEnabled.Enabled
+}
+
+// LoadFile take a path and load the file and return a new configuration.
+func LoadFile(path string) (*Config, error) {
+	fp, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	return NewConfigFrom(fp)
+}
+
+// LoadFiles takes multiples files, load and merge all of them in a single one.
+func LoadFiles(paths ...string) (*Config, error) {
+	merger := cfgutil.NewCollector(nil)
+	for _, path := range paths {
+		cfg, err := LoadFile(path)
+		if err := merger.Add(cfg.access(), err); err != nil {
+			return nil, err
+		}
+	}
+	return newConfigFrom(merger.Config()), nil
+}
+
+func getUcfgOptions(opts ...interface{}) ([]ucfg.Option, error) {
+	if len(opts) == 0 {
+		opts = DefaultOptions
+	}
+	var ucfgOpts []ucfg.Option
+	for _, o := range opts {
+		switch ot := o.(type) {
+		case ucfg.Option:
+			ucfgOpts = append(ucfgOpts, ot)
+		case Option:
+			// ignored during unpack
+			continue
+		default:
+			return nil, fmt.Errorf("unknown option type %T", o)
+		}
+	}
+	return ucfgOpts, nil
+}

--- a/loader/config.go
+++ b/loader/config.go
@@ -1,8 +1,21 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-package loader 
+package loader
 
 import (
 	"fmt"
@@ -10,7 +23,7 @@ import (
 	"io/ioutil"
 	"os"
 
-	"gopkg.in/yaml.v2" 
+	"gopkg.in/yaml.v2"
 
 	"github.com/elastic/go-ucfg"
 	"github.com/elastic/go-ucfg/cfgutil"

--- a/loader/config_test.go
+++ b/loader/config_test.go
@@ -1,0 +1,124 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func TestConfig(t *testing.T) {
+	testToMapStr(t)
+	testLoadFiles(t)
+}
+
+func TestInputsResolveNOOP(t *testing.T) {
+	contents := map[string]interface{}{
+		"outputs": map[string]interface{}{
+			"default": map[string]interface{}{
+				"type":     "elasticsearch",
+				"hosts":    []interface{}{"127.0.0.1:9200"},
+				"username": "elastic",
+				"password": "changeme",
+			},
+		},
+		"inputs": []interface{}{
+			map[string]interface{}{
+				"type": "logfile",
+				"streams": []interface{}{
+					map[string]interface{}{
+						"paths": []interface{}{"/var/log/${host.name}"},
+					},
+				},
+			},
+		},
+	}
+
+	tmp, err := ioutil.TempDir("", "config")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	cfgPath := filepath.Join(tmp, "config.yml")
+	dumpToYAML(t, cfgPath, contents)
+
+	cfg, err := LoadFile(cfgPath)
+	require.NoError(t, err)
+
+	cfgData, err := cfg.ToMapStr()
+	require.NoError(t, err)
+
+	assert.Equal(t, contents, cfgData)
+}
+
+func testToMapStr(t *testing.T) {
+	m := map[string]interface{}{
+		"hello": map[string]interface{}{
+			"what": "who",
+		},
+	}
+
+	c := MustNewConfigFrom(m)
+	nm, err := c.ToMapStr()
+	require.NoError(t, err)
+
+	assert.True(t, reflect.DeepEqual(m, nm))
+}
+
+func testLoadFiles(t *testing.T) {
+	tmp, err := ioutil.TempDir("", "watch")
+	require.NoError(t, err)
+	defer os.RemoveAll(tmp)
+
+	f1 := filepath.Join(tmp, "1.yml")
+	dumpToYAML(t, f1, map[string]interface{}{
+		"hello": map[string]interface{}{
+			"what": "1",
+		},
+	})
+
+	f2 := filepath.Join(tmp, "2.yml")
+	dumpToYAML(t, f2, map[string]interface{}{
+		"hello": map[string]interface{}{
+			"where": "2",
+		},
+	})
+
+	f3 := filepath.Join(tmp, "3.yml")
+	dumpToYAML(t, f3, map[string]interface{}{
+		"super": map[string]interface{}{
+			"awesome": "cool",
+		},
+	})
+
+	c, err := LoadFiles(f1, f2, f3)
+	require.NoError(t, err)
+
+	r, err := c.ToMapStr()
+	require.NoError(t, err)
+
+	assert.Equal(t, map[string]interface{}{
+		"hello": map[string]interface{}{
+			"what":  "1",
+			"where": "2",
+		},
+		"super": map[string]interface{}{
+			"awesome": "cool",
+		},
+	}, r)
+}
+
+func dumpToYAML(t *testing.T, out string, in interface{}) {
+	b, err := yaml.Marshal(in)
+	require.NoError(t, err)
+	err = ioutil.WriteFile(out, b, 0600)
+	require.NoError(t, err)
+}

--- a/loader/config_test.go
+++ b/loader/config_test.go
@@ -1,6 +1,19 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package loader
 

--- a/loader/discover.go
+++ b/loader/discover.go
@@ -1,0 +1,37 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader
+
+import (
+	"errors"
+)
+
+// ErrNoConfiguration is returned when no configuration are found.
+var ErrNoConfiguration = errors.New("no configuration found")
+
+// DiscoverFunc is a function that discovers a list of files to load.
+type DiscoverFunc func() ([]string, error)
+
+// Discoverer returns a DiscoverFunc that discovers all files that match the given patterns.
+func Discoverer(patterns ...string) DiscoverFunc {
+	p := make([]string, 0, len(patterns))
+	for _, newP := range patterns {
+		if len(newP) == 0 {
+			continue
+		}
+
+		p = append(p, newP)
+	}
+
+	if len(p) == 0 {
+		return func() ([]string, error) {
+			return []string{}, ErrNoConfiguration
+		}
+	}
+
+	return func() ([]string, error) {
+		return DiscoverFiles(p...)
+	}
+}

--- a/loader/discover.go
+++ b/loader/discover.go
@@ -1,6 +1,19 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package loader
 

--- a/loader/discover_test.go
+++ b/loader/discover_test.go
@@ -1,0 +1,73 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const agentConfigFile = "elastic-agent.yml"
+
+func TestDiscover(t *testing.T) {
+	t.Run("support wildcards patterns", withFiles([]string{"hello", "helllooo"}, func(
+		dst string,
+		t *testing.T,
+	) {
+		r, err := DiscoverFiles(filepath.Join(dst, "hel*"))
+		require.NoError(t, err)
+		assert.Equal(t, 2, len(r))
+	}))
+
+	t.Run("support direct file", withFiles([]string{"hello", "helllooo"}, func(
+		dst string,
+		t *testing.T,
+	) {
+		r, err := DiscoverFiles(filepath.Join(dst, "hello"))
+		require.NoError(t, err)
+		assert.Equal(t, 1, len(r))
+	}))
+
+	t.Run("support direct file and pattern", withFiles([]string{"hello", "helllooo", agentConfigFile}, func(
+		dst string,
+		t *testing.T,
+	) {
+		r, err := DiscoverFiles(
+			filepath.Join(dst, "hel*"),
+			filepath.Join(dst, agentConfigFile),
+		)
+		require.NoError(t, err)
+		assert.Equal(t, 3, len(r))
+	}))
+
+	t.Run("support direct file and pattern", withFiles([]string{"hello", "helllooo", agentConfigFile}, func(
+		dst string,
+		t *testing.T,
+	) {
+		r, err := DiscoverFiles(filepath.Join(dst, "donotmatch.yml"))
+		require.NoError(t, err)
+		assert.Equal(t, 0, len(r))
+	}))
+}
+
+func withFiles(files []string, fn func(dst string, t *testing.T)) func(t *testing.T) {
+	return func(t *testing.T) {
+		tmp, _ := ioutil.TempDir("", "watch")
+		defer os.RemoveAll(tmp)
+
+		for _, file := range files {
+			path := filepath.Join(tmp, file)
+			empty, _ := os.Create(path)
+			empty.Close()
+		}
+
+		fn(tmp, t)
+	}
+}

--- a/loader/discover_test.go
+++ b/loader/discover_test.go
@@ -1,6 +1,19 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package loader
 

--- a/loader/file_discover.go
+++ b/loader/file_discover.go
@@ -1,0 +1,28 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader
+
+import (
+	"fmt"
+	"path/filepath"
+)
+
+// DiscoverFiles takes a slices of wildcards patterns and try to discover all the matching files
+// recursively and will stop on any errors.
+func DiscoverFiles(patterns ...string) ([]string, error) {
+	files := make([]string, 0)
+	for _, pattern := range patterns {
+		f, err := filepath.Glob(pattern)
+		if err != nil {
+			return files, fmt.Errorf("error while loading glob pattern: %w", err)
+		}
+
+		if len(f) > 0 {
+			files = append(files, f...)
+		}
+	}
+
+	return files, nil
+}

--- a/loader/file_discover.go
+++ b/loader/file_discover.go
@@ -1,6 +1,19 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package loader
 

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,8 +1,21 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-package loader 
+package loader
 
 import (
 	"fmt"
@@ -10,7 +23,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/go-ucfg"
-	"github.com/elastic/go-ucfg/cfgutil" 
+	"github.com/elastic/go-ucfg/cfgutil"
 )
 
 // Loader is used to load configuration from the paths

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -1,0 +1,104 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader 
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/go-ucfg"
+	"github.com/elastic/go-ucfg/cfgutil" 
+)
+
+// Loader is used to load configuration from the paths
+// including appending multiple input configurations.
+type Loader struct {
+	logger       *logp.Logger
+	inputsFolder string
+}
+
+// NewLoader creates a new Loader instance to load configuration
+// files from different paths.
+func NewLoader(logger *logp.Logger, inputsFolder string) *Loader {
+	return &Loader{logger: logger, inputsFolder: inputsFolder}
+}
+
+// Load iterates over the list of files and loads the confguration from them.
+// If a configuration file is under the folder set in `agent.config.inputs.path`
+// it is appended to a list. If it is a regular config file, it is merged into
+// the result config. The list of input configurations is merged into the result
+// last.
+func (l *Loader) Load(files []string) (*Config, error) {
+	inputsList := make([]*ucfg.Config, 0)
+	merger := cfgutil.NewCollector(nil)
+	for _, f := range files {
+		cfg, err := LoadFile(f)
+		if err != nil {
+			if l.isFileUnderInputsFolder(f) {
+				return nil, fmt.Errorf("failed to load external configuration file '%s': %w. Are you sure it contains an inputs section?", f, err)
+			}
+			return nil, fmt.Errorf("failed to load configuration file '%s': %w", f, err)
+		}
+		l.logger.Debugf("Loaded configuration from %s", f)
+		if l.isFileUnderInputsFolder(f) {
+			inp, err := getInput(cfg)
+			if err != nil {
+				return nil, fmt.Errorf("cannot get configuration from '%s': %w", f, err)
+			}
+			inputsList = append(inputsList, inp...)
+			l.logger.Debugf("Loaded %s input(s) from configuration from %s", len(inp), f)
+		} else {
+			if err := merger.Add(cfg.access(), err); err != nil {
+				return nil, fmt.Errorf("failed to merge configuration file '%s' to existing one: %w", f, err)
+			}
+			l.logger.Debugf("Merged configuration from %s into result", f)
+		}
+	}
+	config := merger.Config()
+
+	// if there is no input configuration, return what we have collected.
+	if len(inputsList) == 0 {
+		l.logger.Debugf("Merged all configuration files from %v, no external input files", files)
+		return newConfigFrom(config), nil
+	}
+
+	// merge inputs sections from the last standalone configuration
+	// file and all files from the inputs folder
+	start := 0
+	if config.HasField("inputs") {
+		var err error
+		start, err = config.CountField("inputs")
+		if err != nil {
+			return nil, fmt.Errorf("failed to count the number of inputs in the configuration: %w", err)
+		}
+	}
+	for i, ll := range inputsList {
+		if err := config.SetChild("inputs", start+i, ll); err != nil {
+			return nil, fmt.Errorf("failed to add inputs to result configuration: %w", err)
+		}
+	}
+
+	l.logger.Debugf("Merged all configuration files from %v, with external input files", files)
+	return newConfigFrom(config), nil
+}
+
+func getInput(c *Config) ([]*ucfg.Config, error) {
+	tmpConfig := struct {
+		Inputs []*ucfg.Config `config:"inputs"`
+	}{make([]*ucfg.Config, 0)}
+
+	if err := c.Unpack(&tmpConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse inputs section from configuration: %w", err)
+	}
+	return tmpConfig.Inputs, nil
+}
+
+func (l *Loader) isFileUnderInputsFolder(f string) bool {
+	if matches, err := filepath.Match(l.inputsFolder, f); !matches || err != nil {
+		return false
+	}
+	return true
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,0 +1,209 @@
+// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
+// or more contributor license agreements. Licensed under the Elastic License;
+// you may not use this file except in compliance with the Elastic License.
+
+package loader
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+func TestExternalConfigLoading(t *testing.T) {
+	cases := map[string]struct {
+		configs        []string
+		inputsFolder   string
+		expectedConfig map[string]interface{}
+		err            bool
+	}{
+		"non-existent config files lead to error": {
+			configs: []string{"no-such-configuration-file.yml"},
+			err:     true,
+		},
+		"invalid configuration file in inputs folder lead to error": {
+			configs: []string{
+				filepath.Join("testdata", "inputs", "invalid-inputs.yml"),
+			},
+			inputsFolder: filepath.Join("testdata", "inputs", "*.yml"),
+			err:          true,
+		},
+		"two standalone configs can be merged without inputs": {
+			configs: []string{
+				filepath.Join("testdata", "standalone1.yml"),
+				filepath.Join("testdata", "standalone2.yml"),
+			},
+			inputsFolder: "",
+			expectedConfig: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"default": map[string]interface{}{
+						"type":    "elasticsearch",
+						"hosts":   []interface{}{"127.0.0.1:9201"},
+						"api-key": "my-secret-key",
+					},
+				},
+				"agent": map[string]interface{}{
+					"logging": map[string]interface{}{
+						"level": "debug",
+						"metrics": map[string]interface{}{
+							"enabled": false,
+						},
+					},
+				},
+			},
+		},
+		"one external config, standalone config without inputs section": {
+			configs: []string{
+				filepath.Join("testdata", "standalone1.yml"),
+				filepath.Join("testdata", "inputs", "log-inputs.yml"),
+				filepath.Join("testdata", "inputs", "metrics-inputs.yml"),
+			},
+			inputsFolder: filepath.Join("testdata", "inputs", "*.yml"),
+			expectedConfig: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"default": map[string]interface{}{
+						"type":    "elasticsearch",
+						"hosts":   []interface{}{"127.0.0.1:9201"},
+						"api-key": "my-secret-key",
+					},
+				},
+				"inputs": []interface{}{
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.auth",
+							"type":    "logs",
+						},
+						"exclude_files": []interface{}{".gz$"},
+						"id":            "logfile-system.auth-my-id",
+						"paths":         []interface{}{"/var/log/auth.log*", "/var/log/secure*"},
+						"use_output":    "default",
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.syslog",
+							"type":    "logs",
+						},
+						"type":          "logfile",
+						"id":            "logfile-system.syslog-my-id",
+						"exclude_files": []interface{}{".gz$"},
+						"paths":         []interface{}{"/var/log/messages*", "/var/log/syslog*"},
+						"use_output":    "default",
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.diskio",
+							"type":    "metrics",
+						},
+						"id":         "system/metrics-system.diskio-my-id",
+						"metricsets": []interface{}{"diskio"},
+						"period":     "10s",
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.filesystem",
+							"type":    "metrics",
+						},
+						"id":         "system/metrics-system.filesystem-my-id",
+						"metricsets": []interface{}{"filesystem"},
+						"period":     "30s",
+					},
+				},
+			},
+		},
+		"inputs sections of all external and standalone configuration are merged to the result": {
+			configs: []string{
+				filepath.Join("testdata", "standalone-with-inputs.yml"),
+				filepath.Join("testdata", "inputs", "log-inputs.yml"),
+				filepath.Join("testdata", "inputs", "metrics-inputs.yml"),
+			},
+			inputsFolder: filepath.Join("testdata", "inputs", "*.yml"),
+			expectedConfig: map[string]interface{}{
+				"outputs": map[string]interface{}{
+					"default": map[string]interface{}{
+						"type":    "elasticsearch",
+						"hosts":   []interface{}{"127.0.0.1:9201"},
+						"api-key": "my-secret-key",
+					},
+				},
+				"inputs": []interface{}{
+					map[string]interface{}{
+						"type":                  "system/metrics",
+						"data_stream.namespace": "default",
+						"use_output":            "default",
+						"streams": []interface{}{
+							map[string]interface{}{
+								"metricset":           "cpu",
+								"data_stream.dataset": "system.cpu",
+							},
+						},
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.auth",
+							"type":    "logs",
+						},
+						"exclude_files": []interface{}{".gz$"},
+						"id":            "logfile-system.auth-my-id",
+						"paths":         []interface{}{"/var/log/auth.log*", "/var/log/secure*"},
+						"use_output":    "default",
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.syslog",
+							"type":    "logs",
+						},
+						"type":          "logfile",
+						"id":            "logfile-system.syslog-my-id",
+						"exclude_files": []interface{}{".gz$"},
+						"paths":         []interface{}{"/var/log/messages*", "/var/log/syslog*"},
+						"use_output":    "default",
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.diskio",
+							"type":    "metrics",
+						},
+						"id":         "system/metrics-system.diskio-my-id",
+						"metricsets": []interface{}{"diskio"},
+						"period":     "10s",
+					},
+					map[string]interface{}{
+						"data_stream": map[string]interface{}{
+							"dataset": "system.filesystem",
+							"type":    "metrics",
+						},
+						"id":         "system/metrics-system.filesystem-my-id",
+						"metricsets": []interface{}{"filesystem"},
+						"period":     "30s",
+					},
+				},
+			},
+		},
+	}
+
+	for name, test := range cases {
+		t.Run(name, func(t *testing.T) {
+			test := test
+
+			l := mustNewLoader(test.inputsFolder)
+			c, err := l.Load(test.configs)
+			if test.err {
+				require.NotNil(t, err)
+				return
+			}
+
+			require.Nil(t, err)
+			raw, err := c.ToMapStr()
+			require.Nil(t, err)
+			require.Equal(t, test.expectedConfig, raw)
+		})
+	}
+}
+
+func mustNewLoader(inputsFolder string) *Loader {
+	log := logp.L()
+	return NewLoader(log, inputsFolder)
+}

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -27,6 +27,55 @@ import (
 )
 
 func TestExternalConfigLoading(t *testing.T) {
+	authCfg := map[string]interface{}{
+		"data_stream": map[string]interface{}{
+			"dataset": "system.auth",
+			"type":    "logs",
+		},
+		"exclude_files": []interface{}{".gz$"},
+		"id":            "logfile-system.auth-my-id",
+		"paths":         []interface{}{"/var/log/auth.log*", "/var/log/secure*"},
+		"use_output":    "default",
+	}
+	syslogCfg := map[string]interface{}{
+		"data_stream": map[string]interface{}{
+			"dataset": "system.syslog",
+			"type":    "logs",
+		},
+		"type":          "logfile",
+		"id":            "logfile-system.syslog-my-id",
+		"exclude_files": []interface{}{".gz$"},
+		"paths":         []interface{}{"/var/log/messages*", "/var/log/syslog*"},
+		"use_output":    "default",
+	}
+
+	diskioCfg := map[string]interface{}{
+		"data_stream": map[string]interface{}{
+			"dataset": "system.diskio",
+			"type":    "metrics",
+		},
+		"id":         "system/metrics-system.diskio-my-id",
+		"metricsets": []interface{}{"diskio"},
+		"period":     "10s",
+	}
+	filesystemCfg := map[string]interface{}{
+		"data_stream": map[string]interface{}{
+			"dataset": "system.filesystem",
+			"type":    "metrics",
+		},
+		"id":         "system/metrics-system.filesystem-my-id",
+		"metricsets": []interface{}{"filesystem"},
+		"period":     "30s",
+	}
+
+	outputCfg := map[string]interface{}{
+		"default": map[string]interface{}{
+			"type":    "elasticsearch",
+			"hosts":   []interface{}{"127.0.0.1:9201"},
+			"api-key": "my-secret-key",
+		},
+	}
+
 	cases := map[string]struct {
 		configs        []string
 		inputsFolder   string
@@ -51,13 +100,7 @@ func TestExternalConfigLoading(t *testing.T) {
 			},
 			inputsFolder: "",
 			expectedConfig: map[string]interface{}{
-				"outputs": map[string]interface{}{
-					"default": map[string]interface{}{
-						"type":    "elasticsearch",
-						"hosts":   []interface{}{"127.0.0.1:9201"},
-						"api-key": "my-secret-key",
-					},
-				},
+				"outputs": outputCfg,
 				"agent": map[string]interface{}{
 					"logging": map[string]interface{}{
 						"level": "debug",
@@ -84,45 +127,10 @@ func TestExternalConfigLoading(t *testing.T) {
 					},
 				},
 				"inputs": []interface{}{
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.auth",
-							"type":    "logs",
-						},
-						"exclude_files": []interface{}{".gz$"},
-						"id":            "logfile-system.auth-my-id",
-						"paths":         []interface{}{"/var/log/auth.log*", "/var/log/secure*"},
-						"use_output":    "default",
-					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.syslog",
-							"type":    "logs",
-						},
-						"type":          "logfile",
-						"id":            "logfile-system.syslog-my-id",
-						"exclude_files": []interface{}{".gz$"},
-						"paths":         []interface{}{"/var/log/messages*", "/var/log/syslog*"},
-						"use_output":    "default",
-					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.diskio",
-							"type":    "metrics",
-						},
-						"id":         "system/metrics-system.diskio-my-id",
-						"metricsets": []interface{}{"diskio"},
-						"period":     "10s",
-					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.filesystem",
-							"type":    "metrics",
-						},
-						"id":         "system/metrics-system.filesystem-my-id",
-						"metricsets": []interface{}{"filesystem"},
-						"period":     "30s",
-					},
+					authCfg,
+					syslogCfg,
+					diskioCfg,
+					filesystemCfg,
 				},
 			},
 		},
@@ -134,13 +142,7 @@ func TestExternalConfigLoading(t *testing.T) {
 			},
 			inputsFolder: filepath.Join("testdata", "inputs", "*.yml"),
 			expectedConfig: map[string]interface{}{
-				"outputs": map[string]interface{}{
-					"default": map[string]interface{}{
-						"type":    "elasticsearch",
-						"hosts":   []interface{}{"127.0.0.1:9201"},
-						"api-key": "my-secret-key",
-					},
-				},
+				"outputs": outputCfg,
 				"inputs": []interface{}{
 					map[string]interface{}{
 						"type":                  "system/metrics",
@@ -153,45 +155,10 @@ func TestExternalConfigLoading(t *testing.T) {
 							},
 						},
 					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.auth",
-							"type":    "logs",
-						},
-						"exclude_files": []interface{}{".gz$"},
-						"id":            "logfile-system.auth-my-id",
-						"paths":         []interface{}{"/var/log/auth.log*", "/var/log/secure*"},
-						"use_output":    "default",
-					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.syslog",
-							"type":    "logs",
-						},
-						"type":          "logfile",
-						"id":            "logfile-system.syslog-my-id",
-						"exclude_files": []interface{}{".gz$"},
-						"paths":         []interface{}{"/var/log/messages*", "/var/log/syslog*"},
-						"use_output":    "default",
-					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.diskio",
-							"type":    "metrics",
-						},
-						"id":         "system/metrics-system.diskio-my-id",
-						"metricsets": []interface{}{"diskio"},
-						"period":     "10s",
-					},
-					map[string]interface{}{
-						"data_stream": map[string]interface{}{
-							"dataset": "system.filesystem",
-							"type":    "metrics",
-						},
-						"id":         "system/metrics-system.filesystem-my-id",
-						"metricsets": []interface{}{"filesystem"},
-						"period":     "30s",
-					},
+					authCfg,
+					syslogCfg,
+					diskioCfg,
+					filesystemCfg,
 				},
 			},
 		},

--- a/loader/loader_test.go
+++ b/loader/loader_test.go
@@ -1,6 +1,19 @@
-// Copyright Elasticsearch B.V. and/or licensed to Elasticsearch B.V. under one
-// or more contributor license agreements. Licensed under the Elastic License;
-// you may not use this file except in compliance with the Elastic License.
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
 package loader
 

--- a/loader/testdata/inputs/log-inputs.yml
+++ b/loader/testdata/inputs/log-inputs.yml
@@ -1,0 +1,20 @@
+inputs:
+- data_stream:
+    dataset: system.auth
+    type: logs
+  exclude_files: [".gz$"]
+  id: logfile-system.auth-my-id
+  paths:
+  - /var/log/auth.log*
+  - /var/log/secure*
+  use_output: default
+- data_stream:
+    dataset: system.syslog
+    type: logs
+  type: logfile
+  id: logfile-system.syslog-my-id
+  exclude_files: [".gz$"]
+  paths:
+  - /var/log/messages*
+  - /var/log/syslog*
+  use_output: default

--- a/loader/testdata/inputs/metrics-inputs.yml
+++ b/loader/testdata/inputs/metrics-inputs.yml
@@ -1,0 +1,16 @@
+inputs:
+- data_stream:
+    dataset: system.diskio
+    type: metrics
+  id: system/metrics-system.diskio-my-id
+  metricsets:
+  - diskio
+  period: 10s
+- data_stream:
+    dataset: system.filesystem
+    type: metrics
+  id: system/metrics-system.filesystem-my-id
+  metricsets:
+  - filesystem
+  period: 30s
+

--- a/loader/testdata/standalone-with-inputs.yml
+++ b/loader/testdata/standalone-with-inputs.yml
@@ -1,0 +1,13 @@
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9201]
+    api-key: "my-secret-key"
+
+inputs:
+  - type: system/metrics
+    data_stream.namespace: default
+    use_output: default
+    streams:
+      - metricset: cpu
+        data_stream.dataset: system.cpu

--- a/loader/testdata/standalone1.yml
+++ b/loader/testdata/standalone1.yml
@@ -1,0 +1,6 @@
+outputs:
+  default:
+    type: elasticsearch
+    hosts: [127.0.0.1:9201]
+    api-key: "my-secret-key"
+

--- a/loader/testdata/standalone2.yml
+++ b/loader/testdata/standalone2.yml
@@ -1,0 +1,3 @@
+agent.logging.level: debug
+agent.logging.metrics.enabled: false
+


### PR DESCRIPTION
## What does this PR do?

This PR doesn't really do anything on its own, but is a dependency on an upcoming PR that will give `elastic-agent-client` a standalone mode, allowing a client to run from a raw elastic-agent.yml config file, without an attached instance of elastic-agent. This library was previously in elastic-agent's internal library, but it's very useful for any code that needs to read a yaml file that's similarly structured.

## Why is it important?

This will be a requirement for a PR to improve elastic-agent-client.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
