### PR TITLE
Improve Kibana policy API wrappers: add IsProtected flag, add context

### DIFF
--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -181,12 +181,12 @@ func (client *Client) DeletePolicy(ctx context.Context, id string) error {
 
 	reqBody, err := json.Marshal(delRequest)
 	if err != nil {
-		return fmt.Errorf("unable to marshal update policy request into JSON: %w", err)
+		return fmt.Errorf("unable to marshal delete policy request into JSON: %w", err)
 	}
 
 	resp, err := client.Connection.SendWithContext(ctx, http.MethodPost, fleetAgentsDeleteAPI, nil, nil, bytes.NewReader(reqBody))
 	if err != nil {
-		return fmt.Errorf("error calling update policy API: %w", err)
+		return fmt.Errorf("error calling delete policy API: %w", err)
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
@@ -220,29 +220,23 @@ type CreateEnrollmentAPIKeyResponse struct {
 }
 
 // CreateEnrollmentAPIKey creates an enrollment API key
-func (client *Client) CreateEnrollmentAPIKey(request CreateEnrollmentAPIKeyRequest) (*CreateEnrollmentAPIKeyResponse, error) {
+func (client *Client) CreateEnrollmentAPIKey(ctx context.Context, request CreateEnrollmentAPIKeyRequest) (r CreateEnrollmentAPIKeyResponse, err error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal create enrollment API key request into JSON: %w", err)
+		return r, fmt.Errorf("unable to marshal create enrollment API key request into JSON: %w", err)
 	}
 
-	statusCode, respBody, err := client.Request(http.MethodPost, fleetEnrollmentAPIKeysAPI, nil, nil, bytes.NewReader(reqBody))
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodPost, fleetEnrollmentAPIKeysAPI, nil, nil, bytes.NewReader(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("error calling create enrollment API key API: %w", err)
+		return r, fmt.Errorf("error calling create enrollment API key API: %w", err)
 	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to create enrollment API key; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
+	defer resp.Body.Close()
 
-	var resp struct {
+	var enrollResp struct {
 		Item CreateEnrollmentAPIKeyResponse `json:"item"`
 	}
-
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse create enrollment API key API response: %w", err)
-	}
-
-	return &resp.Item, nil
+	err = readJSONResponse(resp, &enrollResp)
+	return enrollResp.Item, err
 }
 
 //
@@ -283,22 +277,15 @@ type ListAgentsResponse struct {
 }
 
 // ListAgents returns a list of agents known to Kibana
-func (client *Client) ListAgents(_ ListAgentsRequest) (*ListAgentsResponse, error) {
-	statusCode, respBody, err := client.Request(http.MethodGet, fleetAgentsAPI, nil, nil, nil)
+func (client *Client) ListAgents(ctx context.Context, _ ListAgentsRequest) (r ListAgentsResponse, err error) {
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodGet, fleetAgentsAPI, nil, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error calling list agents API: %w", err)
+		return r, fmt.Errorf("error calling list agents API: %w", err)
 	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to list agents; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
+	defer resp.Body.Close()
 
-	var resp ListAgentsResponse
-
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse list agents API response: %w", err)
-	}
-
-	return &resp, nil
+	err = readJSONResponse(resp, &r)
+	return r, err
 }
 
 //
@@ -314,25 +301,20 @@ type GetAgentRequest struct {
 type GetAgentResponse AgentExisting
 
 // GetAgent fetches data for an agent
-func (client *Client) GetAgent(request GetAgentRequest) (*GetAgentResponse, error) {
+func (client *Client) GetAgent(ctx context.Context, request GetAgentRequest) (r GetAgentResponse, err error) {
 	apiURL := fmt.Sprintf(fleetAgentAPI, request.ID)
-	statusCode, respBody, err := client.Request(http.MethodGet, apiURL, nil, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error calling get agent API: %w", err)
-	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to get agent; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
 
-	var resp struct {
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodGet, apiURL, nil, nil, nil)
+	if err != nil {
+		return r, fmt.Errorf("error calling get agent API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var agentResp struct {
 		Item GetAgentResponse `json:"item"`
 	}
-
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse get agent API response: %w", err)
-	}
-
-	return &resp.Item, nil
+	err = readJSONResponse(resp, &agentResp)
+	return agentResp.Item, err
 }
 
 //
@@ -351,28 +333,21 @@ type UnEnrollAgentResponse struct {
 }
 
 // UnEnrollAgent removes the agent from fleet
-func (client *Client) UnEnrollAgent(request UnEnrollAgentRequest) (*UnEnrollAgentResponse, error) {
+func (client *Client) UnEnrollAgent(ctx context.Context, request UnEnrollAgentRequest) (r UnEnrollAgentResponse, err error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal unenroll agent request into JSON: %w", err)
+		return r, fmt.Errorf("unable to marshal unenroll agent request into JSON: %w", err)
 	}
-
 	apiURL := fmt.Sprintf(fleetUnEnrollAgentAPI, request.ID)
-	statusCode, respBody, err := client.Request(http.MethodPost, apiURL, nil, nil, bytes.NewReader(reqBody))
+
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodPost, apiURL, nil, nil, bytes.NewReader(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("error calling unenroll agent API: %w", err)
+		return r, fmt.Errorf("error calling unenroll agent API: %w", err)
 	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to unenroll agent; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
+	defer resp.Body.Close()
 
-	var resp UnEnrollAgentResponse
-
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse unenroll agent API response: %w", err)
-	}
-
-	return &resp, nil
+	err = readJSONResponse(resp, &r)
+	return r, err
 }
 
 //
@@ -391,28 +366,21 @@ type UpgradeAgentResponse struct {
 }
 
 // UpgradeAgent upgrades the requested agent
-func (client *Client) UpgradeAgent(request UpgradeAgentRequest) (*UpgradeAgentResponse, error) {
+func (client *Client) UpgradeAgent(ctx context.Context, request UpgradeAgentRequest) (r UpgradeAgentResponse, err error) {
 	reqBody, err := json.Marshal(request)
 	if err != nil {
-		return nil, fmt.Errorf("unable to marshal upgrade agent request into JSON: %w", err)
+		return r, fmt.Errorf("unable to marshal upgrade agent request into JSON: %w", err)
 	}
 
 	apiURL := fmt.Sprintf(fleetUpgradeAgentAPI, request.ID)
-	statusCode, respBody, err := client.Request(http.MethodPost, apiURL, nil, nil, bytes.NewReader(reqBody))
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodPost, apiURL, nil, nil, bytes.NewReader(reqBody))
 	if err != nil {
-		return nil, fmt.Errorf("error calling upgrade agent API: %w", err)
+		return r, fmt.Errorf("error calling upgrade agent API: %w", err)
 	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to upgrade agent; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
+	defer resp.Body.Close()
 
-	var resp UpgradeAgentResponse
-
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse upgrade agent API response: %w", err)
-	}
-
-	return &resp, nil
+	err = readJSONResponse(resp, &r)
+	return r, err
 }
 
 //
@@ -439,22 +407,16 @@ type ListFleetServerHostsResponse struct {
 }
 
 // ListFleetServerHosts returns a list of fleet server hosts
-func (client *Client) ListFleetServerHosts(_ ListFleetServerHostsRequest) (*ListFleetServerHostsResponse, error) {
-	statusCode, respBody, err := client.Request(http.MethodGet, fleetFleetServerHostsAPI, nil, nil, nil)
+func (client *Client) ListFleetServerHosts(ctx context.Context, _ ListFleetServerHostsRequest) (r ListFleetServerHostsResponse, err error) {
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodGet, fleetFleetServerHostsAPI, nil, nil, nil)
 	if err != nil {
-		return nil, fmt.Errorf("error calling list fleet server hosts API: %w", err)
+		return r, fmt.Errorf("error calling list fleet server hosts API: %w", err)
 	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to list fleet server hosts; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
+	defer resp.Body.Close()
 
-	var resp ListFleetServerHostsResponse
+	err = readJSONResponse(resp, &r)
 
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse list fleet server hosts API response: %w", err)
-	}
-
-	return &resp, nil
+	return r, err
 }
 
 //
@@ -470,25 +432,21 @@ type GetFleetServerHostRequest struct {
 type GetFleetServerHostResponse FleetServerHost
 
 // GetFleetServerHost returns data on a fleet server
-func (client *Client) GetFleetServerHost(request GetFleetServerHostRequest) (*GetFleetServerHostResponse, error) {
+func (client *Client) GetFleetServerHost(ctx context.Context, request GetFleetServerHostRequest) (r GetFleetServerHostResponse, err error) {
 	apiURL := fmt.Sprintf(fleetFleetServerHostAPI, request.ID)
-	statusCode, respBody, err := client.Request(http.MethodGet, apiURL, nil, nil, nil)
-	if err != nil {
-		return nil, fmt.Errorf("error calling get fleet server host API: %w", err)
-	}
-	if statusCode != 200 {
-		return nil, fmt.Errorf("unable to get fleet server host; API returned status code [%d] and body [%s]", statusCode, string(respBody))
-	}
 
-	var resp struct {
+	resp, err := client.Connection.SendWithContext(ctx, http.MethodGet, apiURL, nil, nil, nil)
+	if err != nil {
+		return r, fmt.Errorf("error calling get fleet server hosts API: %w", err)
+	}
+	defer resp.Body.Close()
+
+	var fleetResp struct {
 		Item GetFleetServerHostResponse `json:"item"`
 	}
+	err = readJSONResponse(resp, &fleetResp)
 
-	if err := json.Unmarshal(respBody, &resp); err != nil {
-		return nil, fmt.Errorf("unable to parse get fleet server host API response: %w", err)
-	}
-
-	return &resp.Item, nil
+	return fleetResp.Item, err
 }
 
 //

--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -192,7 +192,7 @@ func (client *Client) DeletePolicy(ctx context.Context, id string) error {
 	if resp.StatusCode != http.StatusOK {
 		respBody, err := io.ReadAll(resp.Body)
 		if err != nil {
-			return fmt.Errorf("unable to delete policy; API returned status code [%d] and err reading the response: %v", resp.StatusCode, err)
+			return fmt.Errorf("unable to delete policy; API returned status code [%d] and error reading response: %w", resp.StatusCode, err)
 		}
 		return fmt.Errorf("unable to delete policy; API returned status code [%d] and body [%s]", resp.StatusCode, string(respBody))
 	}

--- a/kibana/fleet_integration_test.go
+++ b/kibana/fleet_integration_test.go
@@ -50,6 +50,19 @@ func mustGetEnv(t *testing.T) ClientConfig {
 	return cfg
 }
 
+var tests = []struct {
+	name      string
+	protected bool
+}{
+	{
+		name: "unprotected",
+	},
+	{
+		name:      "protected",
+		protected: true,
+	},
+}
+
 /*
 These are a series of integration tests that run some of the fleet API clients against an actual elastic stack.
 Just set the env vars listed in mustGetEnv().
@@ -57,64 +70,101 @@ Just set the env vars listed in mustGetEnv().
 
 func TestGetPolicyKibana(t *testing.T) {
 	cfg := mustGetEnv(t)
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	client, err := NewClientWithConfig(&cfg, "", "", "", "")
 	require.NoError(t, err)
 
-	testPolicy := AgentPolicy{
+	basePolicy := AgentPolicy{
 		Name:        "TestGetPolicyKibana",
 		Namespace:   "defaultttest",
 		Description: "original policy",
 	}
 
-	respPolicy, err := client.CreatePolicy(testPolicy)
-	require.NoError(t, err)
-	t.Logf("Created policy for test with ID %s", respPolicy.ID)
+	for _, tc := range tests {
+		testPolicy := basePolicy
+		testPolicy.IsProtected = tc.protected
 
-	respGet, err := client.GetPolicy(respPolicy.ID)
-	require.NoError(t, err)
+		t.Run(tc.name, func(t *testing.T) {
+			respPolicy, err := client.CreatePolicy(ctx, testPolicy)
+			require.NoError(t, err)
+			t.Logf("Created policy for test with ID %s", respPolicy.ID)
 
-	require.Equal(t, respPolicy.Description, respGet.Description)
+			respGet, err := client.GetPolicy(ctx, respPolicy.ID)
+			require.NoError(t, err)
 
-	err = client.DeletePolicy(respPolicy.ID)
-	require.NoError(t, err)
+			require.Equal(t, respPolicy.Description, respGet.Description)
+			require.Equal(t, respPolicy.IsProtected, respGet.IsProtected)
+
+			err = client.DeletePolicy(ctx, respPolicy.ID)
+			require.NoError(t, err)
+		})
+	}
 }
 
 func TestCreatePolicyKibana(t *testing.T) {
 	cfg := mustGetEnv(t)
 
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	client, err := NewClientWithConfig(&cfg, "", "", "", "")
 	require.NoError(t, err)
 
-	testPolicy := AgentPolicy{
+	basePolicy := AgentPolicy{
 		Name:      "TestCreatePolicyKibana",
 		Namespace: "defaulttest",
 	}
+	for _, tc := range tests {
+		testPolicy := basePolicy
+		testPolicy.IsProtected = tc.protected
+		t.Run(tc.name, func(t *testing.T) {
+			respPolicy, err := client.CreatePolicy(ctx, testPolicy)
+			t.Logf("created policy with ID %s", respPolicy.ID)
+			require.NoError(t, err)
+			require.Equal(t, testPolicy.Name, respPolicy.Name)
+			require.Equal(t, testPolicy.Namespace, respPolicy.Namespace)
+			require.Equal(t, testPolicy.IsProtected, respPolicy.IsProtected)
+			require.NotEmpty(t, respPolicy.ID)
+			// delete policy
+			err = client.DeletePolicy(ctx, respPolicy.ID)
+			require.NoError(t, err)
+		})
+	}
 
-	respPolicy, err := client.CreatePolicy(testPolicy)
-	t.Logf("created policy with ID %s", respPolicy.ID)
-	require.NoError(t, err)
-	require.Equal(t, testPolicy.Name, respPolicy.Name)
-	require.Equal(t, testPolicy.Namespace, respPolicy.Namespace)
-	require.NotEmpty(t, respPolicy.ID)
-	// delete policy
-	err = client.DeletePolicy(respPolicy.ID)
-	require.NoError(t, err)
 }
 
 func TestUpdatePolicyKibana(t *testing.T) {
 	cfg := mustGetEnv(t)
+
 	client, err := NewClientWithConfig(&cfg, "", "", "", "")
 	require.NoError(t, err)
 
 	uid, err := uuid.NewV4()
 	require.NoError(t, err)
 
-	testPolicy := AgentPolicy{
+	basePolicy := AgentPolicy{
 		Name:        "TestUpdatePolicyKibana-" + uid.String(),
 		Namespace:   "defaultttest",
 		Description: "original policy",
 	}
-	respPolicy, err := client.CreatePolicy(testPolicy)
+
+	for _, tc := range tests {
+		testPolicy := basePolicy
+		testPolicy.IsProtected = tc.protected
+		t.Run(tc.name, func(t *testing.T) {
+			testUpdatePolicyKibana(t, client, testPolicy)
+		})
+	}
+}
+
+func testUpdatePolicyKibana(t *testing.T, client *Client, testPolicy AgentPolicy) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
+	respPolicy, err := client.CreatePolicy(ctx, testPolicy)
 	require.NoError(t, err)
 	t.Logf("Created policy for test with ID %s", respPolicy.ID)
 	require.Empty(t, respPolicy.MonitoringEnabled)
@@ -123,15 +173,17 @@ func TestUpdatePolicyKibana(t *testing.T) {
 		Name:              testPolicy.Name,
 		Namespace:         testPolicy.Namespace,
 		MonitoringEnabled: []MonitoringEnabledOption{MonitoringEnabledMetrics},
+		IsProtected:       &testPolicy.IsProtected,
 	}
 
-	updateResp, err := client.UpdatePolicy(respPolicy.ID, updatePolicy)
+	updateResp, err := client.UpdatePolicy(ctx, respPolicy.ID, updatePolicy)
 	require.NoError(t, err)
 	// make sure our update was applied
 	require.Equal(t, []MonitoringEnabledOption{MonitoringEnabledMetrics}, updateResp.MonitoringEnabled)
 	// make sure we didn't somehow change something else
 	require.Equal(t, respPolicy.InactivityTImeout, updateResp.InactivityTImeout)
 	require.Equal(t, respPolicy.Description, updateResp.Description)
+	require.Equal(t, respPolicy.IsProtected, updateResp.IsProtected)
 
 	// Enable tamper protection
 	updatePolicyTamperProtection := AgentPolicyUpdateRequest{
@@ -141,12 +193,12 @@ func TestUpdatePolicyKibana(t *testing.T) {
 	}
 
 	// Verify that tamper protection is enabled
-	updateResp, err = client.UpdatePolicy(respPolicy.ID, updatePolicyTamperProtection)
+	updateResp, err = client.UpdatePolicy(ctx, respPolicy.ID, updatePolicyTamperProtection)
 	require.NoError(t, err)
 	require.Equal(t, *updatePolicyTamperProtection.IsProtected, updateResp.IsProtected)
 
 	// Get uninstall tokens, should be one
-	uninstallTokenResp, err := client.GetPolicyUninstallTokens(context.Background(), respPolicy.ID)
+	uninstallTokenResp, err := client.GetPolicyUninstallTokens(ctx, respPolicy.ID)
 	require.NoError(t, err)
 	require.Greater(t, len(uninstallTokenResp.Items), 0, "Expected non-zero number of tokens")
 	require.Greater(t, len(uninstallTokenResp.Items[0].Token), 0, "expected non-empty token")
@@ -159,11 +211,11 @@ func TestUpdatePolicyKibana(t *testing.T) {
 	}
 
 	// Verify that tamper protection is disabled
-	updateResp, err = client.UpdatePolicy(respPolicy.ID, updatePolicyTamperProtection)
+	updateResp, err = client.UpdatePolicy(ctx, respPolicy.ID, updatePolicyTamperProtection)
 	require.NoError(t, err)
 	require.Equal(t, *updatePolicyTamperProtection.IsProtected, updateResp.IsProtected)
 
-	err = client.DeletePolicy(respPolicy.ID)
+	err = client.DeletePolicy(ctx, respPolicy.ID)
 	require.NoError(t, err)
 }
 
@@ -181,6 +233,10 @@ const endpointPackageVersion = "8.9.0"
 
 func TestFleetPackage(t *testing.T) {
 	cfg := mustGetEnv(t)
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	client, err := NewClientWithConfig(&cfg, "", "", "", "")
 	require.NoError(t, err)
 
@@ -198,7 +254,7 @@ func TestFleetPackage(t *testing.T) {
 	}
 
 	// Create policy
-	res, err := client.CreatePolicy(req)
+	res, err := client.CreatePolicy(ctx, req)
 	require.NoError(t, err)
 
 	// Install package
@@ -212,7 +268,7 @@ func TestFleetPackage(t *testing.T) {
 	require.Equal(t, packagePolicyID, delRes.ID)
 
 	// Cleanup
-	err = client.DeletePolicy(res.ID)
+	err = client.DeletePolicy(ctx, res.ID)
 	require.NoError(t, err)
 }
 

--- a/kibana/fleet_test.go
+++ b/kibana/fleet_test.go
@@ -18,6 +18,7 @@
 package kibana
 
 import (
+	"context"
 	_ "embed"
 	"fmt"
 	"net/http"
@@ -61,6 +62,9 @@ func TestFleetCreatePolicy(t *testing.T) {
 		policyDescription = "a policy used for testing"
 	)
 
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fleetAgentPoliciesAPI:
@@ -80,7 +84,7 @@ func TestFleetCreatePolicy(t *testing.T) {
 			MonitoringEnabledMetrics,
 		},
 	}
-	resp, err := client.CreatePolicy(req)
+	resp, err := client.CreatePolicy(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -95,6 +99,10 @@ func TestFleetCreatePolicy(t *testing.T) {
 
 func TestFleetGetPolicy(t *testing.T) {
 	const id = "elastic-agent-managed-ep"
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fmt.Sprintf(fleetAgentPolicyAPI, id):
@@ -106,7 +114,7 @@ func TestFleetGetPolicy(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, client)
 
-	resp, err := client.GetPolicy(id)
+	resp, err := client.GetPolicy(ctx, id)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -123,6 +131,9 @@ func TestFleetUpdatePolicy(t *testing.T) {
 		id         = "b4cd25b0-f040-11ed-a1b3-373f5d648cd4"
 		policyName = "test-fqdn"
 	)
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
 
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
@@ -150,7 +161,8 @@ func TestFleetUpdatePolicy(t *testing.T) {
 		},
 		AgentFeatures: agentFeatures,
 	}
-	resp, err := client.UpdatePolicy(id, req)
+
+	resp, err := client.UpdatePolicy(ctx, id, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 

--- a/kibana/fleet_test.go
+++ b/kibana/fleet_test.go
@@ -182,6 +182,9 @@ func TestFleetCreateEnrollmentAPIKey(t *testing.T) {
 		policyID = "a580c680-ea40-11ed-aae7-4b4fd4906b3d"
 	)
 
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fleetEnrollmentAPIKeysAPI:
@@ -197,7 +200,7 @@ func TestFleetCreateEnrollmentAPIKey(t *testing.T) {
 		Name:     name,
 		PolicyID: policyID,
 	}
-	resp, err := client.CreateEnrollmentAPIKey(req)
+	resp, err := client.CreateEnrollmentAPIKey(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -209,6 +212,9 @@ func TestFleetCreateEnrollmentAPIKey(t *testing.T) {
 }
 
 func TestFleetListAgents(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fleetAgentsAPI:
@@ -221,7 +227,7 @@ func TestFleetListAgents(t *testing.T) {
 	require.NotNil(t, client)
 
 	req := ListAgentsRequest{}
-	resp, err := client.ListAgents(req)
+	resp, err := client.ListAgents(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -234,6 +240,10 @@ func TestFleetListAgents(t *testing.T) {
 
 func TestFleetGetAgent(t *testing.T) {
 	const id = "26802301-8996-457a-ab6a-8ea955ef2723"
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fmt.Sprintf(fleetAgentAPI, id):
@@ -248,7 +258,7 @@ func TestFleetGetAgent(t *testing.T) {
 	req := GetAgentRequest{
 		ID: id,
 	}
-	resp, err := client.GetAgent(req)
+	resp, err := client.GetAgent(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -264,6 +274,10 @@ func TestFleetGetAgent(t *testing.T) {
 
 func TestFleetUnEnrollAgent(t *testing.T) {
 	const agentID = "f512f36f-bf78-4285-aff0-baeafbcdf21e"
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fmt.Sprintf(fleetUnEnrollAgentAPI, agentID):
@@ -279,13 +293,17 @@ func TestFleetUnEnrollAgent(t *testing.T) {
 		ID:     agentID,
 		Revoke: true,
 	}
-	resp, err := client.UnEnrollAgent(req)
+	resp, err := client.UnEnrollAgent(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
 
 func TestFleetUpgradeAgent(t *testing.T) {
 	const agentID = "f512f36f-bf78-4285-aff0-baeafbcdf21e"
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fmt.Sprintf(fleetUpgradeAgentAPI, agentID):
@@ -301,12 +319,15 @@ func TestFleetUpgradeAgent(t *testing.T) {
 		ID:      agentID,
 		Version: "8.8.0",
 	}
-	resp, err := client.UpgradeAgent(req)
+	resp, err := client.UpgradeAgent(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 }
 
 func TestFleetListFleetServerHosts(t *testing.T) {
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fleetFleetServerHostsAPI:
@@ -319,7 +340,7 @@ func TestFleetListFleetServerHosts(t *testing.T) {
 	require.NotNil(t, client)
 
 	req := ListFleetServerHostsRequest{}
-	resp, err := client.ListFleetServerHosts(req)
+	resp, err := client.ListFleetServerHosts(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 
@@ -334,6 +355,10 @@ func TestFleetListFleetServerHosts(t *testing.T) {
 
 func TestFleetGetFleetServerHost(t *testing.T) {
 	const id = "fleet-default-fleet-server-host"
+
+	ctx, cn := context.WithCancel(context.Background())
+	defer cn()
+
 	handler := func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case fmt.Sprintf(fleetFleetServerHostAPI, id):
@@ -348,7 +373,7 @@ func TestFleetGetFleetServerHost(t *testing.T) {
 	req := GetFleetServerHostRequest{
 		ID: id,
 	}
-	resp, err := client.GetFleetServerHost(req)
+	resp, err := client.GetFleetServerHost(ctx, req)
 	require.NoError(t, err)
 	require.NotNil(t, resp)
 


### PR DESCRIPTION
## What does this PR do?

* Adds IsProtected to the AgentPolicy.
* Improves Kibana policy API wrappers with added context parameter

## Why is it important?

Allows to move over more custom code for E2E tests with tamper protection.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have added an entry in `CHANGELOG.md`

