### PR TITLE
Cleanup: Remove `// +build` lines

### DIFF
--- a/api/make_listener_posix.go
+++ b/api/make_listener_posix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package api
 

--- a/api/make_listener_windows.go
+++ b/api/make_listener_windows.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build windows
-// +build windows
 
 package api
 

--- a/api/npipe/listener_windows.go
+++ b/api/npipe/listener_windows.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build windows
-// +build windows
 
 package npipe
 

--- a/api/npipe/listener_windows_test.go
+++ b/api/npipe/listener_windows_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build windows
-// +build windows
 
 package npipe
 

--- a/api/npipe/listerner_posix.go
+++ b/api/npipe/listerner_posix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package npipe
 

--- a/api/server_windows_test.go
+++ b/api/server_windows_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build windows
-// +build windows
 
 package api
 

--- a/atomic/atomic32.go
+++ b/atomic/atomic32.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build 386 || arm || mips || mipsle
-// +build 386 arm mips mipsle
 
 package atomic
 

--- a/atomic/atomic64.go
+++ b/atomic/atomic64.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build amd64 || arm64 || loong64 || ppc64 || ppc64le || mips64 || mips64le || s390x
-// +build amd64 arm64 loong64 ppc64 ppc64le mips64 mips64le s390x
 
 package atomic
 

--- a/file/fileinfo_test.go
+++ b/file/fileinfo_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows && !openbsd
-// +build !windows,!openbsd
 
 // Test for openbsd are excluded here as info.GID() returns 0 instead of the actual value
 // As the code does not seem to be used in any of the beats, this should be ok

--- a/file/fileinfo_unix.go
+++ b/file/fileinfo_unix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !aix && !windows
-// +build !aix,!windows
 
 package file
 

--- a/file/helper_test.go
+++ b/file/helper_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package file
 

--- a/file/stderr_other.go
+++ b/file/stderr_other.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package file
 

--- a/kibana/url_test.go
+++ b/kibana/url_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package kibana
 

--- a/logp/eventlog_unsupported.go
+++ b/logp/eventlog_unsupported.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package logp
 

--- a/logp/global.go
+++ b/logp/global.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !nologpglobal
-// +build !nologpglobal
 
 package logp
 

--- a/logp/global_test.go
+++ b/logp/global_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !nologpglobal
-// +build !nologpglobal
 
 package logp
 

--- a/logp/syslog_unix.go
+++ b/logp/syslog_unix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows && !nacl && !plan9
-// +build !windows,!nacl,!plan9
 
 package logp
 

--- a/logp/syslog_unsupported.go
+++ b/logp/syslog_unsupported.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build windows || nacl || plan9
-// +build windows nacl plan9
 
 package logp
 

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package mapstr
 

--- a/monitoring/opts_test.go
+++ b/monitoring/opts_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package monitoring
 

--- a/monitoring/registry_test.go
+++ b/monitoring/registry_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package monitoring
 

--- a/monitoring/visitor_expvar_test.go
+++ b/monitoring/visitor_expvar_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package monitoring
 

--- a/service/service_unix.go
+++ b/service/service_unix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package service
 

--- a/transform/typeconv/datetime_test.go
+++ b/transform/typeconv/datetime_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package typeconv
 

--- a/transport/dialer/dialer_posix.go
+++ b/transport/dialer/dialer_posix.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !windows
-// +build !windows
 
 package dialer
 

--- a/transport/dialer/dialer_windows.go
+++ b/transport/dialer/dialer_windows.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build windows
-// +build windows
 
 package dialer
 

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !integration
-// +build !integration
 
 package tlscommon
 

--- a/transport/tlscommon/versions_default.go
+++ b/transport/tlscommon/versions_default.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build go1.13
-// +build go1.13
 
 package tlscommon
 

--- a/transport/tlscommon/versions_legacy.go
+++ b/transport/tlscommon/versions_legacy.go
@@ -16,7 +16,6 @@
 // under the License.
 
 //go:build !go1.13
-// +build !go1.13
 
 package tlscommon
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

This PR runs `go fix -fix buildtag ./...` on the `elastic-agent-libs` codebase to remove the deprecated `// +build` build tags from `.go` source files.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

Starting with Go 1.17, `//go:build` tags are preferred over the more bespoke `// +build` tags, for consistency with other `//go:` directives.  Starting with Go 1.18, `go fix` is able to remove the deprecated `// +build` tags and only leave the corresponding `//go:build` tags in their place.

More here: https://go.dev/doc/go1.18#go-build-lines

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
