### PR TITLE
feat: bump default TLS version to TLS v1.2

### DIFF
--- a/transport/tlscommon/versions_default.go
+++ b/transport/tlscommon/versions_default.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	// TLSVersionMin is the min TLS version supported.
-	TLSVersionMin = TLSVersion12
+	TLSVersionMin = TLSVersion11
 
 	// TLSVersionMax is the max TLS version supported.
 	TLSVersionMax = TLSVersion13


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Bump the default TLS version to TLS v1.2 from TLS v1.1.

Support for TLS v1.1 is not removed for the sake of compatibility.

## Why is it important?

Motivated from the work in APM Server toward bumping the default TLS version to 1.2: https://github.com/elastic/apm-server/issues/10491

TLS v1.1. was formally deprecated in 2021 and is considered obsolete: https://datatracker.ietf.org/doc/html/rfc8996

Several standard and the NIST guidelines for TLS implementation recommends not using TLS 1.1 or lower.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
~- [ ] I have commented my code, particularly in hard-to-understand areas~
- [x] I have added tests that prove my fix is effective or that my feature works
~- [ ] I have added an entry in `CHANGELOG.md`~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

Related to https://github.com/elastic/apm-server/issues/10491

