### PR TITLE
Add optimized ReadAll for http responses

### DIFF
--- a/transport/httpcommon/httpcommon_test.go
+++ b/transport/httpcommon/httpcommon_test.go
@@ -18,6 +18,10 @@
 package httpcommon
 
 import (
+	"bytes"
+	"fmt"
+	"io"
+	"net/http"
 	"testing"
 	"time"
 
@@ -89,6 +93,117 @@ ssl:
 			require.NoError(t, err)
 
 			require.Equal(t, tc.expected, settings)
+		})
+	}
+}
+
+func TestReadAll(t *testing.T) {
+	size := 100
+	body := bytes.Repeat([]byte{'a'}, size)
+	cases := []struct {
+		name    string
+		resp    *http.Response
+		expBody []byte
+	}{
+		{
+			name: "reads known size",
+			resp: &http.Response{
+				ContentLength: int64(size),
+				Body:          io.NopCloser(bytes.NewBuffer(body)),
+			},
+			expBody: body,
+		},
+		{
+			name: "reads unknown size",
+			resp: &http.Response{
+				ContentLength: -1,
+				Body:          io.NopCloser(bytes.NewBuffer(body)),
+			},
+			expBody: body,
+		},
+		{
+			name: "supports empty with size=0",
+			resp: &http.Response{
+				ContentLength: 0,
+				Body:          io.NopCloser(bytes.NewBuffer(nil)),
+			},
+			expBody: []byte{},
+		},
+		{
+			name: "supports empty with unknown size",
+			resp: &http.Response{
+				ContentLength: -1,
+				Body:          io.NopCloser(bytes.NewBuffer(nil)),
+			},
+			expBody: []byte{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			actBody, err := ReadAll(tc.resp)
+			require.NoError(t, err)
+			require.Equal(t, tc.expBody, actBody)
+		})
+	}
+}
+
+func BenchmarkReadAll(b *testing.B) {
+	sizes := []int{
+		100,         // 100 bytes
+		100 * 1024,  // 100KB
+		1024 * 1024, // 1MB
+	}
+	for _, size := range sizes {
+		b.Run(fmt.Sprintf("size: %d", size), func(b *testing.B) {
+
+			// emulate a file or an HTTP response
+			generated := bytes.Repeat([]byte{'a'}, size)
+			content := bytes.NewReader(generated)
+			cases := []struct {
+				name string
+				resp *http.Response
+			}{
+				{
+					name: "unknown length",
+					resp: &http.Response{
+						ContentLength: -1,
+						Body:          io.NopCloser(content),
+					},
+				},
+				{
+					name: "known length",
+					resp: &http.Response{
+						ContentLength: int64(size),
+						Body:          io.NopCloser(content),
+					},
+				},
+			}
+
+			b.ResetTimer()
+
+			for _, tc := range cases {
+				b.Run(tc.name, func(b *testing.B) {
+					b.Run("io.ReadAll", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_, err := content.Seek(0, io.SeekStart) // reset
+							require.NoError(b, err)
+							data, err := io.ReadAll(tc.resp.Body)
+							require.NoError(b, err)
+							require.Equalf(b, size, len(data), "size does not match, expected %d, actual %d", size, len(data))
+						}
+					})
+					b.Run("bytes.Buffer+io.Copy", func(b *testing.B) {
+						for i := 0; i < b.N; i++ {
+							_, err := content.Seek(0, io.SeekStart) // reset
+							require.NoError(b, err)
+							data, err := ReadAll(tc.resp)
+							require.NoError(b, err)
+							require.Equalf(b, size, len(data), "size does not match, expected %d, actual %d", size, len(data))
+						}
+					})
+				})
+			}
 		})
 	}
 }


### PR DESCRIPTION
## What does this PR do?

1. When the body content length is known it's much faster to pre-allocated the entire buffer once.
2. When the length is unknown using `bytes.NewBuffer` + `io.Copy` is much faster.

Also, added benchmarks to prove the difference.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->



<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->
When we start using this function in main products it will significantly improve the performance.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Benchmark

```
goos: darwin
goarch: arm64
pkg: github.com/elastic/elastic-agent-libs/transport/httpcommon
BenchmarkReadAll/size:_100/unknown_length/io.ReadAll-10                       	    1000	      1232 ns/op	     576 B/op	       3 allocs/op
BenchmarkReadAll/size:_100/unknown_length/bytes.Buffer+io.Copy-10         	    1000	      1219 ns/op	     224 B/op	       4 allocs/op

BenchmarkReadAll/size:_100/known_length/io.ReadAll-10                     	    1000	      1275 ns/op	     576 B/op	       3 allocs/op
BenchmarkReadAll/size:_100/known_length/bytes.Buffer+io.Copy-10           	    1000	      1206 ns/op	     176 B/op	       3 allocs/op

BenchmarkReadAll/size:_102400/unknown_length/io.ReadAll-10                	    1000	     60858 ns/op	  514405 B/op	      24 allocs/op
BenchmarkReadAll/size:_102400/unknown_length/bytes.Buffer+io.Copy-10      	    1000	      9833 ns/op	  106640 B/op	       8 allocs/op

BenchmarkReadAll/size:_102400/known_length/io.ReadAll-10                  	    1000	     44423 ns/op	  514401 B/op	      24 allocs/op
BenchmarkReadAll/size:_102400/known_length/bytes.Buffer+io.Copy-10        	    1000	      9229 ns/op	  106592 B/op	       7 allocs/op

BenchmarkReadAll/size:_1048576/unknown_length/io.ReadAll-10               	    1000	    474003 ns/op	 5241202 B/op	      33 allocs/op
BenchmarkReadAll/size:_1048576/unknown_length/bytes.Buffer+io.Copy-10     	    1000	     81912 ns/op	 1048722 B/op	       8 allocs/op

BenchmarkReadAll/size:_1048576/known_length/io.ReadAll-10                 	    1000	    457693 ns/op	 5241196 B/op	      33 allocs/op
BenchmarkReadAll/size:_1048576/known_length/bytes.Buffer+io.Copy-10       	    1000	     80061 ns/op	 1048674 B/op	       7 allocs/op
PASS
ok  	github.com/elastic/elastic-agent-libs/transport/httpcommon	1.543s
```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/beats/issues/36151

