### PR TITLE
Disable logging when all outputs are disabled

### DIFF
--- a/logp/core.go
+++ b/logp/core.go
@@ -211,7 +211,7 @@ func createLogOutput(cfg Config, enab zapcore.LevelEnabler) (zapcore.Core, error
 	case SystemdEnvironment, ContainerEnvironment:
 		return makeStderrOutput(cfg, enab)
 	case MacOSServiceEnvironment, WindowsServiceEnvironment:
-		fallthrough
+		return makeFileOutput(cfg, enab)
 	default:
 		return zapcore.NewNopCore(), nil
 	}

--- a/logp/core.go
+++ b/logp/core.go
@@ -213,7 +213,7 @@ func createLogOutput(cfg Config, enab zapcore.LevelEnabler) (zapcore.Core, error
 	case MacOSServiceEnvironment, WindowsServiceEnvironment:
 		fallthrough
 	default:
-		return makeFileOutput(cfg, enab)
+		return zapcore.NewNopCore(), nil
 	}
 }
 

--- a/logp/core_test.go
+++ b/logp/core_test.go
@@ -612,6 +612,25 @@ func TestTypedLoggerCoreWith(t *testing.T) {
 	}
 }
 
+func TestCreateLogOutputAllDisabled(t *testing.T) {
+	cfg := DefaultConfig(DefaultEnvironment)
+	cfg.toIODiscard = false
+	cfg.toObserver = false
+	cfg.ToEventLog = false
+	cfg.ToFiles = false
+	cfg.ToStderr = false
+	cfg.ToSyslog = false
+
+	out, err := createLogOutput(cfg, zap.DebugLevel)
+	if err != nil {
+		t.Fatalf("did not expect an error calling createLogOutput: %s", err)
+	}
+
+	if out.Enabled(zap.DebugLevel) {
+		t.Fatal("the output must be disabled to all log levels")
+	}
+}
+
 func strField(key, val string) zapcore.Field {
 	return zapcore.Field{Type: zapcore.StringType, Key: key, String: val}
 }


### PR DESCRIPTION

## What does this PR do?

Disable logging when all outputs are disabled

## Why is it important?

Even when all log outputs were disabled in the configuration, we were still instantiating a file output. This is not the correct behaviour. If all log outputs are disabled, there should be no log output.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

~~## Author's Checklist~~


## Related issues
- https://github.com/elastic/beats/pull/38767

