### PR TITLE
add idle_connection_timeout to HTTPTransportSettings

### DIFF
--- a/transport/httpcommon/httpcommon.go
+++ b/transport/httpcommon/httpcommon.go
@@ -40,10 +40,11 @@ type HTTPTransportSettings struct {
 
 	Proxy HTTPClientProxySettings `config:",inline" yaml:",inline"`
 
+	IdleConnTimeout time.Duration `config:"idle_connection_timeout" yaml:"idle_connection_timeout,omitempty" json:"idle_connection_timeout,omitempty"`
+
 	// Add more settings:
 	//  - DisableKeepAlive
 	//  - MaxIdleConns
-	//  - IdleConnTimeout
 	//  - ResponseHeaderTimeout
 	//  - ConnectionTimeout (currently 'Timeout' is used for both)
 }
@@ -159,9 +160,13 @@ func DefaultHTTPTransportSettings() HTTPTransportSettings {
 // Unpack reads a config object into the settings.
 func (settings *HTTPTransportSettings) Unpack(cfg *config.C) error {
 	tmp := struct {
-		TLS     *tlscommon.Config `config:"ssl"`
-		Timeout time.Duration     `config:"timeout"`
-	}{Timeout: settings.Timeout}
+		TLS             *tlscommon.Config `config:"ssl"`
+		Timeout         time.Duration     `config:"timeout"`
+		IdleConnTimeout time.Duration     `config:"idle_connection_timeout"`
+	}{
+		Timeout:         settings.Timeout,
+		IdleConnTimeout: settings.IdleConnTimeout,
+	}
 
 	if err := cfg.Unpack(&tmp); err != nil {
 		return err
@@ -178,9 +183,10 @@ func (settings *HTTPTransportSettings) Unpack(cfg *config.C) error {
 	}
 
 	*settings = HTTPTransportSettings{
-		TLS:     tmp.TLS,
-		Timeout: tmp.Timeout,
-		Proxy:   proxy,
+		TLS:             tmp.TLS,
+		Timeout:         tmp.Timeout,
+		Proxy:           proxy,
+		IdleConnTimeout: tmp.IdleConnTimeout,
 	}
 	return nil
 }

--- a/transport/httpcommon/httpcommon_test.go
+++ b/transport/httpcommon/httpcommon_test.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package httpcommon
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
+)
+
+func TestUnpack(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expected HTTPTransportSettings
+	}{
+		"blank": {
+			input:    "",
+			expected: HTTPTransportSettings{},
+		},
+		"idleConnectionTimeout": {
+			input: `
+idle_connection_timeout: 15s
+`,
+			expected: HTTPTransportSettings{IdleConnTimeout: 15 * time.Second},
+		},
+		"timeoutAndIdleConnectionTimeout": {
+			input: `
+idle_connection_timeout: 15s
+timeout: 5s
+`,
+			expected: HTTPTransportSettings{
+				IdleConnTimeout: 15 * time.Second,
+				Timeout:         5 * time.Second,
+			},
+		},
+		"ssl": {
+			input: `
+ssl:
+  verification_mode: certificate
+`,
+			expected: HTTPTransportSettings{
+				TLS: &tlscommon.Config{
+					VerificationMode: tlscommon.VerifyCertificate,
+				},
+			},
+		},
+		"complex": {
+			input: `
+timeout: 5s
+idle_connection_timeout: 15s
+ssl:
+  verification_mode: certificate
+`,
+			expected: HTTPTransportSettings{
+				TLS: &tlscommon.Config{
+					VerificationMode: tlscommon.VerifyCertificate,
+				},
+				IdleConnTimeout: 15 * time.Second,
+				Timeout:         5 * time.Second,
+			},
+		},
+	}
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			cfg, err := config.NewConfigFrom(tc.input)
+			require.NoError(t, err)
+
+			settings := HTTPTransportSettings{}
+			err = cfg.Unpack(&settings)
+			require.NoError(t, err)
+
+			require.Equal(t, tc.expected, settings)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

Add idle_connection_timeout to HTTPTransportSettings

## Why is it important?

Will allow users of the library that use

```
	Transport httpcommon.HTTPTransportSettings `config:",inline"`
```

in their config objects to set the keep alive setting of `IdleConnTimeout` by setting `idle_connection_timeout`

## Checklist

- [x] My code follows the style guidelines of this project
~~- [ ] I have commented my code, particularly in hard-to-understand areas~~
- [x] I have added tests that prove my fix is effective or that my feature works
~~- [ ] I have added an entry in `CHANGELOG.md` ~~


## Related issues

- Relates elastic/beats#35615

