### PR TITLE
[Fleet API] Include upgrade details in Agent object

### DIFF
--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -256,20 +256,22 @@ type AgentCommon struct {
 			Hostname string `json:"hostname"`
 		} `json:"host"`
 	} `json:"local_metadata"`
-	PolicyID       string `json:"policy_id"`
-	PolicyRevision int    `json:"policy_revision"`
-	UpgradeDetails struct {
-		TargetVersion string `json:"target_version"`
-		State         string `json:"state"`
-		ActionID      string `json:"action_id"`
-		Metadata      struct {
-			ScheduledAt     *time.Time `json:"scheduled_at"`
-			DownloadPercent float64    `json:"download_percent"`
-			DownloadRate    float64    `json:"download_rate"`
-			FailedState     string     `json:"failed_state"`
-			ErrorMsg        string     `json:"error_msg"`
-		} `json:"metadata"`
-	} `json:"upgrade_details"`
+	PolicyID       string               `json:"policy_id"`
+	PolicyRevision int                  `json:"policy_revision"`
+	UpgradeDetails *AgentUpgradeDetails `json:"upgrade_details"`
+}
+
+type AgentUpgradeDetails struct {
+	TargetVersion string `json:"target_version"`
+	State         string `json:"state"`
+	ActionID      string `json:"action_id"`
+	Metadata      struct {
+		ScheduledAt     *time.Time `json:"scheduled_at"`
+		DownloadPercent float64    `json:"download_percent"`
+		DownloadRate    float64    `json:"download_rate"`
+		FailedState     string     `json:"failed_state"`
+		ErrorMsg        string     `json:"error_msg"`
+	} `json:"metadata"`
 }
 
 // AgentExisting is the data structure for an existing agent

--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -263,11 +263,11 @@ type AgentCommon struct {
 		State         string `json:"state"`
 		ActionID      string `json:"action_id"`
 		Metadata      struct {
-			ScheduledAt     *time.Time   `json:"scheduled_at"`
-			DownloadPercent float64      `json:"download_percent"`
-			DownloadRate    downloadRate `json:"download_rate"`
-			FailedState     State        `json:"failed_state"`
-			ErrorMsg        string       `json:"error_msg"`
+			ScheduledAt     *time.Time `json:"scheduled_at"`
+			DownloadPercent float64    `json:"download_percent"`
+			DownloadRate    float64    `json:"download_rate"`
+			FailedState     string     `json:"failed_state"`
+			ErrorMsg        string     `json:"error_msg"`
 		} `json:"metadata"`
 	} `json:"upgrade_details"`
 }

--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -258,6 +258,18 @@ type AgentCommon struct {
 	} `json:"local_metadata"`
 	PolicyID       string `json:"policy_id"`
 	PolicyRevision int    `json:"policy_revision"`
+	UpgradeDetails struct {
+		TargetVersion string `json:"target_version"`
+		State         string `json:"state"`
+		ActionID      string `json:"action_id"`
+		Metadata      struct {
+			ScheduledAt     *time.Time   `json:"scheduled_at"`
+			DownloadPercent float64      `json:"download_percent"`
+			DownloadRate    downloadRate `json:"download_rate"`
+			FailedState     State        `json:"failed_state"`
+			ErrorMsg        string       `json:"error_msg"`
+		} `json:"metadata"`
+	} `json:"upgrade_details"`
 }
 
 // AgentExisting is the data structure for an existing agent


### PR DESCRIPTION
## What does this PR do?

This PR enhances the Agent object returned by various Fleet APIs to include the `upgrade_details` field.

## Why is it important?

For E2E tests being updated in https://github.com/elastic/elastic-agent/pull/3528.
