### PR TITLE
Add filewatcher package

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1130,6 +1130,37 @@ SOFTWARE.
 
 
 --------------------------------------------------------------------------------
+Dependency : github.com/mitchellh/hashstructure
+Version: v1.1.0
+Licence type (autodetected): MIT
+--------------------------------------------------------------------------------
+
+Contents of probable licence file $GOMODCACHE/github.com/mitchellh/hashstructure@v1.1.0/LICENSE:
+
+The MIT License (MIT)
+
+Copyright (c) 2016 Mitchell Hashimoto
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+
+--------------------------------------------------------------------------------
 Dependency : github.com/rcrowley/go-metrics
 Version: v0.0.0-20201227073835-cf1acfcdf475
 Licence type (autodetected): BSD-2-Clause-FreeBSD

--- a/README.md
+++ b/README.md
@@ -9,7 +9,9 @@ Provided packages:
 * `github.com/elastic/elastic-agent-libs/cloudid` is used for parsing `cloud.id` and `cloud.auth` when connecting to the Elastic stack.
 * `github.com/elastic/elastic-agent-libs/config` the previous `config.go` file from `github.com/elastic/beats/v7/libbeat/common`. A minimal wrapper around `github.com/elastic/go-ucfg`. It contains helpers for merging and accessing configuration objects and flags.
 * `github.com/elastic/elastic-agent-libs/file` is responsible for rotating and writing input and output files.
+* `github.com/elastic/elastic-agent-libs/filewatcher` Watches files and notifies if they have been modified.
 * `github.com/elastic/elastic-agent-libs/keystore` interface for keystores and file keystore implementation.
+* `github.com/elastic/elastic-agent-libs/loader` Helpers for loading a main elastic-agent config file.
 * `github.com/elastic/elastic-agent-libs/logp/cfgwarn` provides logging utilities for warning users about deprecated settings.
 * `github.com/elastic/elastic-agent-libs/logp` is the well known logger from libbeat.
 * `github.com/elastic/elastic-agent-libs/mapstr` is the old `github.com/elastic/beats/v7/libbeat/common.MapStr`. It is an extra layer on top of `map[string]interface{}`.
@@ -20,4 +22,3 @@ Provided packages:
 * `github.com/elastic/elastic-agent-libs/testing` Testing helpers for network communication and outputs.
 * `github.com/elastic/elastic-agent-libs/transport/tlscommon` TLS configuration and validation, CA pinning, etc.
 * `github.com/elastic/elastic-agent-libs/transport` Dialers for testing, TLS, etc.
-* `github.com/elastic/elastic-agent-libs/loader` Helpers for loading a main elastic-agent config file.

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -62,10 +62,13 @@ func (f *FileWatcher) Scan() ([]string, bool, error) {
 		}
 
 		// Check if one of the files was changed recently
-		// File modification time can be in seconds. -1 + truncation is to cover for files which
-		// were created during this second.
-		// If the last scan was at 09:02:15.00001 it will pick up files which were modified also 09:02:14
-		// As this scan no necessarily picked up files form 09:02:14
+		// File modification time usually is in seconds. We subtract a
+		// second and truncate to account for files which  were
+		// created during this second the scan is running.
+		// If the last scan was at 09:02:15.00001 it will pick up
+		// files which were modified at 09:02:14.
+		// Otherwise this scan would not necessarily pick up files
+		// form 09:02:14.
 		// TODO: How could this be improved / simplified? Behaviour was sometimes flaky. Is ModTime updated with delay?
 		if info.ModTime().After(f.lastScan.Add(-1 * time.Second).Truncate(time.Second)) {
 			updatedFiles = true

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -42,10 +42,11 @@ func New(files ...string) *FileWatcher {
 
 // Scan scans all file paths and checks if the number of files or the modtime of the files changed
 // It returns the list of existing files, a boolean if anything in has changed and potential errors.
-// To detect changes not only mod time is compared but also the hash of the files list. This is required to
+// To detect changes not only modtime is compared but also the hash of the files list. This is required to
 // also detect files which were removed.
-// The modtime is compared based on second as normally mod-time is in seconds. If it is unclear if something changed
-// the method will return true for the changes. It is strongly recommend to call scan not more frequent then 1s.
+// Normally, the modtime is presented in seconds, so the change detection is also based on seconds.
+// When it's unclear whether something changed or not the method will return `true` to make sure potential changes are handled.
+// It is strongly recommended to call `Scan` not more than once a second.
 func (f *FileWatcher) Scan() ([]string, bool, error) {
 	updatedFiles := false
 	files := []string{}

--- a/filewatcher/filewatcher.go
+++ b/filewatcher/filewatcher.go
@@ -1,0 +1,88 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filewatcher
+
+import (
+	"os"
+	"time"
+
+	"github.com/mitchellh/hashstructure"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+type FileWatcher struct {
+	files    []string
+	lastScan time.Time
+	lastHash uint64
+}
+
+func New(files ...string) *FileWatcher {
+	return &FileWatcher{
+		lastScan: time.Time{},
+		lastHash: 0,
+		files:    files,
+	}
+}
+
+// Scan scans all file paths and checks if the number of files or the modtime of the files changed
+// It returns the list of existing files, a boolean if anything in has changed and potential errors.
+// To detect changes not only mod time is compared but also the hash of the files list. This is required to
+// also detect files which were removed.
+// The modtime is compared based on second as normally mod-time is in seconds. If it is unclear if something changed
+// the method will return true for the changes. It is strongly recommend to call scan not more frequent then 1s.
+func (f *FileWatcher) Scan() ([]string, bool, error) {
+	updatedFiles := false
+	files := []string{}
+
+	lastScan := time.Now()
+	defer func() { f.lastScan = lastScan }()
+
+	for _, path := range f.files {
+		info, err := os.Stat(path)
+		if err != nil {
+			logp.Err("Error getting stats for file: %s", path)
+			continue
+		}
+
+		// Check if one of the files was changed recently
+		// File modification time can be in seconds. -1 + truncation is to cover for files which
+		// were created during this second.
+		// If the last scan was at 09:02:15.00001 it will pick up files which were modified also 09:02:14
+		// As this scan no necessarily picked up files form 09:02:14
+		// TODO: How could this be improved / simplified? Behaviour was sometimes flaky. Is ModTime updated with delay?
+		if info.ModTime().After(f.lastScan.Add(-1 * time.Second).Truncate(time.Second)) {
+			updatedFiles = true
+		}
+
+		files = append(files, path)
+	}
+
+	hash, err := hashstructure.Hash(files, nil)
+	if err != nil {
+		return files, true, err
+	}
+	defer func() { f.lastHash = hash }()
+
+	// Check if something changed
+	if !updatedFiles && hash == f.lastHash {
+		return files, false, nil
+	}
+
+	return files, true, nil
+}

--- a/filewatcher/filewatcher_test.go
+++ b/filewatcher/filewatcher_test.go
@@ -1,0 +1,80 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package filewatcher
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileWatcher(t *testing.T) {
+	dir := t.TempDir()
+	files := []string{
+		"file-1",
+		"file-2",
+		"file-3",
+	}
+	filenames := []string{}
+
+	// Create the files and write something on them
+	for _, f := range files {
+		filename := filepath.Join(dir, f)
+		if err := os.WriteFile(filename, []byte("test\n"), 0644); err != nil {
+			t.Fatalf("could not create '%s' for testing, err: %s", filename, err)
+		}
+		filenames = append(filenames, filename)
+	}
+
+	watcher := New(filenames...)
+
+	// Modification timestamps usually have second precision,
+	// we wait to make sure we're not in the second the files were created
+	time.Sleep(2 * time.Second)
+
+	files, changed, err := watcher.Scan()
+	assert.Len(t, files, 3, "number of watched files")
+	assert.NoError(t, err)
+	assert.True(t, changed, "first scan should always return true for 'changed'")
+
+	files, changed, err = watcher.Scan()
+	assert.Len(t, files, 3, "number of watched files")
+	assert.NoError(t, err)
+	assert.False(t, changed, "'changed' must be false, no files should have changed")
+
+	// Modify one file
+	err = os.WriteFile(filenames[2], []byte("data\n"), 0644)
+	assert.NoError(t, err)
+
+	files, changed, err = watcher.Scan()
+	assert.Len(t, files, 3, "number of files watched")
+	assert.NoError(t, err)
+	assert.True(t, changed, "'changed' must be true, one file has changed")
+
+	// Remove a file
+	err = os.Remove(filenames[2])
+	assert.NoError(t, err)
+
+	files, changed, err = watcher.Scan()
+	assert.Len(t, files, 2, "number of files watched")
+	assert.NoError(t, err)
+	assert.True(t, changed, "'changed' must be truem one file has been removed")
+}

--- a/filewatcher/filewatcher_test.go
+++ b/filewatcher/filewatcher_test.go
@@ -76,5 +76,5 @@ func TestFileWatcher(t *testing.T) {
 	files, changed, err = watcher.Scan()
 	assert.Len(t, files, 2, "number of files watched")
 	assert.NoError(t, err)
-	assert.True(t, changed, "'changed' must be truem one file has been removed")
+	assert.True(t, changed, "'changed' must be true, one file has been removed")
 }

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/joeshaw/multierror v0.0.0-20140124173710-69b34d4ec901
 	github.com/magefile/mage v1.13.0
 	github.com/mattn/go-colorable v0.1.12
+	github.com/mitchellh/hashstructure v1.1.0
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/spf13/cobra v1.3.0
 	github.com/stretchr/testify v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -305,6 +305,8 @@ github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJys
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=
 github.com/mitchellh/go-homedir v1.1.0/go.mod h1:SfyaCUpYCn1Vlf4IUYiD9fPX4A5wJrkLzIz1N1q0pr0=
 github.com/mitchellh/go-testing-interface v1.0.0/go.mod h1:kRemZodwjscx+RGhAo8eIhFbs2+BFgRtFPeD/KE+zxI=
+github.com/mitchellh/hashstructure v1.1.0 h1:P6P1hdjqAAknpY/M1CGipelZgp+4y9ja9kmUZPXP+H0=
+github.com/mitchellh/hashstructure v1.1.0/go.mod h1:xUDAozZz0Wmdiufv0uyhnHkUTN6/6d8ulp4AwfLKrmA=
 github.com/mitchellh/mapstructure v0.0.0-20160808181253-ca63d7c062ee/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.1.2/go.mod h1:FVVH3fgwuzCH5S8UJGiWEs2h04kUh9fWfEaFds41c1Y=
 github.com/mitchellh/mapstructure v1.4.3/go.mod h1:bFUtVrKA4DC2yAKiSyO/QUcy7e+RRV2QTWOzhPopBRo=


### PR DESCRIPTION
## What does this PR do?

This commit adds a filewatcher package, it is a slitl modified version of `libbeat/cfgfile/glob_watcher` that instead of watching glob patterns, it watches for specific files.

It also sorts the packages on `README.md` alphabetically.


## Why is it important?

Different projects require watching for files, so it makes sense to have it on this shared repository.

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

~~## Author's Checklist~~

## Related issues
- https://github.com/elastic/beats/issues/34408

