### PR TITLE
Use core-windows-2019 instead of unmaintained ci-windows-2019 build agent image

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -29,7 +29,7 @@ steps:
       - ".buildkite/scripts/test.ps1"
     agents:
       provider: "gcp"
-      image: "family/ci-windows-2019"
+      image: "family/core-windows-2019"
     artifact_paths:
       - "junit-*.xml"
 


### PR DESCRIPTION
## What does this PR do?
The image family `ci-windows-2019` has been unmaintained for a while and has been replaced by `core-windows-2019`. This PR updates them to this instead.

Related to [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)

## Why is it important?
To mitigate issues from [incident 505.](https://elastic.slack.com/archives/C078RND5G5C)
