### PR TITLE
[Fleet client] Do not send Agent IDs in request bodies

### DIFF
--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -344,7 +344,7 @@ func (client *Client) GetAgent(request GetAgentRequest) (*GetAgentResponse, erro
 
 // UnEnrollAgentRequest is the JSON request for unenrolling an agent
 type UnEnrollAgentRequest struct {
-	ID     string `json:"id"`
+	ID     string `json:"-"` // ID is not part of the request body send to the Fleet API
 	Revoke bool   `json:"revoke"`
 }
 
@@ -384,7 +384,7 @@ func (client *Client) UnEnrollAgent(request UnEnrollAgentRequest) (*UnEnrollAgen
 
 // UpgradeAgentRequest is the JSON request for an agent upgrade
 type UpgradeAgentRequest struct {
-	ID      string `json:"id"`
+	ID      string `json:"-"` // ID is not part of the request body send to the Fleet API
 	Version string `json:"version"`
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR fixes the Fleet client, specifically for the Upgrade Agent and Un-enroll Agent API calls, to not send the Agent IDs in the request bodies of these APIs.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

For these API calls to work as expected.  Needed by https://github.com/elastic/elastic-agent/pull/2809.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~I have added tests that prove my fix is effective or that my feature works~
- [ ] ~I have added an entry in `CHANGELOG.md`~
