### PR TITLE
fix: update macos_service environment flag value

### DIFF
--- a/logp/environment.go
+++ b/logp/environment.go
@@ -47,7 +47,7 @@ const (
 	defaultEnvironmentString        = "default"
 	systemdEnvironmentString        = "systemd"
 	containerEnvironmentString      = "container"
-	macOSServiceEnvironmentString   = "macOS_service"
+	macOSServiceEnvironmentString   = "macos_service"
 	windowsServiceEnvironmentString = "windows_service"
 	invalidEnvironmentString        = "<invalid>"
 )


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Update macos_service value for the flag `--environment`.
Passing `--environment macos_service` will always fail because the equality check is comparing against `macOS_service`. Using the new name does not help because the value is lowercased before the comparison.

## Why is it important?

This is breaking an APM Server flag.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Related to https://github.com/elastic/apm-server/pull/10250

