### PR TITLE
update `IsServerless()` to use correct Kibana APIs

### DIFF
--- a/kibana/client.go
+++ b/kibana/client.go
@@ -345,8 +345,6 @@ func (client *Client) readVersion() error {
 func (client *Client) GetVersion() version.V { return client.Version }
 
 // KibanaIsServerless returns true if we're talking to a serverless instance.
-// Right now we don't have an API to tell us if we're running against serverless or not, so this actual implementation is something of a hack.
-// see https://github.com/elastic/kibana/pull/164850
 func (client *Client) KibanaIsServerless() (bool, error) {
 
 	type apiStatus struct {

--- a/kibana/client_test.go
+++ b/kibana/client_test.go
@@ -59,6 +59,28 @@ func assertConnection(t *testing.T, URL string, expectedStatusCode int) {
 	assert.Error(t, err)
 }
 
+func TestIsServerless(t *testing.T) {
+	rawStatusCall := `{"name":"kb","uuid":"d2130570-f7d8-463b-bd67-8503150004d5","version":{"number":"8.15.0","build_hash":"13382875e99e8c97f4574d86eca07cac3be9edfc","build_number":75422,"build_snapshot":false,"build_flavor":"stateful","build_date":"2024-06-15T18:13:50.595Z"}}`
+
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(rawStatusCall))
+	}))
+	defer kibanaTS.Close()
+
+	conn := Connection{
+		URL:  kibanaTS.URL,
+		HTTP: http.DefaultClient,
+	}
+
+	testClient := Client{
+		Connection: conn,
+	}
+
+	got, err := testClient.KibanaIsServerless()
+	require.NoError(t, err)
+	require.False(t, got)
+}
+
 func TestErrorBadJson(t *testing.T) {
 	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusGone)


### PR DESCRIPTION


## What does this PR do?

closes https://github.com/elastic/elastic-agent-libs/issues/181

The initial implementation of `Client.IsServerless()` was implemented as a hack before we had any kind of API; this updates the method to use the `/api/status` endpoint that now reports the build type.

You can test this against a "real" Kibana instance like this:
```go
func TestServerlessInt(t *testing.T) {
	conn := Connection{
		URL:    "KIBANA_URL",
		HTTP:   http.DefaultClient,
		APIKey: "BEATS_API_KEY",
	}

	testClient := Client{
		Connection: conn,
	}

	got, err := testClient.KibanaIsServerless()
	require.NoError(t, err)
	require.True(t, got)

}
```

## Why is it important?

The current implementation is broken.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

