### PR TITLE
Implement BlockSelectors for level debug

### DIFF
--- a/logp/config.go
+++ b/logp/config.go
@@ -24,9 +24,10 @@ import (
 // Config contains the configuration options for the logger. To create a Config
 // from a common.Config use logp/config.Build.
 type Config struct {
-	Beat      string   `config:",ignore"`   // Name of the Beat (for default file name).
-	Level     Level    `config:"level"`     // Logging level (error, warning, info, debug).
-	Selectors []string `config:"selectors"` // Selectors for debug level logging.
+	Beat           string   `config:",ignore"`         // Name of the Beat (for default file name).
+	Level          Level    `config:"level"`           // Logging level (error, warning, info, debug).
+	Selectors      []string `config:"selectors"`       // Selectors for debug level logging.
+	BlockSelectors []string `config:"block_selectors"` // Block list of selectors for debug logging.
 
 	toObserver  bool
 	toIODiscard bool

--- a/logp/options.go
+++ b/logp/options.go
@@ -35,6 +35,14 @@ func WithSelectors(selectors ...string) Option {
 	}
 }
 
+// WithBlockSelectors specifies what debug selectors are disabled. If no selectors
+// are specified, then nothing is blocked
+func WithBlockSelectors(blockList ...string) Option {
+	return func(cfg *Config) {
+		cfg.BlockSelectors = append(cfg.BlockSelectors, blockList...)
+	}
+}
+
 // ToObserverOutput specifies that the output should be collected in memory so
 // that they can be read by an observer by calling ObserverLogs().
 func ToObserverOutput() Option {


### PR DESCRIPTION
## What does this PR do?

This commit implements a block list of selectors for debug logging on `logp`.

## Why is it important?

It allows us to drop logs from some very verbose debug loggers while still getting all the other debug logs. There are some situations where we know the verbose loggers we do not need, however we don't have a exhaustive list of all the loggers we do want debug logs, this PR aims to solve this problem.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.md`~~

~~## Author's Checklist~~
~~## Related issues~~


