### PR TITLE
monitoring - Rename NewRegistry to MustNewRegistry

### DIFF
--- a/monitoring/metrics_test.go
+++ b/monitoring/metrics_test.go
@@ -25,7 +25,7 @@ import (
 
 func TestSafeVars(t *testing.T) {
 	uintValName := "testUint"
-	testReg := Default.NewRegistry("safe_registry")
+	testReg := Default.MustNewRegistry("safe_registry")
 	testUint := NewUint(testReg, uintValName)
 	testUint.Set(5)
 	// Add the first time
@@ -39,7 +39,7 @@ func TestSafeVars(t *testing.T) {
 }
 
 func TestVarsTypes(t *testing.T) {
-	testReg := Default.NewRegistry("test_type_reg")
+	testReg := Default.MustNewRegistry("test_type_reg")
 
 	expected := map[string]interface{}{
 		"string_key": "string_val",

--- a/monitoring/registry_test.go
+++ b/monitoring/registry_test.go
@@ -62,6 +62,17 @@ func TestRegistryEmpty(t *testing.T) {
 	}
 }
 
+func TestNewRegistry(t *testing.T) {
+	parentReg := NewRegistry()
+
+	subReg, err := parentReg.NewRegistry("foo")
+	require.NoError(t, err)
+	require.NotNil(t, subReg)
+
+	_, err = parentReg.NewRegistry("foo")
+	require.Error(t, err, "expected error because foo is already registered")
+}
+
 func TestRegistryGet(t *testing.T) {
 	defer func(t *testing.T) {
 		err := Clear()
@@ -74,8 +85,8 @@ func TestRegistryGet(t *testing.T) {
 
 	// register top-level and recursive metric
 	v1 := NewInt(Default, name1, Report)
-	sub1 := Default.NewRegistry(nameSub1)
-	sub2 := Default.NewRegistry(nameSub2)
+	sub1 := Default.MustNewRegistry(nameSub1)
+	sub2 := Default.MustNewRegistry(nameSub2)
 	v2 := NewString(nil, name2, Report)
 	v3 := NewFloat(sub2, name1, Report)
 
@@ -115,8 +126,8 @@ func TestRegistryRemove(t *testing.T) {
 
 	// register top-level and recursive metric
 	NewInt(Default, name1, Report)
-	sub1 := Default.NewRegistry(nameSub1)
-	sub2 := Default.NewRegistry(nameSub2)
+	sub1 := Default.MustNewRegistry(nameSub1)
+	sub2 := Default.MustNewRegistry(nameSub2)
 	NewInt(Default, name2, Report)
 	NewInt(sub2, name1, Report)
 

--- a/monitoring/snapshot_test.go
+++ b/monitoring/snapshot_test.go
@@ -60,7 +60,7 @@ func TestSnapshot(t *testing.T) {
 			"do not report empty nested exported",
 			map[string]interface{}{"test": int64(0)},
 			func(R *Registry) {
-				metrics := R.NewRegistry("exported", Report)
+				metrics := R.MustNewRegistry("exported", Report)
 				NewInt(metrics, "unexported", DoNotReport)
 				NewInt(R, "test", Report)
 			},
@@ -69,7 +69,7 @@ func TestSnapshot(t *testing.T) {
 			"export namespaced as nested-document from registry instance",
 			map[string]interface{}{"exported": map[string]interface{}{"test": int64(0)}},
 			func(R *Registry) {
-				metrics := R.NewRegistry("exported", Report)
+				metrics := R.MustNewRegistry("exported", Report)
 				NewInt(metrics, "test", Report)
 				NewInt(R, "unexported.test")
 			},
@@ -78,7 +78,7 @@ func TestSnapshot(t *testing.T) {
 			"export unmarked namespaced as nested-document from registry instance",
 			map[string]interface{}{"exported": map[string]interface{}{"test": int64(0)}},
 			func(R *Registry) {
-				metrics := R.NewRegistry("exported", Report)
+				metrics := R.MustNewRegistry("exported", Report)
 				NewInt(metrics, "test")
 				NewInt(R, "unexported.test")
 			},


### PR DESCRIPTION
## What does this PR do?

`registry.NewRegistry` could panic and it was not documented. This is a breaking change to force callers of this method to evaluate if they are willing to accept the current behavior which panics.

This creates two choices for existing users. The can use either:

    MustNewRegistry(...) *Registry      // Keep the same behavior.
    NewRegistry(...) (*Registry, error) // Handle the error.

A similar change was made to the `registry.Add` method (except existing code will continue to compile since it previously had no return value).

## Why is it important?

In Beats there have been several bugs that resulted in a panic. I would rather have an option to receive an error and handled it as I see fit rather than have a panic forced on my application.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] ~I have added an entry in `CHANGELOG.md`~ _What changelog file? This does not exist._

