### PR TITLE
Rename passphrase attribute

### DIFF
--- a/transport/tlscommon/tls.go
+++ b/transport/tlscommon/tls.go
@@ -48,8 +48,8 @@ func LoadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
 
 	log := logp.NewLogger(logSelector)
 	passphrase := config.Passphrase
-	if passphrase == "" && config.PassphraseFile != "" {
-		p, err := os.ReadFile(config.PassphraseFile)
+	if passphrase == "" && config.PassphrasePath != "" {
+		p, err := os.ReadFile(config.PassphrasePath)
 		if err != nil {
 			return nil, fmt.Errorf("unable to read passphrase_file: %w", err)
 		}

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -102,7 +102,7 @@ func TestLoadWithEmptyValues(t *testing.T) {
     certificate:
     key:
     key_passphrase:
-    key_passphrase_file:
+    key_passphrase_path:
     certificate_authorities:
     cipher_suites:
     curve_types:
@@ -677,7 +677,7 @@ func TestKeyPassphrase(t *testing.T) {
     enabled: true
     certificate: testdata/ca.crt
     key: testdata/ca.encrypted.key
-    key_passphrase_file: %s
+    key_passphrase_path: %s
     `, fileName)))
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(cfg.Certificates), "expected 1 certificate to be loaded")
@@ -689,7 +689,7 @@ func TestKeyPassphrase(t *testing.T) {
     enabled: true
     certificate: testdata/ca.crt
     key: testdata/ca.encrypted.key
-    key_passphrase_file: %s
+    key_passphrase_path: %s
     `, fileName)))
 		assert.ErrorContains(t, err, "no PEM blocks") // ReadPEMFile will generate an internal "no passphrase available" error that is logged and the no PEM blocks error is returned instead
 	})

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -260,7 +260,7 @@ type CertificateConfig struct {
 	Certificate    string `config:"certificate" yaml:"certificate,omitempty"`
 	Key            string `config:"key" yaml:"key,omitempty"`
 	Passphrase     string `config:"key_passphrase" yaml:"key_passphrase,omitempty"`
-	PassphraseFile string `config:"key_passphrase_file" yaml:"key_passphrase_file,omitempty"`
+	PassphrasePath string `config:"key_passphrase_path" yaml:"key_passphrase_path,omitempty"`
 }
 
 // Validate validates the CertificateConfig


### PR DESCRIPTION
Rename the `key_passphrase_file` attribute to `key_passphrase_path` to be consistent with suggestions and naming conventions in elastic-agent