### PR TITLE
Add NewWithConfig init function to api/server.go

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -65,6 +65,17 @@ func New(log *logp.Logger, mux *http.ServeMux, c *config.C) (*Server, error) {
 	return &Server{mux: mux, srv: srv, l: l, config: cfg, log: log.Named("api")}, nil
 }
 
+// NewFromConfig creates a new API server from the given Config object
+func NewFromConfig(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, error) {
+	srv := &http.Server{ReadHeaderTimeout: cfg.Timeout}
+	l, err := makeListener(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Server{mux: mux, srv: srv, l: l, config: cfg, log: log.Named("api")}, nil
+}
+
 // AddRoute adds a route to the server mux
 func (s *Server) AddRoute(path string, handler HandlerFunc) {
 	s.mux.HandleFunc(path, handler)

--- a/api/server.go
+++ b/api/server.go
@@ -56,17 +56,16 @@ func New(log *logp.Logger, mux *http.ServeMux, c *config.C) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	srv := &http.Server{ReadHeaderTimeout: cfg.Timeout}
-	l, err := makeListener(cfg)
-	if err != nil {
-		return nil, err
-	}
-
-	return &Server{mux: mux, srv: srv, l: l, config: cfg, log: log.Named("api")}, nil
+	return new(log, mux, cfg)
 }
 
-// NewFromConfig creates a new API server from the given Config object
+// NewFromConfig creates a new API server from the given Config object.
 func NewFromConfig(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, error) {
+	return new(log, mux, cfg)
+}
+
+// new creates the server from a config struct
+func new(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, error) {
 	srv := &http.Server{ReadHeaderTimeout: cfg.Timeout}
 	l, err := makeListener(cfg)
 	if err != nil {


### PR DESCRIPTION
## What does this PR do?

This adds a new init method, `NewWithConfig`, that takes a `Config` struct, and not a `config.C` blob.

## Why is it important?

As part of https://github.com/elastic/elastic-agent/pull/4499 I'm refactoring the server setup process so the monitoring server can properly be reloaded by agent. I need this to clean up the init process, since agent will needlessly turn the Config struct into a config blob so it can pass it to `New`.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

