### PR TITLE
Add Addr() method to server

### DIFF
--- a/api/server.go
+++ b/api/server.go
@@ -101,6 +101,12 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	return s.srv.Shutdown(ctx)
 }
 
+// Addr returns the network address of the server
+// This is useful for tests, where we usually pass the port as `0` to get allocated a random free port
+func (s *Server) Addr() net.Addr {
+	return s.l.Addr()
+}
+
 // AttachHandler will attach a handler at the specified route and return an error instead of panicing.
 func (s *Server) AttachHandler(route string, h http.Handler) (err error) {
 	defer func() {


### PR DESCRIPTION
## What does this PR do?

This exposes the `net.Addr` interfaced used by the API server. This is done to help testing, since most of our tests are designed to fetch the nearest open port, so it's helpful to just have a method where we can return the addr and see what port we got allocated in the underlying listener.

## Why is it important?

This aids in writing tests.

## Checklist


- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

