### PR TITLE
[service] windows service, receive multiple change requests

### DIFF
--- a/service/service_windows.go
+++ b/service/service_windows.go
@@ -50,13 +50,15 @@ func (m *beatService) Execute(args []string, r <-chan svc.ChangeRequest, changes
 	log := logp.NewLogger("service_windows")
 	combinedChan := make(chan svc.ChangeRequest)
 	go func() {
-		select {
-		case c := <-r:
-			combinedChan <- c
-		case <-m.done:
-			// exits consumption loop on termination and reports stopping
-			combinedChan <- svc.ChangeRequest{Cmd: svc.Shutdown}
-			return
+		for {
+			select {
+			case c := <-r:
+				combinedChan <- c
+			case <-m.done:
+				// exits consumption loop on termination and reports stopping
+				combinedChan <- svc.ChangeRequest{Cmd: svc.Shutdown}
+				return
+			}
 		}
 	}()
 


### PR DESCRIPTION
## What does this PR do?

In the windows service `Execute` function, use for loop to receive all the change requests not just the first one.


## Why is it important?

Without this only the first change request is received.  So if the service is sent Interrogate, followed by Shutdown, it would only see the Interrogate request and never receive the Shutdown request.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

- elastic/elastic-agent#3557
- elastic/elastic-agent#3372
- elastic/elastic-agent#3307
- elastic/elastic-agent#3061
- elastic/elastic-agent#3557

