### PR TITLE
Define and document `log.type`

### DIFF
--- a/logp/typedloggercore.go
+++ b/logp/typedloggercore.go
@@ -23,6 +23,25 @@ import (
 	"go.uber.org/zap/zapcore"
 )
 
+// TypeKey is the default key to define log types.
+//
+// Different log types can be handled by different cores, the `typedLoggerCore`
+// allows for choosing a different core based on a key/value pair. TypeKey
+// is the default key for using the typedLoggerCore.
+//
+// It should be used in conjunction with the defined types on this package.
+const TypeKey = "log.type"
+
+// DefaultType is the default log type. If `log.type` is not defined a log
+// entry is considered of type `DefaultType`. Those log entries should follow
+// the default logging configuration.
+const DefaultType = "default"
+
+// EventType is the type for log entries containing event data.
+// Beats and Elastic-Agent use this with the `typedLoggerCore` to direct
+// those log entries to a different file.
+const EventType = "event"
+
 // typedLoggerCore takes two cores and directs logs entries to one of them
 // with the value of the field defined by the pair `key` and `value`
 //


### PR DESCRIPTION
## What does this PR do?

It defines and documents the `log.type` key and possible values.

Beats and Elastic-Agent already use those values.

## Why is it important?

It documents standard values to be used with the `typpedLoggerCore`

## Checklist

- [ ] ~~My code follows the style guidelines of this project~~
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

~~## Author's Checklist~~
~~## Related issues~~

- Relates https://github.com/elastic/beats/pull/38767
- Relates https://github.com/elastic/elastic-agent/pull/4549

