### PR TITLE
Update the linter to the latest version

### DIFF
--- a/dev-tools/mage/linter.go
+++ b/dev-tools/mage/linter.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	linterVersion    = "v1.50.1"
+	linterVersion    = "v1.51.2"
 	linterInstallURL = "https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh"
 )
 


### PR DESCRIPTION
So, we can support Go up to 1.20.
