### PR TITLE
Add repack support for ServerConfig.ClientAuth

### DIFF
--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -165,7 +165,6 @@ func (m *TLSVerificationMode) Unpack(in interface{}) error {
 		*m = VerifyFull
 		return nil
 	}
-
 	switch o := in.(type) {
 	case string:
 		if o == "" {
@@ -207,17 +206,30 @@ func (m TLSClientAuth) MarshalText() ([]byte, error) {
 	return nil, fmt.Errorf("could not marshal '%+v' to text", m)
 }
 
-func (m *TLSClientAuth) Unpack(s string) error {
-	if s == "" {
+func (m *TLSClientAuth) Unpack(in interface{}) error {
+	if in == nil {
 		*m = TLSClientAuthNone
 		return nil
 	}
-	mode, found := tlsClientAuthTypes[s]
-	if !found {
-		return fmt.Errorf("unknown client authentication mode '%v'", s)
-	}
+	switch o := in.(type) {
+	case string:
+		if o == "" {
+			*m = TLSClientAuthNone
+			return nil
+		}
+		mode, found := tlsClientAuthTypes[o]
+		if !found {
+			return fmt.Errorf("unknown client authentication mode '%v'", o)
+		}
 
-	*m = mode
+		*m = mode
+	case uint64:
+		*m = TLSClientAuth(o)
+	case int64: // underlying type is int so we need both uint64 and int64 as options for TLSClientAuth
+		*m = TLSClientAuth(o)
+	default:
+		return fmt.Errorf("client auth mode is an unknown type: %T", o)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## What does this PR do?

Follow up to #196 to allow fleet-server to repack the ServerConfig struct.
Extend the ClientAuthType unpack method to allow integer values and repack support. Add unit tests to verify behaviour.

## Why is it important?

output from policy in fleet-server needs to be able to merge structs

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/2784

