### PR TITLE
Refactor fleet policy APIs, fix JSON issues

### DIFF
--- a/kibana/client.go
+++ b/kibana/client.go
@@ -82,7 +82,7 @@ func extractError(result []byte) error {
 		}
 	}
 	if err := json.Unmarshal(result, &kibanaResult); err != nil {
-		return fmt.Errorf("error extacting JSON for error response: %w", err)
+		return fmt.Errorf("error extracting JSON for error response: %w", err)
 	}
 	var errs multierror.Errors
 	if kibanaResult.Message != "" {

--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -313,7 +313,7 @@ type GetAgentRequest struct {
 	ID string
 }
 
-// GetAgentResponse is the JSON repsonse for GetAgent
+// GetAgentResponse is the JSON response for GetAgent
 type GetAgentResponse AgentExisting
 
 // GetAgent fetches data for an agent

--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -22,11 +22,13 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 )
 
 const (
 	fleetAgentPoliciesAPI     = "/api/fleet/agent_policies"
 	fleetAgentPolicyAPI       = "/api/fleet/agent_policies/%s"
+	fleetAgentsDeleteAPI      = "/api/fleet/agent_policies/delete"
 	fleetEnrollmentAPIKeysAPI = "/api/fleet/enrollment_api_keys" //nolint:gosec // no API key being leaked here
 	fleetAgentsAPI            = "/api/fleet/agents"
 	fleetAgentAPI             = "/api/fleet/agents/%s"
@@ -40,34 +42,69 @@ const (
 // Create Policy
 //
 
+// MonitoringEnabledOption is a Kibana JSON value that specifies the various monitoring option types
 type MonitoringEnabledOption string
 
 const (
-	MonitoringEnabledLogs    MonitoringEnabledOption = "logs"
+	// MonitoringEnabledLogs specifies log monitoring
+	MonitoringEnabledLogs MonitoringEnabledOption = "logs"
+	// MonitoringEnabledMetrics specifies metrics monitoring
 	MonitoringEnabledMetrics MonitoringEnabledOption = "metrics"
 )
 
-type PolicyCommon struct {
-	Name              string                    `json:"name"`
-	Namespace         string                    `json:"namespace"`
-	Description       string                    `json:"description"`
-	MonitoringEnabled []MonitoringEnabledOption `json:"monitoring_enabled"`
-	FleetServerHostID string                    `json:"fleet_server_host_id"`
-	AgentFeatures     []map[string]interface{}  `json:"agent_features"`
-	Status            string                    `json:"status"`
-	IsManaged         bool                      `json:"is_managed"`
+// AgentPolicy is the JSON that represents a agent policy. These fields are used by both the create policy request, and the GET request for an agent policy.
+// see: https://github.com/elastic/kibana/blob/v8.8.0/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_create_request.yaml
+// and https://github.com/elastic/kibana/blob/v8.8.0/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy.yaml
+type AgentPolicy struct {
+	ID string `json:"id,omitempty"`
+	// Name of the policy. Required to create a policy.
+	Name string `json:"name"`
+	// Namespace of the policy. Required to create a policy.
+	Namespace          string                    `json:"namespace"`
+	Description        string                    `json:"description,omitempty"`
+	MonitoringEnabled  []MonitoringEnabledOption `json:"monitoring_enabled,omitempty"`
+	DataOutputID       string                    `json:"data_output_id,omitempty"`
+	MonitoringOutputID string                    `json:"monitoring_output_id,omitempty"`
+	FleetServerHostID  string                    `json:"fleet_server_host_id,omitempty"`
+	DownloadSourceID   string                    `json:"download_source_id,omitempty"`
+	UnenrollTimeout    int                       `json:"unenroll_timeout,omitempty"`
+	InactivityTImeout  int                       `json:"inactivity_timeout,omitempty"`
+	AgentFeatures      []map[string]interface{}  `json:"agent_features,omitempty"`
 }
 
-type PolicyExisting struct {
-	ID           string `json:"id"`
-	PolicyCommon `json:",inline"`
+// PolicyResponse is the response JSON from a policy request
+// This is returned on a GET request for a policy, and on a policy create request
+// See https://github.com/elastic/kibana/blob/v8.8.0/x-pack/plugins/fleet/common/openapi/paths/agent_policies.yaml
+type PolicyResponse struct {
+	AgentPolicy     `json:",inline"`
+	UpdatedOn       time.Time                `json:"updated_on"`
+	UpdatedBy       string                   `json:"updated_by"`
+	Revision        int                      `json:"revision"`
+	IsProtected     bool                     `json:"is_protected"`
+	PackagePolicies []map[string]interface{} `json:"package_policies"`
 }
 
-type CreatePolicyRequest PolicyCommon
+// AgentPolicyUpdateRequest is the JSON object for requesting an updated policy
+// Unlike the Agent create and response structures, the update request does not contain an ID field.
+// See https://github.com/elastic/kibana/blob/v8.8.0/x-pack/plugins/fleet/common/openapi/components/schemas/agent_policy_update_request.yaml
+type AgentPolicyUpdateRequest struct {
+	// Name of the policy. Required in an update request.
+	Name string `json:"name"`
+	// Namespace of the policy. Required in an update request.
+	Namespace          string                    `json:"namespace"`
+	Description        string                    `json:"description,omitempty"`
+	MonitoringEnabled  []MonitoringEnabledOption `json:"monitoring_enabled,omitempty"`
+	DataOutputID       string                    `json:"data_output_id,omitempty"`
+	MonitoringOutputID string                    `json:"monitoring_output_id,omitempty"`
+	FleetServerHostID  string                    `json:"fleet_server_host_id,omitempty"`
+	DownloadSourceID   string                    `json:"download_source_id,omitempty"`
+	UnenrollTimeout    int                       `json:"unenroll_timeout,omitempty"`
+	InactivityTImeout  int                       `json:"inactivity_timeout,omitempty"`
+	AgentFeatures      []map[string]interface{}  `json:"agent_features,omitempty"`
+}
 
-type CreatePolicyResponse PolicyExisting
-
-func (client *Client) CreatePolicy(request CreatePolicyRequest) (*CreatePolicyResponse, error) {
+// CreatePolicy creates a new agent policy with the given config
+func (client *Client) CreatePolicy(request AgentPolicy) (*PolicyResponse, error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal create policy request into JSON: %w", err)
@@ -82,7 +119,7 @@ func (client *Client) CreatePolicy(request CreatePolicyRequest) (*CreatePolicyRe
 	}
 
 	var resp struct {
-		Item CreatePolicyResponse `json:"item"`
+		Item PolicyResponse `json:"item"`
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
@@ -92,18 +129,9 @@ func (client *Client) CreatePolicy(request CreatePolicyRequest) (*CreatePolicyRe
 	return &resp.Item, nil
 }
 
-//
-// Get Policy
-//
-
-type GetPolicyRequest struct {
-	ID string
-}
-
-type GetPolicyResponse PolicyExisting
-
-func (client *Client) GetPolicy(request GetPolicyRequest) (*GetPolicyResponse, error) {
-	apiURL := fmt.Sprintf(fleetAgentPolicyAPI, request.ID)
+// GetPolicy returns the requested ID
+func (client *Client) GetPolicy(id string) (*PolicyResponse, error) {
+	apiURL := fmt.Sprintf(fleetAgentPolicyAPI, id)
 	statusCode, respBody, err := client.Request(http.MethodGet, apiURL, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error calling get policy API: %w", err)
@@ -113,7 +141,7 @@ func (client *Client) GetPolicy(request GetPolicyRequest) (*GetPolicyResponse, e
 	}
 
 	var resp struct {
-		Item GetPolicyResponse `json:"item"`
+		Item PolicyResponse `json:"item"`
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
@@ -123,21 +151,14 @@ func (client *Client) GetPolicy(request GetPolicyRequest) (*GetPolicyResponse, e
 	return &resp.Item, nil
 }
 
-//
-// Update Policy
-//
-
-type UpdatePolicyRequest PolicyExisting
-
-type UpdatePolicyResponse PolicyExisting
-
-func (client *Client) UpdatePolicy(request UpdatePolicyRequest) (*UpdatePolicyResponse, error) {
+// UpdatePolicy updates an existing agent policy.
+func (client *Client) UpdatePolicy(ID string, request AgentPolicyUpdateRequest) (*PolicyResponse, error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
 		return nil, fmt.Errorf("unable to marshal update policy request into JSON: %w", err)
 	}
 
-	apiURL := fmt.Sprintf(fleetAgentPolicyAPI, request.ID)
+	apiURL := fmt.Sprintf(fleetAgentPolicyAPI, ID)
 	statusCode, respBody, err := client.Request(http.MethodPut, apiURL, nil, nil, bytes.NewReader(reqBody))
 	if err != nil {
 		return nil, fmt.Errorf("error calling update policy API: %w", err)
@@ -147,7 +168,7 @@ func (client *Client) UpdatePolicy(request UpdatePolicyRequest) (*UpdatePolicyRe
 	}
 
 	var resp struct {
-		Item UpdatePolicyResponse `json:"item"`
+		Item PolicyResponse `json:"item"`
 	}
 
 	if err := json.Unmarshal(respBody, &resp); err != nil {
@@ -157,15 +178,41 @@ func (client *Client) UpdatePolicy(request UpdatePolicyRequest) (*UpdatePolicyRe
 	return &resp.Item, nil
 }
 
+// DeletePolicy deletes the policy with the given ID
+func (client *Client) DeletePolicy(id string) error {
+	var delRequest = struct {
+		AgentPolicyID string `json:"agentPolicyId"`
+	}{
+		AgentPolicyID: id,
+	}
+
+	reqBody, err := json.Marshal(delRequest)
+	if err != nil {
+		return fmt.Errorf("unable to marshal update policy request into JSON: %w", err)
+	}
+
+	statusCode, respBody, err := client.Request(http.MethodPost, fleetAgentsDeleteAPI, nil, nil, bytes.NewReader(reqBody))
+	if err != nil {
+		return fmt.Errorf("error calling update policy API: %w", err)
+	}
+	if statusCode != 200 {
+		return fmt.Errorf("unable to update policy; API returned status code [%d] and body [%s]", statusCode, string(respBody))
+	}
+
+	return nil
+}
+
 //
 // Create Enrollment API Key
 //
 
+// CreateEnrollmentAPIKeyRequest is the JSON object for requesting an enrollment API key
 type CreateEnrollmentAPIKeyRequest struct {
 	Name     string `json:"name"`
 	PolicyID string `json:"policy_id"`
 }
 
+// CreateEnrollmentAPIKeyResponse is the JSON response the an enrollment key request
 type CreateEnrollmentAPIKeyResponse struct {
 	Active   bool   `json:"active"`
 	APIKey   string `json:"api_key"`
@@ -175,6 +222,7 @@ type CreateEnrollmentAPIKeyResponse struct {
 	PolicyID string `json:"policy_id"`
 }
 
+// CreateEnrollmentAPIKey creates an enrollment API key
 func (client *Client) CreateEnrollmentAPIKey(request CreateEnrollmentAPIKeyRequest) (*CreateEnrollmentAPIKeyResponse, error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
@@ -204,6 +252,7 @@ func (client *Client) CreateEnrollmentAPIKey(request CreateEnrollmentAPIKeyReque
 // List Agents
 //
 
+// AgentCommon represents common agent data used across APIs
 type AgentCommon struct {
 	Active bool   `json:"active"`
 	Status string `json:"status"`
@@ -220,20 +269,24 @@ type AgentCommon struct {
 	PolicyRevision int    `json:"policy_revision"`
 }
 
+// AgentExisting is the data structure for an existing agent
 type AgentExisting struct {
 	ID          string `json:"id"`
 	AgentCommon `json:",inline"`
 }
 
+// ListAgentsRequest is currently unused
 type ListAgentsRequest struct {
 	// For future use
 }
 
+// ListAgentsResponse is a list of agents returned by the API
 type ListAgentsResponse struct {
 	Items []AgentExisting `json:"items"`
 }
 
-func (client *Client) ListAgents(request ListAgentsRequest) (*ListAgentsResponse, error) {
+// ListAgents returns a list of agents known to Kibana
+func (client *Client) ListAgents(_ ListAgentsRequest) (*ListAgentsResponse, error) {
 	statusCode, respBody, err := client.Request(http.MethodGet, fleetAgentsAPI, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error calling list agents API: %w", err)
@@ -255,12 +308,15 @@ func (client *Client) ListAgents(request ListAgentsRequest) (*ListAgentsResponse
 // Get Agent
 //
 
+// GetAgentRequest contains the ID used for fetching agent data
 type GetAgentRequest struct {
 	ID string
 }
 
+// GetAgentResponse is the JSON repsonse for GetAgent
 type GetAgentResponse AgentExisting
 
+// GetAgent fetches data for an agent
 func (client *Client) GetAgent(request GetAgentRequest) (*GetAgentResponse, error) {
 	apiURL := fmt.Sprintf(fleetAgentAPI, request.ID)
 	statusCode, respBody, err := client.Request(http.MethodGet, apiURL, nil, nil, nil)
@@ -286,15 +342,18 @@ func (client *Client) GetAgent(request GetAgentRequest) (*GetAgentResponse, erro
 // Unenroll Agent
 //
 
+// UnEnrollAgentRequest is the JSON request for unenrolling an agent
 type UnEnrollAgentRequest struct {
 	ID     string `json:"id"`
 	Revoke bool   `json:"revoke"`
 }
 
+// UnEnrollAgentResponse is currently unused
 type UnEnrollAgentResponse struct {
 	// For future use
 }
 
+// UnEnrollAgent removes the agent from fleet
 func (client *Client) UnEnrollAgent(request UnEnrollAgentRequest) (*UnEnrollAgentResponse, error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
@@ -323,15 +382,18 @@ func (client *Client) UnEnrollAgent(request UnEnrollAgentRequest) (*UnEnrollAgen
 // Upgrade Agent
 //
 
+// UpgradeAgentRequest is the JSON request for an agent upgrade
 type UpgradeAgentRequest struct {
 	ID      string `json:"id"`
 	Version string `json:"version"`
 }
 
+// UpgradeAgentResponse is currently unused
 type UpgradeAgentResponse struct {
 	// For future use
 }
 
+// UpgradeAgent upgrades the requested agent
 func (client *Client) UpgradeAgent(request UpgradeAgentRequest) (*UpgradeAgentResponse, error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
@@ -360,6 +422,7 @@ func (client *Client) UpgradeAgent(request UpgradeAgentRequest) (*UpgradeAgentRe
 // List Fleet Server Hosts
 //
 
+// FleetServerHost handles JSON data for fleet server info
 type FleetServerHost struct {
 	ID              string   `json:"id"`
 	Name            string   `json:"name"`
@@ -368,15 +431,18 @@ type FleetServerHost struct {
 	IsPreconfigured bool     `json:"is_preconfigured"`
 }
 
+// ListFleetServerHostsRequest is currently unused
 type ListFleetServerHostsRequest struct {
 	// For future use
 }
 
+// ListFleetServerHostsResponse is the JSON response for ListFleetServerHosts
 type ListFleetServerHostsResponse struct {
 	Items []FleetServerHost `json:"items"`
 }
 
-func (client *Client) ListFleetServerHosts(request ListFleetServerHostsRequest) (*ListFleetServerHostsResponse, error) {
+// ListFleetServerHosts returns a list of fleet server hosts
+func (client *Client) ListFleetServerHosts(_ ListFleetServerHostsRequest) (*ListFleetServerHostsResponse, error) {
 	statusCode, respBody, err := client.Request(http.MethodGet, fleetFleetServerHostsAPI, nil, nil, nil)
 	if err != nil {
 		return nil, fmt.Errorf("error calling list fleet server hosts API: %w", err)
@@ -398,12 +464,15 @@ func (client *Client) ListFleetServerHosts(request ListFleetServerHostsRequest) 
 // Get Fleet Server Host
 //
 
+// GetFleetServerHostRequest is the ID for a request via GetFleetServerHost
 type GetFleetServerHostRequest struct {
 	ID string
 }
 
+// GetFleetServerHostResponse is the JSON respose from GetFleetServerHost
 type GetFleetServerHostResponse FleetServerHost
 
+// GetFleetServerHost returns data on a fleet server
 func (client *Client) GetFleetServerHost(request GetFleetServerHostRequest) (*GetFleetServerHostResponse, error) {
 	apiURL := fmt.Sprintf(fleetFleetServerHostAPI, request.ID)
 	statusCode, respBody, err := client.Request(http.MethodGet, apiURL, nil, nil, nil)

--- a/kibana/fleet_integration_test.go
+++ b/kibana/fleet_integration_test.go
@@ -1,0 +1,126 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package kibana
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func mustGetEnv(t *testing.T) ClientConfig {
+	kibUser, foundUser := os.LookupEnv("KIBANA_USERNAME")
+	kibPass, foundPass := os.LookupEnv("KIBANA_PASSWORD")
+	kibHost, foundHost := os.LookupEnv("KIBANA_HOST")
+
+	if !foundPass || !foundUser || !foundHost {
+		t.Skip("test requires a Kibana instance with KIBANA_USERNAME, KIBANA_PASSWORD and KIBANA_HOST set")
+	}
+
+	cfg := ClientConfig{
+		Host:     kibHost,
+		Username: kibUser,
+		Password: kibPass,
+	}
+
+	return cfg
+}
+
+/*
+These are a series of integration tests that run some of the fleet API clients against an actual elastic stack.
+Just set the env vars listed in mustGetEnv().
+*/
+
+func TestGetPolicyKibana(t *testing.T) {
+	cfg := mustGetEnv(t)
+	client, err := NewClientWithConfig(&cfg, "", "", "", "")
+	require.NoError(t, err)
+
+	testPolicy := AgentPolicy{
+		Name:        "TestGetPolicyKibana",
+		Namespace:   "defaultttest",
+		Description: "original policy",
+	}
+
+	respPolicy, err := client.CreatePolicy(testPolicy)
+	require.NoError(t, err)
+	t.Logf("Created policy for test with ID %s", respPolicy.ID)
+
+	respGet, err := client.GetPolicy(respPolicy.ID)
+	require.NoError(t, err)
+
+	require.Equal(t, respPolicy.Description, respGet.Description)
+
+	err = client.DeletePolicy(respPolicy.ID)
+	require.NoError(t, err)
+}
+
+func TestCreatePolicyKibana(t *testing.T) {
+	cfg := mustGetEnv(t)
+
+	client, err := NewClientWithConfig(&cfg, "", "", "", "")
+	require.NoError(t, err)
+
+	testPolicy := AgentPolicy{
+		Name:      "TestCreatePolicyKibana",
+		Namespace: "defaulttest",
+	}
+
+	respPolicy, err := client.CreatePolicy(testPolicy)
+	t.Logf("created policy with ID %s", respPolicy.ID)
+	require.NoError(t, err)
+	require.Equal(t, testPolicy.Name, respPolicy.Name)
+	require.Equal(t, testPolicy.Namespace, respPolicy.Namespace)
+	require.NotEmpty(t, respPolicy.ID)
+	// delete policy
+	err = client.DeletePolicy(respPolicy.ID)
+	require.NoError(t, err)
+}
+
+func TestUpdatePolicyKibana(t *testing.T) {
+	cfg := mustGetEnv(t)
+	client, err := NewClientWithConfig(&cfg, "", "", "", "")
+	require.NoError(t, err)
+
+	testPolicy := AgentPolicy{
+		Name:        "TestUpdatePolicyKibana",
+		Namespace:   "defaultttest",
+		Description: "original policy",
+	}
+	respPolicy, err := client.CreatePolicy(testPolicy)
+	require.NoError(t, err)
+	t.Logf("Created policy for test with ID %s", respPolicy.ID)
+	require.Empty(t, respPolicy.MonitoringEnabled)
+
+	updatePolicy := AgentPolicyUpdateRequest{
+		Name:              testPolicy.Name,
+		Namespace:         testPolicy.Namespace,
+		MonitoringEnabled: []MonitoringEnabledOption{MonitoringEnabledMetrics},
+	}
+
+	updateResp, err := client.UpdatePolicy(respPolicy.ID, updatePolicy)
+	require.NoError(t, err)
+	// make sure our update was applied
+	require.Equal(t, []MonitoringEnabledOption{MonitoringEnabledMetrics}, updateResp.MonitoringEnabled)
+	// make sure we didn't somehow change something else
+	require.Equal(t, respPolicy.InactivityTImeout, updateResp.InactivityTImeout)
+	require.Equal(t, respPolicy.Description, updateResp.Description)
+	err = client.DeletePolicy(respPolicy.ID)
+	require.NoError(t, err)
+}

--- a/kibana/fleet_test.go
+++ b/kibana/fleet_test.go
@@ -72,7 +72,7 @@ func TestFleetCreatePolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	req := CreatePolicyRequest{
+	req := AgentPolicy{
 		Name:        policyName,
 		Description: policyDescription,
 		MonitoringEnabled: []MonitoringEnabledOption{
@@ -88,8 +88,8 @@ func TestFleetCreatePolicy(t *testing.T) {
 	require.Equal(t, resp.Name, policyName)
 	require.Equal(t, resp.Description, policyDescription)
 	require.Equal(t, resp.Namespace, "default")
-	require.Equal(t, resp.Status, "active")
-	require.Equal(t, resp.IsManaged, false)
+	// require.Equal(t, resp.Status, "active")
+	// require.Equal(t, resp.IsManaged, false)
 	require.Equal(t, resp.MonitoringEnabled, []MonitoringEnabledOption{MonitoringEnabledLogs, MonitoringEnabledMetrics})
 }
 
@@ -106,10 +106,7 @@ func TestFleetGetPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	req := GetPolicyRequest{
-		ID: id,
-	}
-	resp, err := client.GetPolicy(req)
+	resp, err := client.GetPolicy(id)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -144,26 +141,24 @@ func TestFleetUpdatePolicy(t *testing.T) {
 			"enabled": true,
 		},
 	}
-	req := UpdatePolicyRequest{
-		id,
-		PolicyCommon{
-			Name: policyName,
-			MonitoringEnabled: []MonitoringEnabledOption{
-				MonitoringEnabledLogs,
-				MonitoringEnabledMetrics,
-			},
-			AgentFeatures: agentFeatures,
+	req := AgentPolicyUpdateRequest{
+
+		Name: policyName,
+		MonitoringEnabled: []MonitoringEnabledOption{
+			MonitoringEnabledLogs,
+			MonitoringEnabledMetrics,
 		},
+		AgentFeatures: agentFeatures,
 	}
-	resp, err := client.UpdatePolicy(req)
+	resp, err := client.UpdatePolicy(id, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
 	require.Equal(t, id, resp.ID)
 	require.Equal(t, policyName, resp.Name)
 	require.Equal(t, "default", resp.Namespace)
-	require.Equal(t, "active", resp.Status)
-	require.Equal(t, false, resp.IsManaged)
+	//require.Equal(t, "active", resp.Status)
+	//require.Equal(t, false, resp.IsManaged)
 	require.Equal(t, []MonitoringEnabledOption{MonitoringEnabledLogs, MonitoringEnabledMetrics}, resp.MonitoringEnabled)
 	require.Equal(t, agentFeatures, resp.AgentFeatures)
 }


### PR DESCRIPTION
Fixes https://github.com/elastic/elastic-agent-libs/issues/127

## What does this PR do?

This PR does a few things:

- Update the JSON objects being sent to the fleet API to fix a few bugs as documented in https://github.com/elastic/elastic-agent-libs/issues/127. Most of these bugs were due to small things like missing `omitempty` fields.
- Change the structs used by the go APIs to reflect the fields actually accepted/returned by Kibana, in order to make the API usage clearer.
- Reference the openAPI docs in Kibana where needed
- Add some integration tests. These require a Kibana instance, but I don't think we have any built-in e2e tests ready-to-use in this repo.
- Add a `DeletePolicy()` helper 
- Fix some of the error handling in client.go

## Why is it important?
This is blocking integration test development.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`
