### PR TITLE
Fix data race

### DIFF
--- a/logp/core.go
+++ b/logp/core.go
@@ -26,6 +26,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"sync/atomic"
 	"unsafe"
 
@@ -66,10 +67,13 @@ type coreLogger struct {
 type closerCore struct {
 	zapcore.Core
 	io.Closer
+	mutex sync.Mutex
 }
 
 func (c *closerCore) With(fields []zapcore.Field) zapcore.Core {
+	c.mutex.Lock()
 	c.Core = c.Core.With(fields)
+	c.mutex.Unlock()
 	return c
 }
 


### PR DESCRIPTION
## What does this PR do?

There was a possible data race when calling `With` on a `closerCore`. If `With` was called from different goroutines, a data race could occur.

The data race was detected in one of the Elastic-Agent tests: https://buildkite.com/elastic/elastic-agent/builds/9195#018fc641-ddba-4caa-98ac-e681d50553c5/106-588

## Why is it important?

It fixes a data race

## Checklist
- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

~~## Author's Checklist~~
~~## Related issues~~
