### PR TITLE
Add Elastic-Api-Version header to kibana client

### DIFF
--- a/kibana/client.go
+++ b/kibana/client.go
@@ -191,14 +191,7 @@ func NewClientWithConfigDefault(config *ClientConfig, defaultPort int, binaryNam
 		binaryName = "Libbeat"
 	}
 	userAgent := useragent.UserAgent(binaryName, version, commit, buildtime)
-
-	const elasticAPIVersionHeaderKey = "Elastic-Api-Version"
-	const elasticAPIDefaultVersion = "2023-10-31"
-	rt, err := config.Transport.Client(
-		httpcommon.WithHeaderRoundTripper(
-			map[string]string{"User-Agent": userAgent, elasticAPIVersionHeaderKey: elasticAPIDefaultVersion},
-		),
-	)
+	rt, err := config.Transport.Client(httpcommon.WithHeaderRoundTripper(map[string]string{"User-Agent": userAgent}))
 	if err != nil {
 		return nil, err
 	}

--- a/kibana/client.go
+++ b/kibana/client.go
@@ -191,7 +191,14 @@ func NewClientWithConfigDefault(config *ClientConfig, defaultPort int, binaryNam
 		binaryName = "Libbeat"
 	}
 	userAgent := useragent.UserAgent(binaryName, version, commit, buildtime)
-	rt, err := config.Transport.Client(httpcommon.WithHeaderRoundTripper(map[string]string{"User-Agent": userAgent}))
+
+	const elasticAPIVersionHeaderKey = "Elastic-Api-Version"
+	const elasticAPIDefaultVersion = "2023-10-31"
+	rt, err := config.Transport.Client(
+		httpcommon.WithHeaderRoundTripper(
+			map[string]string{"User-Agent": userAgent, elasticAPIVersionHeaderKey: elasticAPIDefaultVersion},
+		),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/kibana/client_config.go
+++ b/kibana/client_config.go
@@ -23,6 +23,9 @@ import (
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
+const elasticAPIVersionHeaderKey = "Elastic-Api-Version"
+const elasticAPIDefaultVersion = "2023-10-31"
+
 // ClientConfig to connect to Kibana
 type ClientConfig struct {
 	Protocol     string `config:"protocol" yaml:"protocol,omitempty"`
@@ -54,6 +57,7 @@ func DefaultClientConfig() ClientConfig {
 		APIKey:       "",
 		ServiceToken: "",
 		Transport:    httpcommon.DefaultHTTPTransportSettings(),
+		Headers:      map[string]string{elasticAPIVersionHeaderKey: elasticAPIDefaultVersion},
 	}
 }
 


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Adds the `Elastic-Api-Version` header to all request to kibana Api as it's mandatory since merge of elastic/kibana#163570

This is the first step of a 2-step fox for issue elastic/elastic-agent#3362: after this PR is merged we need to bump the version and use the newer version in elastic-agent.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- ~~[ ] My code follows the style guidelines of this project~~
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~
- ~~[ ] I have added an entry in `CHANGELOG.md`~~

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates elastic/elastic-agent#3362

