### PR TITLE
[file] rotator purge fix

### DIFF
--- a/file/rotator.go
+++ b/file/rotator.go
@@ -482,7 +482,7 @@ func (d *dateRotator) Rotate(reason rotateReason, rotateTime time.Time) error {
 }
 
 func (d *dateRotator) RotatedFiles() []string {
-	files, err := filepath.Glob(d.filenamePrefix + "*")
+	files, err := filepath.Glob(d.filenamePrefix + "*" + d.extension)
 	if err != nil {
 		if d.log != nil {
 			d.log.Debugw("failed to list existing logs: %+v", err)

--- a/file/rotator_test.go
+++ b/file/rotator_test.go
@@ -134,6 +134,7 @@ func TestDailyRotation(t *testing.T) {
 		logname + "-" + twoDaysAgo + "-1.ndjson",
 		logname + "-" + twoDaysAgo + "-2.ndjson",
 		logname + "-" + twoDaysAgo + "-3.ndjson",
+		logname + "-diagnostic-" + twoDaysAgo + ".zip",
 	}
 
 	for _, f := range files {
@@ -153,26 +154,26 @@ func TestDailyRotation(t *testing.T) {
 
 	Rotate(t, r)
 
-	AssertDirContents(t, dir, logname+"-"+yesterday+"-12.ndjson", logname+"-"+yesterday+"-13.ndjson")
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-12.ndjson", logname+"-"+yesterday+"-13.ndjson", logname+"-diagnostic-"+twoDaysAgo+".zip")
 
 	WriteMsg(t, r)
 
 	today := time.Now().Format(file.DateFormat)
-	AssertDirContents(t, dir, logname+"-"+yesterday+"-12.ndjson", logname+"-"+yesterday+"-13.ndjson", logname+"-"+today+".ndjson")
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-12.ndjson", logname+"-"+yesterday+"-13.ndjson", logname+"-"+today+".ndjson", logname+"-diagnostic-"+twoDaysAgo+".zip")
 
 	Rotate(t, r)
 
-	AssertDirContents(t, dir, logname+"-"+yesterday+"-13.ndjson", logname+"-"+today+".ndjson")
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-13.ndjson", logname+"-"+today+".ndjson", logname+"-diagnostic-"+twoDaysAgo+".zip")
 
 	WriteMsg(t, r)
 
-	AssertDirContents(t, dir, logname+"-"+yesterday+"-13.ndjson", logname+"-"+today+".ndjson", logname+"-"+today+"-1.ndjson")
+	AssertDirContents(t, dir, logname+"-"+yesterday+"-13.ndjson", logname+"-"+today+".ndjson", logname+"-"+today+"-1.ndjson", logname+"-diagnostic-"+twoDaysAgo+".zip")
 
 	for i := 0; i < (int(maxSizeBytes)/len(logMessage))+1; i++ {
 		WriteMsg(t, r)
 	}
 
-	AssertDirContents(t, dir, logname+"-"+today+"-1.ndjson", logname+"-"+today+"-2.ndjson", logname+"-"+today+"-3.ndjson")
+	AssertDirContents(t, dir, logname+"-"+today+"-1.ndjson", logname+"-"+today+"-2.ndjson", logname+"-"+today+"-3.ndjson", logname+"-diagnostic-"+twoDaysAgo+".zip")
 }
 
 // Tests the FileConfig.RotateOnStartup parameter


### PR DESCRIPTION
## What does this PR do?

In file daily rotator.  Previously files that matched the Glob `filenamePrefix*` were considered rotated files.  This change makes it `filenamePrefix*.extension`.

## Why is it important?

With the previous code, files that started with the prefix but ended with a different extension could be considered rotated files and thus available to be purged.  For example `elastic-agent-diagnostics.zip` would be considered a rotated file if the filename prefix was `elastic-agent-`

Adding the the extension keeps those files from being considered rotated files, and thus out of the list of files that are eligible to be purged.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.md`

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes elastic/elastic-agent#3286

