### PR TITLE
Make test output honor output.logstash.proxy_url

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -232,7 +232,7 @@ func (c *Client) Test(d testing.Driver) {
 				dialer = TestNetDialer(d, c.config.Timeout)
 			} else {
 				dialer = NetDialer(c.config.Timeout)
-				dialer = TestProxyDialer(d, dialer, c.config.Proxy, c.config.Timeout)
+				dialer = TestProxyDialer(d, dialer, c.config.Proxy)
 			}
 			_, err := dialer.Dial("tcp", c.host)
 			d.Fatal("dial up", err)
@@ -244,7 +244,7 @@ func (c *Client) Test(d testing.Driver) {
 			d.Run("TLS", func(d testing.Driver) {
 				dialer := NetDialer(c.config.Timeout)
 				if c.config.Proxy.URL != "" {
-					dialer = TestProxyDialer(d, dialer, c.config.Proxy, c.config.Timeout)
+					dialer = TestProxyDialer(d, dialer, c.config.Proxy)
 				}
 				dialer = TestTLSDialer(d, dialer, c.config.TLS, c.config.Timeout)
 				_, err := dialer.Dial("tcp", c.host)

--- a/transport/client.go
+++ b/transport/client.go
@@ -232,7 +232,7 @@ func (c *Client) Test(d testing.Driver) {
 				dialer = TestNetDialer(d, c.config.Timeout)
 			} else {
 				dialer = NetDialer(c.config.Timeout)
-				dialer = TestProxyDialer(d, dialer, c.config.Proxy)
+				dialer = testProxyDialer(d, dialer, c.config.Proxy)
 			}
 			_, err := dialer.Dial("tcp", c.host)
 			d.Fatal("dial up", err)
@@ -244,7 +244,7 @@ func (c *Client) Test(d testing.Driver) {
 			d.Run("TLS", func(d testing.Driver) {
 				dialer := NetDialer(c.config.Timeout)
 				if c.config.Proxy.URL != "" {
-					dialer = TestProxyDialer(d, dialer, c.config.Proxy)
+					dialer = testProxyDialer(d, dialer, c.config.Proxy)
 				}
 				dialer = TestTLSDialer(d, dialer, c.config.TLS, c.config.Timeout)
 				_, err := dialer.Dial("tcp", c.host)

--- a/transport/httpcommon/proxy.go
+++ b/transport/httpcommon/proxy.go
@@ -18,16 +18,10 @@
 package httpcommon
 
 import (
-	"bufio"
-	"encoding/base64"
-	"fmt"
-	"net"
 	"net/http"
 	"net/url"
 
 	"github.com/elastic/elastic-agent-libs/config"
-	"github.com/elastic/elastic-agent-libs/transport"
-	"golang.org/x/net/proxy"
 )
 
 // HTTPClientProxySettings provides common HTTP proxy setup support.
@@ -109,55 +103,4 @@ func (settings *HTTPClientProxySettings) ProxyFunc() func(*http.Request) (*url.U
 	}
 
 	return http.ProxyURL(settings.URL.URI())
-}
-
-// ProxyDialer is a dialer that can be registered to golang.org/x/net/proxy
-func (settings *HTTPClientProxySettings) ProxyDialer(_ *url.URL, forward proxy.Dialer) (proxy.Dialer, error) {
-	return transport.DialerFunc(func(_, address string) (net.Conn, error) {
-
-		// Headers given to the CONNECT request
-		hdr := settings.Headers.Headers()
-		if settings.URL.User != nil {
-			username := settings.URL.User.Username()
-			password, _ := settings.URL.User.Password()
-			if len(hdr) == 0 {
-				hdr = http.Header{}
-			}
-			hdr.Add("Proxy-Authorization", "Basic "+base64.StdEncoding.EncodeToString([]byte(username+":"+password)))
-		}
-
-		req := &http.Request{
-			Method: "CONNECT",
-			URL:    &url.URL{Opaque: address},
-			Host:   address,
-			Header: hdr,
-		}
-
-		// Dial the proxy host
-		c, err := forward.Dial("tcp", settings.URL.Host)
-		if err != nil {
-			return nil, err
-		}
-
-		// Write the CONNECT request
-		err = req.Write(c)
-		if err != nil {
-			c.Close()
-			return nil, err
-		}
-
-		res, err := http.ReadResponse(bufio.NewReader(c), req)
-		if err != nil {
-			c.Close()
-			return nil, err
-		}
-		res.Body.Close()
-
-		if res.StatusCode != http.StatusOK {
-			c.Close()
-			return nil, fmt.Errorf("proxy server returned status code %d", res.StatusCode)
-		}
-
-		return c, nil
-	}), nil
 }

--- a/transport/proxy.go
+++ b/transport/proxy.go
@@ -99,7 +99,7 @@ func ProxyDialer(log *logp.Logger, config *ProxyConfig, forward Dialer) (Dialer,
 	}), nil
 }
 
-func TestProxyDialer(
+func testProxyDialer(
 	d testing.Driver,
 	forward Dialer,
 	config *ProxyConfig,

--- a/transport/proxy.go
+++ b/transport/proxy.go
@@ -20,7 +20,6 @@ package transport
 import (
 	"net"
 	"net/url"
-	"time"
 
 	"golang.org/x/net/proxy"
 
@@ -104,7 +103,6 @@ func TestProxyDialer(
 	d testing.Driver,
 	forward Dialer,
 	config *ProxyConfig,
-	timeout time.Duration,
 ) Dialer {
 	dialer, err := ProxyDialer(logp.L(), config, forward)
 	d.Fatal("proxy", err)

--- a/transport/proxy.go
+++ b/transport/proxy.go
@@ -20,10 +20,12 @@ package transport
 import (
 	"net"
 	"net/url"
+	"time"
 
 	"golang.org/x/net/proxy"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/testing"
 )
 
 // ProxyConfig holds the configuration information required to proxy
@@ -96,4 +98,15 @@ func ProxyDialer(log *logp.Logger, config *ProxyConfig, forward Dialer) (Dialer,
 		}
 		return DialWith(dialer, network, host, addresses, port)
 	}), nil
+}
+
+func TestProxyDialer(
+	d testing.Driver,
+	forward Dialer,
+	config *ProxyConfig,
+	timeout time.Duration,
+) Dialer {
+	dialer, err := ProxyDialer(logp.L(), config, forward)
+	d.Fatal("proxy", err)
+	return dialer
 }


### PR DESCRIPTION
## What does this PR do?

This PR will fix the part of elastic/beats#24751 related to Logstash.

**w/o proxy**:
```console
$ ./filebeat test output -E output.elasticsearch.enabled=false -E output.logstash.enabled=true -E output.logstash.hosts=elastic.co:443
logstash: elastic.co:443...
  connection...
    parse host... OK
    dns lookup... OK
    addresses: 34.107.161.234, 2600:1901:0:1f6d::
    dial up... OK
  TLS... WARN secure connection disabled
  talk to server... OK
```

**w/ proxy**:
```console
$ ./filebeat test output -E output.elasticsearch.enabled=false -E output.logstash.enabled=true -E output.logstash.hosts=elastic.co:443 -E output.logstash.proxy_url=socks5://user:pswd@localhost:1080
logstash: elastic.co:443...
  proxy...
    parse url... OK
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  connection...
    proxy... OK
    dial up... OK
  TLS... WARN secure connection disabled
  talk to server... OK
```

**w/ proxy and ssl**:
```console
$ ./filebeat test output -E output.elasticsearch.enabled=false -E output.logstash.enabled=true -E output.logstash.hosts=elastic.co:443 -E output.logstash.proxy_url=socks5://user:pswd@localhost:1080 -E output.logstash.ssl.enabled=true
logstash: elastic.co:443...
  proxy...
    parse url... OK
    parse host... OK
    dns lookup... OK
    addresses: 127.0.0.1
    dial up... OK
  connection...
    proxy... OK
    dial up... OK
  TLS...
    proxy... OK
    security: server's certificate chain verification is enabled
    handshake... OK
    TLS version: TLSv1.3
    dial up... OK
  talk to server... OK
```

<details>
<summary>How I run the testing socks5 proxy</summary>

```
docker run -it --rm --name socks5 -p 1080:1080 -e PROXY_USER=user -e PROXY_PASSWORD=pswd serjs/go-socks5-proxy
```
</details>

## Why is it important?

I frequently rely on `test output` command for troubleshooting, so its reliability is key.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project - `mage linter:lastChange` passed.
- [x] I have commented my code, particularly in hard-to-understand areas - n/a as no such area.
- [x] I have added tests that prove my fix is effective or that my feature works - n/a as there is https://github.com/elastic/beats/blob/main/libbeat/tests/integration/cmd_test.go
- [x] I have added an entry in `CHANGELOG.md` - n/a as there's no such file.

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [x] Fix for `output.elasticsearch.proxy_url`. https://github.com/elastic/beats/pull/36715

## Related issues

- Relates  elastic/beats#24751
