### PR TITLE
Add target for go benchmarks and benchstat

### DIFF
--- a/dev-tools/mage/benchmark.go
+++ b/dev-tools/mage/benchmark.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package mage
 
 import (

--- a/dev-tools/mage/benchmark.go
+++ b/dev-tools/mage/benchmark.go
@@ -1,0 +1,154 @@
+package mage
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/elastic/elastic-agent-libs/dev-tools/mage/gotool"
+	"github.com/magefile/mage/mg"
+)
+
+const (
+	goBenchstat = "golang.org/x/perf/cmd/benchstat@v0.0.0-20230227161431-f7320a6d63e8"
+)
+
+var (
+	benchmarkCount = 8
+)
+
+// Benchmark namespace for mage to group all the related targets under this namespace
+type Benchmark mg.Namespace
+
+// Deps installs required plugins for reading benchmarks results
+func (Benchmark) Deps() error {
+	err := gotool.Install(gotool.Install.Package(goBenchstat))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// Run execute the go benchmark tests for this repository, define OUTPUT to write results into a file
+func (Benchmark) Run(ctx context.Context) error {
+	mg.Deps(Benchmark.Deps)
+	fmt.Println(">> go Test:", "Benchmark")
+	outputFile := os.Getenv("OUTPUT")
+	benchmarkCountOverride := os.Getenv("BENCH_COUNT")
+	if benchmarkCountOverride != "" {
+		var overrideErr error
+		benchmarkCount, overrideErr = strconv.Atoi(benchmarkCountOverride)
+		if overrideErr != nil {
+			return fmt.Errorf("failed to parse BENCH_COUNT, verify that you set the right value: , %w", overrideErr)
+		}
+	}
+	projectPackages, er := gotool.ListProjectPackages()
+	if er != nil {
+		return fmt.Errorf("failed to list package dependencies: %w", er)
+	}
+	cmdArg := fmt.Sprintf("test -count=%d -bench=Bench -run=Bench", benchmarkCount)
+	cmdArgs := strings.Split(cmdArg, " ")
+	for _, pkg := range projectPackages {
+		cmdArgs = append(cmdArgs, filepath.Join(pkg, "/..."))
+	}
+	_, err := runCommand(ctx, nil, "go", outputFile, cmdArgs...)
+
+	var goTestErr *exec.ExitError
+	switch {
+	case goTestErr == nil:
+		return nil
+	case errors.As(err, &goTestErr):
+		return fmt.Errorf("failed to execute go test -bench command: %w", err)
+	default:
+		return fmt.Errorf("failed to execute go test -bench command %w", err)
+	}
+}
+
+// Diff compare 2 benchmark outputs, Required BASE variable for parsing results, define NEXT to compare base with next and optional OUTPUT to write to file
+func (Benchmark) Diff(ctx context.Context) error {
+	mg.Deps(Benchmark.Deps)
+	fmt.Println(">> running: benchstat")
+	outputFile := os.Getenv("OUTPUT")
+	baseFile := os.Getenv("BASE")
+	nextFile := os.Getenv("NEXT")
+	var args []string
+	if baseFile == "" {
+		log.Printf("Missing required parameter BASE parameter to parse the results. Please set this to a filepath of the benchmark results")
+		return fmt.Errorf("missing required parameter BASE parameter to parse the results. Please set this to a filepath of the benchmark results")
+	} else {
+		args = append(args, baseFile)
+	}
+	if nextFile == "" {
+		log.Printf("Missing NEXT parameter, we are not going to compare results")
+	} else {
+		args = append(args, nextFile)
+	}
+
+	_, err := runCommand(ctx, nil, "benchstat", outputFile, args...)
+
+	var goTestErr *exec.ExitError
+	switch {
+	case goTestErr == nil:
+		return nil
+	case errors.As(err, &goTestErr):
+		return fmt.Errorf("failed to execute benchstat command: %w", err)
+	default:
+		return fmt.Errorf("failed to execute benchstat command!! %w", err)
+	}
+
+}
+
+// runCommand is executing a command that is represented by cmd.
+// when defining an outputFile it will write the stdErr, stdOut of that command to the output file
+// otherwise it will capture it to stdErr, stdOut of the console used.
+func runCommand(ctx context.Context, env map[string]string, cmd string, outputFile string, args ...string) (*exec.Cmd, error) {
+	c := exec.CommandContext(ctx, cmd, args...)
+	c.Env = os.Environ()
+	for k, v := range env {
+		c.Env = append(c.Env, k+"="+v)
+	}
+
+	if outputFile != "" {
+		fileOutput, err := os.Create(createDir(outputFile))
+		if err != nil {
+			return nil, fmt.Errorf("failed to create %s output file: %w", cmd, err)
+		}
+		defer func(fileOutput *os.File) {
+			err := fileOutput.Close()
+			if err != nil {
+				log.Fatalf("Failed to close file %s", err)
+			}
+		}(fileOutput)
+		c.Stdout = io.MultiWriter(os.Stdout, fileOutput)
+		c.Stderr = io.MultiWriter(os.Stderr, fileOutput)
+
+	} else {
+		c.Stdout = os.Stdout
+		c.Stderr = os.Stderr
+	}
+	c.Stdin = os.Stdin
+
+	log.Println("exec:", cmd, strings.Join(args, " "))
+	fmt.Println("exec:", cmd, strings.Join(args, " "))
+
+	exitCode := c.Run()
+	return c, exitCode
+}
+
+// createDir creates the parent directory for the given file.
+func createDir(file string) string {
+	// Create the output directory.
+	if dir := filepath.Dir(file); dir != "." {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			log.Fatalf("Failed to create parent dir for %s", file)
+		}
+	}
+	return file
+}

--- a/dev-tools/mage/benchmark.go
+++ b/dev-tools/mage/benchmark.go
@@ -56,7 +56,7 @@ func (Benchmark) Deps() error {
 // Run execute the go benchmark tests for this repository, define OUTPUT to write results into a file
 func (Benchmark) Run(ctx context.Context) error {
 	mg.Deps(Benchmark.Deps)
-	fmt.Println(">> go Test:", "Benchmark")
+	log.Println(">> go Test: Benchmark")
 	outputFile := os.Getenv("OUTPUT")
 	benchmarkCountOverride := os.Getenv("BENCH_COUNT")
 	if benchmarkCountOverride != "" {
@@ -91,7 +91,7 @@ func (Benchmark) Run(ctx context.Context) error {
 // Diff compare 2 benchmark outputs, Required BASE variable for parsing results, define NEXT to compare base with next and optional OUTPUT to write to file
 func (Benchmark) Diff(ctx context.Context) error {
 	mg.Deps(Benchmark.Deps)
-	fmt.Println(">> running: benchstat")
+	log.Println(">> running: benchstat")
 	outputFile := os.Getenv("OUTPUT")
 	baseFile := os.Getenv("BASE")
 	nextFile := os.Getenv("NEXT")
@@ -153,7 +153,6 @@ func runCommand(ctx context.Context, env map[string]string, cmd string, outputFi
 	c.Stdin = os.Stdin
 
 	log.Println("exec:", cmd, strings.Join(args, " "))
-	fmt.Println("exec:", cmd, strings.Join(args, " "))
 
 	exitCode := c.Run()
 	return c, exitCode


### PR DESCRIPTION
## What does this PR do?

This PR adds 2 new mage targets for running the go native benchmark tests and running the benchstat for parsing the results.

With the following targets, you can do the following

- Run benchmarks and print or save the output
```bash
$ mage benchmark:run
```

This will execute the go benchmark.
You can control the number of iterations that the benchmark will execute by defining an env var `BENCH_COUNT`
You can write the output into a file by defining the `OUTPUT` variables.

Example:
```bash
$ OUTPUT=base.txt BENCH_COUNT=1 mage benchmark:run
```

When it is finished there is going to be a file `base.txt` with the output of the executed benchmarks.

- Examining the benchmark output

```bash
$ BASE=base.txt mage benchmark:diff
```

This will parse and print the output of the benchmark.

To take the most out of the diff is when comparing benchmark results.

Assuming that you have executed the `benchmark:run` before you start performing your changes and have the output stored in the `base.txt` then after you have completed your changes you can re-run the same benchmark command, but this time writes it to `next.txt`. Then you can compare the outcome by the following command.

```bash
$ BASE=base.txt NEXT=next.txt mage benchmark:diff
```

Defining an OUTPUT variable in the above will save the comparison in the defined output file.

## Why is it important?

Those new targets are going to be used as part of future work and be integrated into the CI workflow of this repository.


