### PR TITLE
Fix ReportBool in visitor, add comments

### DIFF
--- a/monitoring/metrics_test.go
+++ b/monitoring/metrics_test.go
@@ -38,6 +38,30 @@ func TestSafeVars(t *testing.T) {
 	require.Equal(t, uint64(5), testSecondUint.Get())
 }
 
+func TestVarsTypes(t *testing.T) {
+	testReg := Default.NewRegistry("test_type_reg")
+
+	expected := map[string]interface{}{
+		"string_key": "string_val",
+		"bool_key":   false,
+		"int_key":    int64(42),
+		"float_key":  42.1,
+		"slice_key":  []string{"test", "string"},
+	}
+
+	NewFunc(testReg, "test", func(m Mode, v Visitor) {
+		ReportString(v, "string_key", "string_val")
+		ReportBool(v, "bool_key", false)
+		ReportInt(v, "int_key", 42)
+		ReportFloat(v, "float_key", 42.1)
+		ReportStringSlice(v, "slice_key", []string{"test", "string"})
+	})
+
+	gotData := CollectStructSnapshot(testReg, Full, false)
+
+	require.Equal(t, expected, gotData)
+}
+
 func TestNilReg(t *testing.T) {
 	uintValName := "testUint"
 	// This can also just panic if there's a bug

--- a/monitoring/visitor.go
+++ b/monitoring/visitor.go
@@ -23,6 +23,7 @@ type Visitor interface {
 	RegistryVisitor
 }
 
+// ValueVisitor is an interface for the monitoring visitor type
 type ValueVisitor interface {
 	OnString(s string)
 	OnBool(b bool)
@@ -31,12 +32,14 @@ type ValueVisitor interface {
 	OnStringSlice(f []string)
 }
 
+// RegistryVisitor is the interface type for interacting with a monitoring registry
 type RegistryVisitor interface {
 	OnRegistryStart()
 	OnRegistryFinished()
 	OnKey(s string)
 }
 
+// ReportNamespace reports a value for a given namespace
 func ReportNamespace(V Visitor, name string, f func()) {
 	V.OnKey(name)
 	V.OnRegistryStart()
@@ -44,31 +47,37 @@ func ReportNamespace(V Visitor, name string, f func()) {
 	V.OnRegistryFinished()
 }
 
+// ReportVar reports an interface var typew for the visitor
 func ReportVar(V Visitor, name string, m Mode, v Var) {
 	V.OnKey(name)
 	v.Visit(m, V)
 }
 
+// ReportString reports a string value for the visitor
 func ReportString(V Visitor, name string, value string) {
 	V.OnKey(name)
 	V.OnString(value)
 }
 
+// ReportBool reports a bool for the visitor
 func ReportBool(V Visitor, name string, value bool) {
 	V.OnKey(name)
-	V.OnString(name)
+	V.OnBool(value)
 }
 
+// ReportInt reports an int type for the visitor
 func ReportInt(V Visitor, name string, value int64) {
 	V.OnKey(name)
 	V.OnInt(value)
 }
 
+// ReportFloat reports a float type for the visitor
 func ReportFloat(V Visitor, name string, value float64) {
 	V.OnKey(name)
 	V.OnFloat(value)
 }
 
+// ReportStringSlice reports a string array for the visitor
 func ReportStringSlice(V Visitor, name string, value []string) {
 	V.OnKey(name)
 	V.OnStringSlice(value)


### PR DESCRIPTION
## What does this PR do?

This is a little one-liner fix, the `ReportBool` method would report a string, which would result in a bool metric value becoming `"bool_value":"bool_value"` once reported as JSON.

## Why is it important?

This is a bug.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
