### PR TITLE
Update dev-tools to support Go Workspace

### DIFF
--- a/dev-tools/mage/gotool/go.go
+++ b/dev-tools/mage/gotool/go.go
@@ -58,7 +58,9 @@ var Test goTest = runGoTest
 
 // GetModuleName returns the name of the module.
 func GetModuleName() (string, error) {
-	lines, err := getLines(callGo(nil, "list", "-m"))
+	// `go list -buildvcs=false -f '{{.Module}}'` produces the same output as `go list -m`
+	// and it works with go workspace
+	lines, err := getLines(callGo(nil, "list", "-buildvcs=false", "-f", "{{.Module}}"))
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
## What does this PR do?

This commit updates the dev-tool code to support Go Workspace.

## Why is it important?

[Go Workspaces](https://go.dev/doc/go1.18) facilitates working on multiple modules at the same time, Elastic-Agent and Beats share a number of modules and sometimes it's necessary to change more than one at once.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas~~
~~- [ ] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.md`~~

## How to test this PR locally

1. Clone elastic-agent, beats and elastic-agent-libs on the same folder
2. Create a multi-module workspace: `go work init`
3. Add all 3 modules to the workspace:
   ```
   go work use elastic-agent beats elastic-agent-libs
   ```
4. Build the Elastic-Agent (set `PLATFORMS` according to your platform)
    ```
    DEV=true SNAPSHOT=true EXTERNAL=false PLATFORMS="linux/amd64" PACKAGES="tar.gz" mage -v package
    ```
5. The build should succeed

~~## Related issues~~