### PR TITLE
[transport] make dial error logging compatible with ECS

### DIFF
--- a/transport/logging.go
+++ b/transport/logging.go
@@ -33,7 +33,7 @@ type loggingConn struct {
 
 func LoggingDialer(d Dialer, logger *logp.Logger) Dialer {
 	return DialerFunc(func(ctx context.Context, network, addr string) (net.Conn, error) {
-		logger := logger.With("network", network, "address", addr)
+		logger := logger.With("network.transport", network, "server.address", addr)
 		c, err := d.DialContext(ctx, network, addr)
 		if err != nil {
 			logger.Errorf("Error dialing %v", err)


### PR DESCRIPTION
## What does this PR do?

The LoggingDiler was logging an error with the field 'network' set as the network type (tcp/upd), however 'network' is an object in ECS, this would cause the log entry to be rejected by Elasticsearch.


## Why is it important?

It makes our logs compatible with ECS

## Checklist

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

~~## Author's Checklist~~
~~## Related issues~~

