### PR TITLE
add ServerConfig tags, export TLSClientAuth

### DIFF
--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -27,14 +27,14 @@ import (
 
 // ServerConfig defines the user configurable tls options for any TCP based service.
 type ServerConfig struct {
-	Enabled          *bool               `config:"enabled"`
-	VerificationMode TLSVerificationMode `config:"verification_mode"` // one of 'none', 'full', 'strict', 'certificate'
-	Versions         []TLSVersion        `config:"supported_protocols"`
-	CipherSuites     []CipherSuite       `config:"cipher_suites"`
-	CAs              []string            `config:"certificate_authorities"`
-	Certificate      CertificateConfig   `config:",inline"`
-	CurveTypes       []tlsCurveType      `config:"curve_types"`
-	ClientAuth       tlsClientAuth       `config:"client_authentication"` //`none`, `optional` or `required`
+	Enabled          *bool               `config:"enabled" yaml:"enabled,omitempty"`
+	VerificationMode TLSVerificationMode `config:"verification_mode" yaml:"verification_mode,omitempty"` // one of 'none', 'full', 'strict', 'certificate'
+	Versions         []TLSVersion        `config:"supported_protocols" yaml:"supported_protocols,omitempty"`
+	CipherSuites     []CipherSuite       `config:"cipher_suites" yaml:"cipher_suites,omitempty"`
+	CAs              []string            `config:"certificate_authorities" yaml:"certificate_authorities,omitempty"`
+	Certificate      CertificateConfig   `config:",inline" yaml:",inline"`
+	CurveTypes       []tlsCurveType      `config:"curve_types" yaml:"curve_types,omitempty"`
+	ClientAuth       TLSClientAuth       `config:"client_authentication" yaml:"client_authentication,omitempty"` //`none`, `optional` or `required`
 	CASha256         []string            `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
 }
 

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -34,7 +34,7 @@ type ServerConfig struct {
 	CAs              []string            `config:"certificate_authorities" yaml:"certificate_authorities,omitempty"`
 	Certificate      CertificateConfig   `config:",inline" yaml:",inline"`
 	CurveTypes       []tlsCurveType      `config:"curve_types" yaml:"curve_types,omitempty"`
-	ClientAuth       TLSClientAuth       `config:"client_authentication" yaml:"client_authentication"` //`none`, `optional` or `required`
+	ClientAuth       *TLSClientAuth      `config:"client_authentication" yaml:"client_authentication,omitempty"` //`none`, `optional` or `required`
 	CASha256         []string            `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
 }
 
@@ -80,6 +80,11 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 		certs = []tls.Certificate{*cert}
 	}
 
+	clientAuth := TLSClientAuthNone
+	if config.ClientAuth != nil {
+		clientAuth = *config.ClientAuth
+	}
+
 	// return config if no error occurred
 	return &TLSConfig{
 		Versions:         config.Versions,
@@ -88,7 +93,7 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 		ClientCAs:        cas,
 		CipherSuites:     config.CipherSuites,
 		CurvePreferences: curves,
-		ClientAuth:       tls.ClientAuthType(config.ClientAuth),
+		ClientAuth:       tls.ClientAuthType(clientAuth),
 		CASha256:         config.CASha256,
 	}, nil
 }

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -34,7 +34,7 @@ type ServerConfig struct {
 	CAs              []string            `config:"certificate_authorities" yaml:"certificate_authorities,omitempty"`
 	Certificate      CertificateConfig   `config:",inline" yaml:",inline"`
 	CurveTypes       []tlsCurveType      `config:"curve_types" yaml:"curve_types,omitempty"`
-	ClientAuth       TLSClientAuth       `config:"client_authentication" yaml:"client_authentication,omitempty"` //`none`, `optional` or `required`
+	ClientAuth       TLSClientAuth       `config:"client_authentication" yaml:"client_authentication"` //`none`, `optional` or `required`
 	CASha256         []string            `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
 }
 

--- a/transport/tlscommon/server_config_test.go
+++ b/transport/tlscommon/server_config_test.go
@@ -38,7 +38,7 @@ func Test_ServerConfig_Serialization_ClientAuth(t *testing.T) {
 			},
 			CAs: []string{"/path/to/ca.crt"},
 		},
-		clientAuth: TLSClientAuthRequired,
+		clientAuth: TLSClientAuthNone, // NOTE the above config will be serialized with client_authentication: none
 	}, {
 		name: "no ca",
 		cfg: ServerConfig{

--- a/transport/tlscommon/server_config_test.go
+++ b/transport/tlscommon/server_config_test.go
@@ -1,0 +1,81 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tlscommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v2"
+)
+
+func Test_ServerConfig_Serialization_ClientAuth(t *testing.T) {
+	tests := []struct {
+		name       string
+		cfg        ServerConfig
+		clientAuth TLSClientAuth
+	}{{
+		name: "with ca",
+		cfg: ServerConfig{
+			Certificate: CertificateConfig{
+				Certificate: "/path/to/cert.crt",
+				Key:         "/path/to/cert.key",
+			},
+			CAs: []string{"/path/to/ca.crt"},
+		},
+		clientAuth: TLSClientAuthRequired,
+	}, {
+		name: "no ca",
+		cfg: ServerConfig{
+			Certificate: CertificateConfig{
+				Certificate: "/path/to/cert.crt",
+				Key:         "/path/to/cert.key",
+			},
+		},
+		clientAuth: TLSClientAuthNone,
+	}, {
+		name: "with ca and client auth none",
+		cfg: ServerConfig{
+			Certificate: CertificateConfig{
+				Certificate: "/path/to/cert.crt",
+				Key:         "/path/to/cert.key",
+			},
+			CAs:        []string{"/path/to/ca.crt"},
+			ClientAuth: TLSClientAuthNone,
+		},
+		clientAuth: TLSClientAuthNone, // FIXME test fails, it serializes to required
+	}, {
+		name: "no ca and client auth none",
+		cfg: ServerConfig{
+			Certificate: CertificateConfig{
+				Certificate: "/path/to/cert.crt",
+				Key:         "/path/to/cert.key",
+			},
+			ClientAuth: TLSClientAuthNone,
+		},
+		clientAuth: TLSClientAuthNone,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := yaml.Marshal(&tc.cfg)
+			require.NoError(t, err)
+			scfg := mustLoadServerConfig(t, string(p))
+			require.Equal(t, tc.clientAuth, scfg.ClientAuth)
+		})
+	}
+}

--- a/transport/tlscommon/server_config_test.go
+++ b/transport/tlscommon/server_config_test.go
@@ -58,7 +58,7 @@ func Test_ServerConfig_Serialization_ClientAuth(t *testing.T) {
 			CAs:        []string{"/path/to/ca.crt"},
 			ClientAuth: TLSClientAuthNone,
 		},
-		clientAuth: TLSClientAuthNone, // FIXME test fails, it serializes to required
+		clientAuth: TLSClientAuthNone,
 	}, {
 		name: "no ca and client auth none",
 		cfg: ServerConfig{
@@ -71,6 +71,7 @@ func Test_ServerConfig_Serialization_ClientAuth(t *testing.T) {
 		clientAuth: TLSClientAuthNone,
 	}}
 	for _, tc := range tests {
+		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			p, err := yaml.Marshal(&tc.cfg)
 			require.NoError(t, err)

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -74,7 +74,7 @@ var tlsCipherSuites = map[string]CipherSuite{
 var tlsCipherSuitesInverse = make(map[CipherSuite]string, len(tlsCipherSuites))
 var tlsRenegotiationSupportTypesInverse = make(map[TLSRenegotiationSupport]string, len(tlsRenegotiationSupportTypes))
 var tlsVerificationModesInverse = make(map[TLSVerificationMode]string, len(tlsVerificationModes))
-var tlsClientAuthInverse = make(map[TLSClientAuth]string, len(tlsClientAuthTypes))
+var tlsClientAuthTypesInverse = make(map[TLSClientAuth]string, len(tlsClientAuthTypes))
 
 // Init creates a inverse representation of the values mapping.
 func init() {
@@ -91,7 +91,7 @@ func init() {
 	}
 
 	for name, t := range tlsClientAuthTypes {
-		tlsClientAuthInverse[t] = name
+		tlsClientAuthTypesInverse[t] = name
 	}
 }
 
@@ -185,14 +185,14 @@ func (m *TLSVerificationMode) Unpack(in interface{}) error {
 }
 
 func (m TLSClientAuth) String() string {
-	if s, ok := tlsClientAuthInverse[m]; ok {
+	if s, ok := tlsClientAuthTypesInverse[m]; ok {
 		return s
 	}
 	return unknownType
 }
 
 func (m TLSClientAuth) MarshalText() ([]byte, error) {
-	if s, ok := tlsClientAuthInverse[m]; ok {
+	if s, ok := tlsClientAuthTypesInverse[m]; ok {
 		return []byte(s), nil
 	}
 	return nil, fmt.Errorf("could not marshal '%+v' to text", m)
@@ -205,7 +205,7 @@ func (m *TLSClientAuth) Unpack(s string) error {
 	}
 	mode, found := tlsClientAuthTypes[s]
 	if !found {
-		return fmt.Errorf("unknown client authentication mode'%v'", s)
+		return fmt.Errorf("unknown client authentication mode '%v'", s)
 	}
 
 	*m = mode

--- a/transport/tlscommon/types_test.go
+++ b/transport/tlscommon/types_test.go
@@ -177,6 +177,13 @@ func TestLoadTLSClientAuth(t *testing.T) {
     key: mycert.key
     client_authentication: required`,
 		expect: TLSClientAuthRequired,
+	}, {
+		name: "certificate_authorities is not null, no client_authentication",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key
+    certificate_authorities: [ca.crt]`,
+		expect: TLSClientAuthNone, // FIXME this test fails, it serialized to Required in CAs are present
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/transport/tlscommon/types_test.go
+++ b/transport/tlscommon/types_test.go
@@ -18,8 +18,10 @@
 package tlscommon
 
 import (
+	"fmt"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/stretchr/testify/assert"
 
 	"github.com/stretchr/testify/require"
@@ -65,4 +67,148 @@ func TestLoadWithEmptyVerificationMode(t *testing.T) {
 
 	assert.NoError(t, err)
 	assert.Equal(t, cfg.VerificationMode, VerifyFull)
+}
+
+func TestTLSClientAuthUnpack(t *testing.T) {
+	tests := []struct {
+		val    string
+		expect TLSClientAuth
+		err    error
+	}{{
+		val:    "",
+		expect: TLSClientAuthNone,
+		err:    nil,
+	}, {
+		val:    "none",
+		expect: TLSClientAuthNone,
+		err:    nil,
+	}, {
+		val:    "optional",
+		expect: TLSClientAuthOptional,
+		err:    nil,
+	}, {
+		val:    "required",
+		expect: TLSClientAuthRequired,
+		err:    nil,
+	}, {
+		val: "invalid",
+		err: fmt.Errorf("unknown client authentication mode 'invalid'"),
+	}}
+	for _, tc := range tests {
+		t.Run(tc.val, func(t *testing.T) {
+			var auth TLSClientAuth
+			err := auth.Unpack(tc.val)
+			assert.Equal(t, tc.expect, auth)
+			if tc.err != nil {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestTLSClientAuthMarshalText(t *testing.T) {
+	tests := []struct {
+		name   string
+		val    TLSClientAuth
+		expect []byte
+	}{{
+		name:   "no value",
+		expect: []byte("none"),
+	}, {
+		name:   "none",
+		val:    TLSClientAuthNone,
+		expect: []byte("none"),
+	}, {
+		name:   "optional",
+		val:    TLSClientAuthOptional,
+		expect: []byte("optional"),
+	}, {
+		name:   "required",
+		val:    TLSClientAuthRequired,
+		expect: []byte("required"),
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			p, err := tc.val.MarshalText()
+			assert.Equal(t, tc.expect, p)
+			assert.NoError(t, err)
+		})
+	}
+}
+
+func TestLoadTLSClientAuth(t *testing.T) {
+	tests := []struct {
+		name   string
+		yaml   string
+		expect TLSClientAuth
+	}{{
+		name: "no client auth value",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key`,
+		expect: TLSClientAuthNone,
+	}, {
+		name: "client auth empty",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key
+    client_authentication: `,
+		expect: TLSClientAuthNone,
+	}, {
+		name: "client auth none",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key
+    client_authentication: none`,
+		expect: TLSClientAuthNone,
+	}, {
+		name: "client auth optional",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key
+    client_authentication: optional`,
+		expect: TLSClientAuthOptional,
+	}, {
+		name: "client auth required",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key
+    client_authentication: required`,
+		expect: TLSClientAuthRequired,
+	}}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := mustLoadServerConfig(t, tc.yaml)
+			assert.Equal(t, tc.expect, cfg.ClientAuth)
+		})
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		_, err := loadServerConfig(`client_authentication: invalid`)
+		assert.Error(t, err)
+	})
+}
+
+func loadServerConfig(yamlStr string) (*ServerConfig, error) {
+	var cfg ServerConfig
+	config, err := config.NewConfigWithYAML([]byte(yamlStr), "")
+	if err != nil {
+		return nil, err
+	}
+
+	if err := config.Unpack(&cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func mustLoadServerConfig(t *testing.T, yamlStr string) *ServerConfig {
+	t.Helper()
+	cfg, err := loadServerConfig(yamlStr)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return cfg
 }

--- a/transport/tlscommon/types_test.go
+++ b/transport/tlscommon/types_test.go
@@ -183,7 +183,15 @@ func TestLoadTLSClientAuth(t *testing.T) {
     certificate: mycert.pem
     key: mycert.key
     certificate_authorities: [ca.crt]`,
-		expect: TLSClientAuthNone, // FIXME this test fails, it serialized to Required in CAs are present
+		expect: TLSClientAuthRequired, // NOTE Unpack will insert required if cas are present and no client_authentication is passed
+	}, {
+		name: "certificate_authorities is not null, client_authentication is none",
+		yaml: `
+    certificate: mycert.pem
+    key: mycert.key
+    client_authentication: none
+    certificate_authorities: [ca.crt]`,
+		expect: TLSClientAuthNone,
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/transport/tlscommon/types_test.go
+++ b/transport/tlscommon/types_test.go
@@ -142,48 +142,48 @@ func TestLoadTLSClientAuth(t *testing.T) {
 	tests := []struct {
 		name   string
 		yaml   string
-		expect TLSClientAuth
+		expect *TLSClientAuth
 	}{{
 		name: "no client auth value",
 		yaml: `
     certificate: mycert.pem
     key: mycert.key`,
-		expect: TLSClientAuthNone,
+		expect: nil,
 	}, {
 		name: "client auth empty",
 		yaml: `
     certificate: mycert.pem
     key: mycert.key
     client_authentication: `,
-		expect: TLSClientAuthNone,
+		expect: nil,
 	}, {
 		name: "client auth none",
 		yaml: `
     certificate: mycert.pem
     key: mycert.key
     client_authentication: none`,
-		expect: TLSClientAuthNone,
+		expect: &none,
 	}, {
 		name: "client auth optional",
 		yaml: `
     certificate: mycert.pem
     key: mycert.key
     client_authentication: optional`,
-		expect: TLSClientAuthOptional,
+		expect: &optional,
 	}, {
 		name: "client auth required",
 		yaml: `
     certificate: mycert.pem
     key: mycert.key
     client_authentication: required`,
-		expect: TLSClientAuthRequired,
+		expect: &required,
 	}, {
 		name: "certificate_authorities is not null, no client_authentication",
 		yaml: `
     certificate: mycert.pem
     key: mycert.key
     certificate_authorities: [ca.crt]`,
-		expect: TLSClientAuthRequired, // NOTE Unpack will insert required if cas are present and no client_authentication is passed
+		expect: &required, // NOTE Unpack will insert required if cas are present and no client_authentication is passed
 	}, {
 		name: "certificate_authorities is not null, client_authentication is none",
 		yaml: `
@@ -191,12 +191,16 @@ func TestLoadTLSClientAuth(t *testing.T) {
     key: mycert.key
     client_authentication: none
     certificate_authorities: [ca.crt]`,
-		expect: TLSClientAuthNone,
+		expect: &none,
 	}}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := mustLoadServerConfig(t, tc.yaml)
-			assert.Equal(t, tc.expect, cfg.ClientAuth)
+			if tc.expect == nil {
+				assert.Nil(t, cfg.ClientAuth)
+			} else {
+				assert.Equal(t, *tc.expect, *cfg.ClientAuth)
+			}
 		})
 	}
 


### PR DESCRIPTION
## What does this PR do?

add ServerConfig tags, export TLSClientAuth

## Why is it important?

We want to enable mTLS args as part of elastic-agent's CLI. These args should be parsed and passed to fleet-server. YAML tags are needed to allow for serialization.