### PR TITLE
Add optimized ReadAll function

### DIFF
--- a/api/npipe/listener_windows_test.go
+++ b/api/npipe/listener_windows_test.go
@@ -43,7 +43,8 @@ func TestHTTPOverNamedPipe(t *testing.T) {
 	})
 
 	go func() {
-		_ = http.Serve(l, mux)
+		_ = http.Serve(l, mux) //nolint:gosec // Serve does not support setting timeouts, it is fine for tests.
+
 	}()
 
 	c := http.Client{
@@ -52,7 +53,7 @@ func TestHTTPOverNamedPipe(t *testing.T) {
 		},
 	}
 
-	// nolint:noctx // for testing purposes
+	//nolint:noctx // for testing purposes
 	r, err := c.Get("http://npipe/echo-hello")
 	require.NoError(t, err)
 	body, err := httpcommon.ReadAll(r)

--- a/api/npipe/listener_windows_test.go
+++ b/api/npipe/listener_windows_test.go
@@ -21,10 +21,10 @@ package npipe
 
 import (
 	"fmt"
-	"io/ioutil"
 	"net/http"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -55,7 +55,7 @@ func TestHTTPOverNamedPipe(t *testing.T) {
 	// nolint:noctx // for testing purposes
 	r, err := c.Get("http://npipe/echo-hello")
 	require.NoError(t, err)
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := httpcommon.ReadAll(r)
 	require.NoError(t, err)
 	defer r.Body.Close()
 

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -70,10 +70,7 @@ func TestSocket(t *testing.T) {
 	}
 
 	t.Run("socket doesn't exist before", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "testsocket")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
-
+		tmpDir := t.TempDir()
 		sockFile := tmpDir + "/test.sock"
 
 		cfg := config.MustNewConfigFrom(map[string]interface{}{
@@ -101,11 +98,7 @@ func TestSocket(t *testing.T) {
 	})
 
 	t.Run("starting beat and recover a dangling socket file", func(t *testing.T) {
-		tmpDir, err := os.MkdirTemp("", "testsocket")
-		require.NoError(t, err)
-		defer os.RemoveAll(tmpDir)
-
-		sockFile := tmpDir + "/test.sock"
+		sockFile := t.TempDir() + "/test.sock"
 
 		// Create the socket before the server.
 		f, err := os.Create(sockFile)

--- a/api/server_test.go
+++ b/api/server_test.go
@@ -20,8 +20,6 @@ package api
 import (
 	"context"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"net"
 	"net/http"
 	"os"
@@ -32,6 +30,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
 const (
@@ -71,7 +70,7 @@ func TestSocket(t *testing.T) {
 	}
 
 	t.Run("socket doesn't exist before", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "testsocket")
+		tmpDir, err := os.MkdirTemp("", "testsocket")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmpDir)
 
@@ -102,7 +101,7 @@ func TestSocket(t *testing.T) {
 	})
 
 	t.Run("starting beat and recover a dangling socket file", func(t *testing.T) {
-		tmpDir, err := ioutil.TempDir("", "testsocket")
+		tmpDir, err := os.MkdirTemp("", "testsocket")
 		require.NoError(t, err)
 		defer os.RemoveAll(tmpDir)
 
@@ -161,7 +160,7 @@ func getResponse(t *testing.T, sockFile, url string) string {
 	require.NoError(t, err)
 	defer r.Body.Close()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := httpcommon.ReadAll(r)
 	require.NoError(t, err)
 	return string(body)
 }
@@ -188,7 +187,7 @@ func TestHTTP(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := httpcommon.ReadAll(r)
 	require.NoError(t, err)
 
 	assert.Equal(t, "ehlo!", string(body))
@@ -229,7 +228,7 @@ func TestAttachHandler(t *testing.T) {
 		require.NoError(t, err)
 	}()
 
-	body, err := io.ReadAll(r.Body)
+	body, err := httpcommon.ReadAll(r)
 	require.NoError(t, err)
 
 	assert.Equal(t, "test!", string(body))

--- a/api/server_windows_test.go
+++ b/api/server_windows_test.go
@@ -20,7 +20,6 @@
 package api
 
 import (
-	"io/ioutil"
 	"net/http"
 	"testing"
 
@@ -29,6 +28,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/api/npipe"
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
 func TestNamedPipe(t *testing.T) {
@@ -57,7 +57,7 @@ func TestNamedPipe(t *testing.T) {
 	require.NoError(t, err)
 	defer r.Body.Close()
 
-	body, err := ioutil.ReadAll(r.Body)
+	body, err := httpcommon.ReadAll(r)
 	require.NoError(t, err)
 
 	assert.Equal(t, "ehlo!", string(body))

--- a/api/server_windows_test.go
+++ b/api/server_windows_test.go
@@ -52,7 +52,7 @@ func TestNamedPipe(t *testing.T) {
 		},
 	}
 
-	// nolint:noctx // for testing purposes
+	//nolint:noctx // for testing purposes
 	r, err := c.Get("http://npipe/echo-hello")
 	require.NoError(t, err)
 	defer r.Body.Close()

--- a/file/fileinfo_test.go
+++ b/file/fileinfo_test.go
@@ -34,13 +34,14 @@ import (
 )
 
 func TestStat(t *testing.T) {
-	f, err := os.CreateTemp("", "teststat")
+	tmpDir := t.TempDir()
+	f, err := os.Create(filepath.Join(tmpDir, "teststat"))
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer os.Remove(f.Name())
+	defer f.Close()
 
-	link := filepath.Join(os.TempDir(), "teststat-link")
+	link := filepath.Join(tmpDir, "teststat-link")
 	if err := os.Symlink(f.Name(), link); err != nil {
 		t.Fatal(err)
 	}

--- a/file/fileinfo_test.go
+++ b/file/fileinfo_test.go
@@ -24,7 +24,6 @@
 package file_test
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -35,7 +34,7 @@ import (
 )
 
 func TestStat(t *testing.T) {
-	f, err := ioutil.TempFile("", "teststat")
+	f, err := os.CreateTemp("", "teststat")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/file/helper_test.go
+++ b/file/helper_test.go
@@ -29,14 +29,10 @@ import (
 )
 
 func TestSafeFileRotateExistingFile(t *testing.T) {
-	tempdir, err := os.MkdirTemp("", "")
-	assert.NoError(t, err)
-	defer func() {
-		assert.NoError(t, os.RemoveAll(tempdir))
-	}()
+	tempdir := t.TempDir()
 
 	// create an existing registry file
-	err = os.WriteFile(filepath.Join(tempdir, "registry"),
+	err := os.WriteFile(filepath.Join(tempdir, "registry"),
 		[]byte("existing filebeat"), 0x777)
 	assert.NoError(t, err)
 

--- a/file/helper_test.go
+++ b/file/helper_test.go
@@ -20,7 +20,6 @@
 package file
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -29,19 +28,19 @@ import (
 )
 
 func TestSafeFileRotateExistingFile(t *testing.T) {
-	tempdir, err := ioutil.TempDir("", "")
+	tempdir, err := os.MkdirTemp("", "")
 	assert.NoError(t, err)
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tempdir))
 	}()
 
 	// create an existing registry file
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry"),
+	err = os.WriteFile(filepath.Join(tempdir, "registry"),
 		[]byte("existing filebeat"), 0x777)
 	assert.NoError(t, err)
 
 	// create a new registry.new file
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
+	err = os.WriteFile(filepath.Join(tempdir, "registry.new"),
 		[]byte("new filebeat"), 0x777)
 	assert.NoError(t, err)
 
@@ -50,13 +49,13 @@ func TestSafeFileRotateExistingFile(t *testing.T) {
 		filepath.Join(tempdir, "registry.new"))
 	assert.NoError(t, err)
 
-	contents, err := ioutil.ReadFile(filepath.Join(tempdir, "registry"))
+	contents, err := os.ReadFile(filepath.Join(tempdir, "registry"))
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("new filebeat"), contents)
 
 	// do it again to make sure we deal with deleting the old file
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
+	err = os.WriteFile(filepath.Join(tempdir, "registry.new"),
 		[]byte("new filebeat 1"), 0x777)
 	assert.NoError(t, err)
 
@@ -64,13 +63,13 @@ func TestSafeFileRotateExistingFile(t *testing.T) {
 		filepath.Join(tempdir, "registry.new"))
 	assert.NoError(t, err)
 
-	contents, err = ioutil.ReadFile(filepath.Join(tempdir, "registry"))
+	contents, err = os.ReadFile(filepath.Join(tempdir, "registry"))
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("new filebeat 1"), contents)
 
 	// and again for good measure
 
-	err = ioutil.WriteFile(filepath.Join(tempdir, "registry.new"),
+	err = os.WriteFile(filepath.Join(tempdir, "registry.new"),
 		[]byte("new filebeat 2"), 0x777)
 	assert.NoError(t, err)
 
@@ -78,7 +77,7 @@ func TestSafeFileRotateExistingFile(t *testing.T) {
 		filepath.Join(tempdir, "registry.new"))
 	assert.NoError(t, err)
 
-	contents, err = ioutil.ReadFile(filepath.Join(tempdir, "registry"))
+	contents, err = os.ReadFile(filepath.Join(tempdir, "registry"))
 	assert.NoError(t, err)
 	assert.Equal(t, []byte("new filebeat 2"), contents)
 }

--- a/iobuf/iobuf.go
+++ b/iobuf/iobuf.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/iobuf/iobuf.go
+++ b/iobuf/iobuf.go
@@ -27,10 +27,8 @@ import (
 // treat an EOF as an error to be reported.
 //
 // This function is similar to io.ReadAll, but uses a bytes.Buffer to
-// accumulate the data, which has a more efficient growing algorithm.
-//
-// Compared to io.ReadAll, this implementation is more cpu and memory
-// efficient in general, specially for > 512 byte reads.
+// accumulate the data, which has a more efficient growing algorithm and
+// uses io.WriterTo if r implements it.
 func ReadAll(r io.Reader) ([]byte, error) {
 	var buf bytes.Buffer
 	_, err := io.Copy(&buf, r)

--- a/iobuf/iobuf.go
+++ b/iobuf/iobuf.go
@@ -33,27 +33,6 @@ import (
 // efficient in general, specially for > 512 byte reads.
 func ReadAll(r io.Reader) ([]byte, error) {
 	var buf bytes.Buffer
-	// if _, ok := r.(io.WriterTo); !ok {
-	// 	buf.Grow(512)
-	// 	b := buf.AvailableBuffer()
-	// 	for {
-	// 		n, err := r.Read(b[len(b):cap(b)])
-	// 		b = b[:len(b)+n]
-	// 		if err != nil {
-	// 			if err == io.EOF {
-	// 				err = nil
-	// 			}
-	// 			return b, err
-	// 		}
-
-	// 		if len(b) == cap(b) {
-	// 			// buffer full, leave to io.Copy to handle the rest
-	// 			buf.Write(b)
-	// 			break
-	// 		}
-	// 	}
-	// }
-
 	_, err := io.Copy(&buf, r)
 	return buf.Bytes(), err
 }

--- a/iobuf/iobuf.go
+++ b/iobuf/iobuf.go
@@ -1,0 +1,59 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iobuf
+
+import (
+	"bytes"
+	"io"
+)
+
+// ReadAll reads all data from r and returns it as a byte slice.
+// A successful call returns err == nil, not err == EOF. It does not
+// treat an EOF as an error to be reported.
+//
+// This function is similar to io.ReadAll, but uses a bytes.Buffer to
+// accumulate the data, which has a more efficient growing algorithm.
+//
+// Compared to io.ReadAll, this implementation is more cpu and memory
+// efficient in general, specially for > 512 byte reads.
+func ReadAll(r io.Reader) ([]byte, error) {
+	var buf bytes.Buffer
+	// if _, ok := r.(io.WriterTo); !ok {
+	// 	buf.Grow(512)
+	// 	b := buf.AvailableBuffer()
+	// 	for {
+	// 		n, err := r.Read(b[len(b):cap(b)])
+	// 		b = b[:len(b)+n]
+	// 		if err != nil {
+	// 			if err == io.EOF {
+	// 				err = nil
+	// 			}
+	// 			return b, err
+	// 		}
+
+	// 		if len(b) == cap(b) {
+	// 			// buffer full, leave to io.Copy to handle the rest
+	// 			buf.Write(b)
+	// 			break
+	// 		}
+	// 	}
+	// }
+
+	_, err := io.Copy(&buf, r)
+	return buf.Bytes(), err
+}

--- a/iobuf/iobuf_test.go
+++ b/iobuf/iobuf_test.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/iobuf/iobuf_test.go
+++ b/iobuf/iobuf_test.go
@@ -86,7 +86,10 @@ func BenchmarkReadAll(b *testing.B) {
 		buf := genFunc(size)
 		b.ResetTimer()
 		for i := 0; i < b.N; i++ {
-			buf.Seek(0, io.SeekStart) // reset
+			_, err := buf.Seek(0, io.SeekStart) // reset
+			if err != nil {
+				b.Fatal(err)
+			}
 			data, err := readFunc(buf)
 			if err != nil {
 				b.Fatal(err)

--- a/iobuf/iobuf_test.go
+++ b/iobuf/iobuf_test.go
@@ -1,0 +1,120 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package iobuf
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"log"
+	"strings"
+	"testing"
+)
+
+func ExampleReadAll() {
+	r := strings.NewReader("The quick brown fox jumps over the lazy dog.")
+
+	b, err := ReadAll(r)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	fmt.Printf("%s", b)
+
+	// Output:
+	// The quick brown fox jumps over the lazy dog.
+}
+
+// dumbReadSeeker is a ReadSeeker that does not implement the io.WriteTo optimization.
+type dumbReadSeeker struct {
+	rs io.ReadSeeker
+}
+
+func (r *dumbReadSeeker) Read(p []byte) (n int, err error) {
+	return r.rs.Read(p)
+}
+
+func (r *dumbReadSeeker) Seek(offset int64, whence int) (int64, error) {
+	return r.rs.Seek(offset, whence)
+}
+
+func genData(n int) io.ReadSeeker {
+	return bytes.NewReader(bytes.Repeat([]byte{'a'}, n))
+}
+
+func genDataDumb(n int) io.ReadSeeker {
+	return &dumbReadSeeker{rs: genData(n)}
+}
+
+func BenchmarkReadAll(b *testing.B) {
+	// Make sure we test different sizes to overcome initial buffer sizes:
+	// 	io.ReadAll uses a 512 bytes buffer
+	// 	bytes.Buffer uses a 64 bytes buffer
+	sizes := []int{
+		32,          // 32 bytes
+		64,          // 64 bytes
+		512,         // 512 bytes
+		10 * 1024,   // 10KB
+		100 * 1024,  // 100KB
+		1024 * 1024, // 1MB
+	}
+	sizesReadable := []string{
+		"32B",
+		"64B",
+		"512B",
+		"10KB",
+		"100KB",
+		"1MB",
+	}
+
+	benchFunc := func(b *testing.B, size int, genFunc func(n int) io.ReadSeeker, readFunc func(io.Reader) ([]byte, error)) {
+		buf := genFunc(size)
+		b.ResetTimer()
+		for i := 0; i < b.N; i++ {
+			buf.Seek(0, io.SeekStart) // reset
+			data, err := readFunc(buf)
+			if err != nil {
+				b.Fatal(err)
+			}
+			if len(data) != size {
+				b.Fatalf("size does not match, expected %d, actual %d", size, len(data))
+			}
+		}
+	}
+
+	for i, size := range sizes {
+		b.Run(fmt.Sprintf("size %s", sizesReadable[i]), func(b *testing.B) {
+			b.Run("io.ReadAll", func(b *testing.B) {
+				b.Run("WriterTo", func(b *testing.B) {
+					benchFunc(b, size, genData, io.ReadAll)
+				})
+				b.Run("Reader", func(b *testing.B) {
+					benchFunc(b, size, genDataDumb, io.ReadAll)
+				})
+			})
+			b.Run("ReadAll", func(b *testing.B) {
+				b.Run("WriterTo", func(b *testing.B) {
+					benchFunc(b, size, genData, ReadAll)
+				})
+				b.Run("Reader", func(b *testing.B) {
+					benchFunc(b, size, genDataDumb, ReadAll)
+				})
+			})
+		})
+	}
+}

--- a/keystore/file_keystore.go
+++ b/keystore/file_keystore.go
@@ -27,7 +27,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -278,24 +277,18 @@ func (k *FileKeystore) doSave(override bool) error {
 }
 
 func (k *FileKeystore) loadRaw() ([]byte, error) {
-	f, err := os.OpenFile(k.Path, os.O_RDONLY, filePermission)
+	raw, err := os.ReadFile(k.Path)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil, nil
 		}
 		return nil, err
 	}
-	defer f.Close()
 
 	if k.isStrictPerms {
 		if err := k.checkPermissions(k.Path); err != nil {
 			return nil, err
 		}
-	}
-
-	raw, err := ioutil.ReadAll(f)
-	if err != nil {
-		return nil, err
 	}
 
 	v := raw[0:len(version)]
@@ -362,7 +355,7 @@ func (k *FileKeystore) encrypt(reader io.Reader) (io.Reader, error) {
 		return nil, fmt.Errorf("could not create the keystore cipher to encrypt, error: %w", err)
 	}
 
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("could not read unencrypted data, error: %w", err)
 	}
@@ -380,7 +373,7 @@ func (k *FileKeystore) encrypt(reader io.Reader) (io.Reader, error) {
 
 // should receive an io.reader...
 func (k *FileKeystore) decrypt(reader io.Reader) (io.Reader, error) {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("could not read all the data from the encrypted file, error: %w", err)
 	}

--- a/keystore/file_keystore_test.go
+++ b/keystore/file_keystore_test.go
@@ -20,7 +20,6 @@ package keystore
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -348,7 +347,7 @@ func CreateAnExistingKeystore(path string) Keystore {
 
 // GetTemporaryKeystoreFile create a temporary file on disk to save the keystore.
 func GetTemporaryKeystoreFile() string {
-	path, err := ioutil.TempDir("", "testing")
+	path, err := os.MkdirTemp("", "testing")
 	if err != nil {
 		panic(err)
 	}

--- a/keystore/file_keystore_test.go
+++ b/keystore/file_keystore_test.go
@@ -321,7 +321,7 @@ func createAndReadKeystoreWithPassword(t *testing.T, password []byte) {
 }
 
 // CreateAnExistingKeystore creates a keystore with an existing key
-/// `output.elasticsearch.password` with the value `secret`.
+// "output.elasticsearch.password" with the value "secret".
 func CreateAnExistingKeystore(path string) Keystore {
 	keyStore, err := NewFileKeystore(path)
 	// Fail fast in the test suite

--- a/keystore/file_keystore_test.go
+++ b/keystore/file_keystore_test.go
@@ -36,7 +36,7 @@ var keyValue = "output.elasticsearch.password"
 var secretValue = []byte(",s3cRet~`! @#$%^&*()_-+={[}]|\\:;\"'<,>.?/")
 
 func TestCanCreateAKeyStore(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore, err := NewFileKeystore(path)
@@ -50,7 +50,7 @@ func TestCanCreateAKeyStore(t *testing.T) {
 }
 
 func TestCanReadAnExistingKeyStoreWithEmptyString(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	CreateAnExistingKeystore(path)
@@ -67,7 +67,7 @@ func TestCanReadAnExistingKeyStoreWithEmptyString(t *testing.T) {
 }
 
 func TestCanDeleteAKeyFromTheStoreAndPersistChanges(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	CreateAnExistingKeystore(path)
@@ -97,7 +97,7 @@ func TestFilePermissionOnCreate(t *testing.T) {
 		t.Skip("Permission check is not running on windows")
 	}
 
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 	CreateAnExistingKeystore(path)
 
@@ -115,7 +115,7 @@ func TestFilePermissionOnUpdate(t *testing.T) {
 		t.Skip("Permission check is not running on windows")
 	}
 
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore := CreateAnExistingKeystore(path)
@@ -141,7 +141,7 @@ func TestFilePermissionOnLoadWhenStrictIsOn(t *testing.T) {
 		t.Skip("Permission check is not running on windows")
 	}
 
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	// Create a world readable keystore file
@@ -154,7 +154,7 @@ func TestFilePermissionOnLoadWhenStrictIsOn(t *testing.T) {
 }
 
 func TestReturnsUsedKeysInTheStore(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore := CreateAnExistingKeystore(path)
@@ -170,7 +170,7 @@ func TestReturnsUsedKeysInTheStore(t *testing.T) {
 }
 
 func TestCannotDecryptKeyStoreWithWrongPassword(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString([]byte("password")))
@@ -211,7 +211,7 @@ func TestSecretWithASCIIEncodedSecret(t *testing.T) {
 }
 
 func TestGetConfig(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore := CreateAnExistingKeystore(path)
@@ -239,7 +239,7 @@ func TestGetConfig(t *testing.T) {
 }
 
 func TestShouldRaiseAndErrorWhenVersionDontMatch(t *testing.T) {
-	temporaryPath := GetTemporaryKeystoreFile()
+	temporaryPath := GetTemporaryKeystoreFile(t)
 	defer os.Remove(temporaryPath)
 
 	badVersion := `v2D/EQwnDNO7yZsjsRFVWGgbkZudhPxVhBkaQAVud66+tK4HRdfPrNrNNgSmhioDGrQ0z/VZpvbw68gb0G
@@ -258,7 +258,7 @@ func TestShouldRaiseAndErrorWhenVersionDontMatch(t *testing.T) {
 }
 
 func TestMissingEncryptedBlock(t *testing.T) {
-	temporaryPath := GetTemporaryKeystoreFile()
+	temporaryPath := GetTemporaryKeystoreFile(t)
 	defer os.Remove(temporaryPath)
 
 	badVersion := "v1"
@@ -276,7 +276,7 @@ func TestMissingEncryptedBlock(t *testing.T) {
 }
 
 func createAndReadKeystoreSecret(t *testing.T, password []byte, key string, value []byte) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
@@ -298,7 +298,7 @@ func createAndReadKeystoreSecret(t *testing.T, password []byte, key string, valu
 }
 
 func createAndReadKeystoreWithPassword(t *testing.T, password []byte) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keyStore, err := NewFileKeystoreWithPassword(path, NewSecureString(password))
@@ -346,12 +346,9 @@ func CreateAnExistingKeystore(path string) Keystore {
 }
 
 // GetTemporaryKeystoreFile create a temporary file on disk to save the keystore.
-func GetTemporaryKeystoreFile() string {
-	path, err := os.MkdirTemp("", "testing")
-	if err != nil {
-		panic(err)
-	}
-	return filepath.Join(path, "keystore")
+func GetTemporaryKeystoreFile(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(t.TempDir(), "keystore")
 }
 
 func TestRandomBytesLength(t *testing.T) {

--- a/keystore/keystore_test.go
+++ b/keystore/keystore_test.go
@@ -29,7 +29,7 @@ import (
 )
 
 func TestResolverWhenTheKeyDoesntExist(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keystore := CreateAnExistingKeystore(path)
@@ -40,7 +40,7 @@ func TestResolverWhenTheKeyDoesntExist(t *testing.T) {
 }
 
 func TestResolverWhenTheKeyExist(t *testing.T) {
-	path := GetTemporaryKeystoreFile()
+	path := GetTemporaryKeystoreFile(t)
 	defer os.Remove(path)
 
 	keystore := CreateAnExistingKeystore(path)

--- a/loader/config.go
+++ b/loader/config.go
@@ -20,7 +20,6 @@ package loader
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 
 	"gopkg.in/yaml.v2"
@@ -100,7 +99,7 @@ func NewConfigFrom(from interface{}, opts ...interface{}) (*Config, error) {
 		if closer, ok := from.(io.Closer); ok {
 			defer closer.Close()
 		}
-		fData, err := ioutil.ReadAll(in)
+		fData, err := io.ReadAll(in)
 		if err != nil {
 			return nil, err
 		}

--- a/loader/config_test.go
+++ b/loader/config_test.go
@@ -18,7 +18,6 @@
 package loader
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -56,7 +55,7 @@ func TestInputsResolveNOOP(t *testing.T) {
 		},
 	}
 
-	tmp, err := ioutil.TempDir("", "config")
+	tmp, err := os.MkdirTemp("", "config")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 
@@ -87,7 +86,7 @@ func testToMapStr(t *testing.T) {
 }
 
 func testLoadFiles(t *testing.T) {
-	tmp, err := ioutil.TempDir("", "watch")
+	tmp, err := os.MkdirTemp("", "watch")
 	require.NoError(t, err)
 	defer os.RemoveAll(tmp)
 
@@ -132,6 +131,6 @@ func testLoadFiles(t *testing.T) {
 func dumpToYAML(t *testing.T, out string, in interface{}) {
 	b, err := yaml.Marshal(in)
 	require.NoError(t, err)
-	err = ioutil.WriteFile(out, b, 0600)
+	err = os.WriteFile(out, b, 0600)
 	require.NoError(t, err)
 }

--- a/loader/config_test.go
+++ b/loader/config_test.go
@@ -55,11 +55,7 @@ func TestInputsResolveNOOP(t *testing.T) {
 		},
 	}
 
-	tmp, err := os.MkdirTemp("", "config")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
-
-	cfgPath := filepath.Join(tmp, "config.yml")
+	cfgPath := filepath.Join(t.TempDir(), "config.yml")
 	dumpToYAML(t, cfgPath, contents)
 
 	cfg, err := LoadFile(cfgPath)
@@ -86,9 +82,7 @@ func testToMapStr(t *testing.T) {
 }
 
 func testLoadFiles(t *testing.T) {
-	tmp, err := os.MkdirTemp("", "watch")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 
 	f1 := filepath.Join(tmp, "1.yml")
 	dumpToYAML(t, f1, map[string]interface{}{

--- a/loader/discover_test.go
+++ b/loader/discover_test.go
@@ -71,8 +71,7 @@ func TestDiscover(t *testing.T) {
 
 func withFiles(files []string, fn func(dst string, t *testing.T)) func(t *testing.T) {
 	return func(t *testing.T) {
-		tmp, _ := os.MkdirTemp("", "watch")
-		defer os.RemoveAll(tmp)
+		tmp := t.TempDir()
 
 		for _, file := range files {
 			path := filepath.Join(tmp, file)

--- a/loader/discover_test.go
+++ b/loader/discover_test.go
@@ -18,7 +18,6 @@
 package loader
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -72,7 +71,7 @@ func TestDiscover(t *testing.T) {
 
 func withFiles(files []string, fn func(dst string, t *testing.T)) func(t *testing.T) {
 	return func(t *testing.T) {
-		tmp, _ := ioutil.TempDir("", "watch")
+		tmp, _ := os.MkdirTemp("", "watch")
 		defer os.RemoveAll(tmp)
 
 		for _, file := range files {

--- a/periodic/ratelimited_test.go
+++ b/periodic/ratelimited_test.go
@@ -27,6 +27,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/iobuf"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -118,7 +119,7 @@ func TestRateLimitedLogger(t *testing.T) {
 					r.Stop()
 				}
 
-				bs, err := io.ReadAll(buff)
+				bs, err := iobuf.ReadAll(buff)
 				require.NoError(t, err, "failed reading logs")
 				logs := string(bs)
 				got := strings.TrimSpace(logs)
@@ -152,7 +153,7 @@ func TestRateLimitedLogger(t *testing.T) {
 
 		var logs string
 		assert.Eventually(t, func() bool {
-			bs, err := io.ReadAll(buff)
+			bs, err := iobuf.ReadAll(buff)
 			require.NoError(t, err, "failed reading logs")
 			logs = strings.TrimSpace(string(bs))
 
@@ -182,7 +183,7 @@ func TestRateLimitedLogger(t *testing.T) {
 
 		var logs string
 		assert.Eventually(t, func() bool {
-			bs, err := io.ReadAll(buff)
+			bs, err := iobuf.ReadAll(buff)
 			require.NoError(t, err, "failed reading logs")
 			logs = strings.TrimSpace(string(bs))
 

--- a/processors/dissect/dissect_test.go
+++ b/processors/dissect/dissect_test.go
@@ -20,7 +20,6 @@ package dissect
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"testing"
@@ -133,7 +132,7 @@ type dissectTest struct {
 var tests []dissectTest
 
 func init() {
-	content, err := ioutil.ReadFile("testdata/dissect_tests.json")
+	content, err := os.ReadFile("testdata/dissect_tests.json")
 	if err != nil {
 		os.Stderr.WriteString(fmt.Sprintf("could not read the content of 'dissect_tests', error: %s\n", err))
 		os.Exit(1)

--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -26,7 +26,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"io/ioutil"
 	"math/big"
 	"net"
 	"net/http"
@@ -38,6 +37,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/iobuf"
 )
 
 var ser int64 = 1
@@ -150,7 +150,7 @@ func TestCAPinning(t *testing.T) {
 				resp, err := client.Do(req)
 				require.NoError(t, err)
 				defer resp.Body.Close()
-				content, err := ioutil.ReadAll(resp.Body)
+				content, err := iobuf.ReadAll(resp.Body)
 				require.NoError(t, err)
 
 				assert.True(t, bytes.Equal(msg, content))
@@ -234,7 +234,7 @@ func TestCAPinning(t *testing.T) {
 		resp, err := client.Do(req)
 		require.NoError(t, err)
 		defer resp.Body.Close()
-		content, err := ioutil.ReadAll(resp.Body)
+		content, err := iobuf.ReadAll(resp.Body)
 		require.NoError(t, err)
 
 		assert.True(t, bytes.Equal(msg, content))


### PR DESCRIPTION
## What does this PR do?

This adds an optimized io.ReadAll that uses a bytes.Buffer + io.Copy
internally, improving the buffer growth ratio over the runtime append
and taking advange of io.WriterTo when available.

The only scenario where this optimized version is slower than io.ReadAll is
when reading < 512 bytes of a reader that does not implement io.WriterTo.

For now I only updated tests to use the new function as updating the code
requires more careful consideration.

While at it, migrate from the deprecated ioutil package to io.
```
goos: linux
goarch: amd64
pkg: github.com/elastic/elastic-agent-libs/iobuf
cpu: Intel(R) Xeon(R) CPU E5-2697A v4 @ 2.60GHz
BenchmarkReadAll/size_32B/io.ReadAll/WriterTo-32         	 7479658	       162.4 ns/op	     512 B/op	       1 allocs/op
BenchmarkReadAll/size_32B/io.ReadAll/Reader-32           	 7000012	       169.3 ns/op	     512 B/op	       1 allocs/op
BenchmarkReadAll/size_32B/ReadAll/WriterTo-32            	10630838	       112.3 ns/op	     112 B/op	       2 allocs/op
BenchmarkReadAll/size_32B/ReadAll/Reader-32              	 2111246	       567.3 ns/op	    1584 B/op	       3 allocs/op
BenchmarkReadAll/size_64B/io.ReadAll/WriterTo-32         	 7154652	       163.2 ns/op	     512 B/op	       1 allocs/op
BenchmarkReadAll/size_64B/io.ReadAll/Reader-32           	 7223264	       166.1 ns/op	     512 B/op	       1 allocs/op
BenchmarkReadAll/size_64B/ReadAll/WriterTo-32            	10400562	       113.5 ns/op	     112 B/op	       2 allocs/op
BenchmarkReadAll/size_64B/ReadAll/Reader-32              	 2129949	       558.7 ns/op	    1584 B/op	       3 allocs/op
BenchmarkReadAll/size_512B/io.ReadAll/WriterTo-32        	 2843871	       419.1 ns/op	    1408 B/op	       2 allocs/op
BenchmarkReadAll/size_512B/io.ReadAll/Reader-32          	 2871580	       413.1 ns/op	    1408 B/op	       2 allocs/op
BenchmarkReadAll/size_512B/ReadAll/WriterTo-32           	 4976233	       241.5 ns/op	     560 B/op	       2 allocs/op
BenchmarkReadAll/size_512B/ReadAll/Reader-32             	 2183186	       552.9 ns/op	    1584 B/op	       3 allocs/op
BenchmarkReadAll/size_10KB/io.ReadAll/WriterTo-32        	  142633	      8235 ns/op	   46080 B/op	      10 allocs/op
BenchmarkReadAll/size_10KB/io.ReadAll/Reader-32          	  148326	      8229 ns/op	   46080 B/op	      10 allocs/op
BenchmarkReadAll/size_10KB/ReadAll/WriterTo-32           	  574903	      2210 ns/op	   10288 B/op	       2 allocs/op
BenchmarkReadAll/size_10KB/ReadAll/Reader-32             	  147210	      7995 ns/op	   32304 B/op	       7 allocs/op
BenchmarkReadAll/size_100KB/io.ReadAll/WriterTo-32       	   13171	     90853 ns/op	  514304 B/op	      18 allocs/op
BenchmarkReadAll/size_100KB/io.ReadAll/Reader-32         	   12892	     91787 ns/op	  514304 B/op	      18 allocs/op
BenchmarkReadAll/size_100KB/ReadAll/WriterTo-32          	   51472	     22420 ns/op	  106544 B/op	       2 allocs/op
BenchmarkReadAll/size_100KB/ReadAll/Reader-32            	   21568	     55070 ns/op	  261680 B/op	      10 allocs/op
BenchmarkReadAll/size_1MB/io.ReadAll/WriterTo-32         	    1220	    983276 ns/op	 5241098 B/op	      27 allocs/op
BenchmarkReadAll/size_1MB/io.ReadAll/Reader-32           	    1089	    990818 ns/op	 5241100 B/op	      27 allocs/op
BenchmarkReadAll/size_1MB/ReadAll/WriterTo-32            	    4153	    294507 ns/op	 1048627 B/op	       2 allocs/op
BenchmarkReadAll/size_1MB/ReadAll/Reader-32              	    1195	    944781 ns/op	 4193852 B/op	      14 allocs/op
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates to https://github.com/elastic/beats/issues/36151

