### PR TITLE
testing/certutilcmd: add passphrase protected key support

### DIFF
--- a/testing/certutil/certutil.go
+++ b/testing/certutil/certutil.go
@@ -51,16 +51,16 @@ func NewRootCA() (*ecdsa.PrivateKey, *x509.Certificate, Pair, error) {
 		return nil, nil, Pair{}, fmt.Errorf("could not create private key: %w", err)
 	}
 
-	notBefore := time.Now()
-	notAfter := notBefore.Add(3 * time.Hour)
+	notBefore, notAfter := makeNotBeforeAndAfter()
 
 	rootTemplate := x509.Certificate{
-		DNSNames:     []string{"localhost"},
-		IPAddresses:  []net.IP{net.ParseIP("127.0.0.1")},
 		SerialNumber: big.NewInt(1653),
 		Subject: pkix.Name{
-			Organization: []string{"Gallifrey"},
-			CommonName:   "localhost",
+			Country:            []string{"Gallifrey"},
+			Locality:           []string{"The Capitol"},
+			OrganizationalUnit: []string{"Time Lords"},
+			Organization:       []string{"High Council of the Time Lords"},
+			CommonName:         "High Council",
 		},
 		NotBefore:             notBefore,
 		NotAfter:              notAfter,
@@ -125,16 +125,16 @@ func NewRootCA() (*ecdsa.PrivateKey, *x509.Certificate, Pair, error) {
 // If any error occurs during the generation process, a non-nil error is returned.
 func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, caCert *x509.Certificate) (*tls.Certificate, Pair, error) {
 
-	notBefore := time.Now()
-	notAfter := notBefore.Add(3 * time.Hour)
+	notBefore, notAfter := makeNotBeforeAndAfter()
 
 	certTemplate := &x509.Certificate{
 		DNSNames:     []string{name},
 		IPAddresses:  ips,
 		SerialNumber: big.NewInt(1658),
 		Subject: pkix.Name{
-			Organization: []string{"Gallifrey"},
-			CommonName:   name,
+			Locality:     []string{"anywhere in time and space"},
+			Organization: []string{"TARDIS"},
+			CommonName:   "Police Public Call Box",
 		},
 		NotBefore: notBefore,
 		NotAfter:  notAfter,
@@ -211,4 +211,11 @@ func NewRootAndChildCerts() (Pair, Pair, error) {
 	}
 
 	return rootPair, childPair, nil
+}
+
+func makeNotBeforeAndAfter() (time.Time, time.Time) {
+	now := time.Now()
+	notBefore := now.Add(-1 * time.Minute)
+	notAfter := now.Add(7 * 24 * time.Hour)
+	return notBefore, notAfter
 }

--- a/testing/certutil/cmd/main.go
+++ b/testing/certutil/cmd/main.go
@@ -19,20 +19,23 @@ package main
 
 import (
 	"crypto"
+	"crypto/rand"
 	"crypto/tls"
 	"crypto/x509"
+	"encoding/pem"
 	"flag"
 	"fmt"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/testing/certutil"
 )
 
 func main() {
-	var caPath, caKeyPath, dest, name, ipList string
+	var caPath, caKeyPath, dest, name, ipList, filePrefix, pass string
 	flag.StringVar(&caPath, "ca", "",
 		"File path for CA in PEM format")
 	flag.StringVar(&caKeyPath, "ca-key", "",
@@ -43,6 +46,10 @@ func main() {
 		"used as \"distinguished name\" and \"Subject Alternate Name values\" for the child certificate")
 	flag.StringVar(&ipList, "ips", "127.0.0.1",
 		"a comma separated list of IP addresses for the child certificate")
+	flag.StringVar(&filePrefix, "prefix", "current timestamp",
+		"a prefix to be added to the file name. If not provided a timestamp will be used")
+	flag.StringVar(&pass, "pass", "",
+		"a passphrase to encrypt the certificate key")
 	flag.Parse()
 
 	if caPath == "" && caKeyPath != "" || caPath != "" && caKeyPath == "" {
@@ -52,6 +59,16 @@ func main() {
 			caPath, caKeyPath)
 
 	}
+	if filePrefix == "" {
+		filePrefix = fmt.Sprintf("%d", time.Now().Unix())
+	}
+	filePrefix += "-"
+
+	wd, err := os.Getwd()
+	if err != nil {
+		fmt.Printf("error getting current working directory: %v\n", err)
+	}
+	fmt.Println("files will be witten to:", wd)
 
 	ips := strings.Split(ipList, ",")
 	var netIPs []net.IP
@@ -61,7 +78,6 @@ func main() {
 
 	var rootCert *x509.Certificate
 	var rootKey crypto.PrivateKey
-	var err error
 	if caPath == "" && caKeyPath == "" {
 		var pair certutil.Pair
 		rootKey, rootCert, pair, err = certutil.NewRootCA()
@@ -69,17 +85,50 @@ func main() {
 			panic(fmt.Errorf("could not create root CA certificate: %w", err))
 		}
 
-		savePair(dest, "ca", pair)
+		savePair(dest, filePrefix+"ca", pair)
 	} else {
 		rootKey, rootCert = loadCA(caPath, caKeyPath)
 	}
 
-	_, childPair, err := certutil.GenerateChildCert(name, netIPs, rootKey, rootCert)
+	childCert, childPair, err := certutil.GenerateChildCert(name, netIPs, rootKey, rootCert)
 	if err != nil {
 		panic(fmt.Errorf("error generating child certificate: %w", err))
 	}
 
-	savePair(dest, name, childPair)
+	savePair(dest, filePrefix+name, childPair)
+
+	if pass == "" {
+		return
+	}
+
+	fmt.Printf("passphrase present, encrypting \"%s\" certificate key\n",
+		name)
+	err = os.WriteFile(filePrefix+name+"-passphrase", []byte(pass), 0o600)
+	if err != nil {
+		panic(fmt.Errorf("error writing passphrase file: %w", err))
+	}
+
+	key, err := x509.MarshalPKCS8PrivateKey(childCert.PrivateKey)
+	if err != nil {
+		panic(fmt.Errorf("error getting ecdh.PrivateKey from the child's private key: %w", err))
+	}
+
+	encPem, err := x509.EncryptPEMBlock( //nolint:staticcheck // we need to drop support for this, but while we don't, it needs to be tested.
+		rand.Reader,
+		"EC PRIVATE KEY",
+		key,
+		[]byte(pass),
+		x509.PEMCipherAES128)
+	if err != nil {
+		panic(fmt.Errorf("failed encrypting agent child certificate key block: %v", err))
+	}
+
+	certKeyEnc := pem.EncodeToMemory(encPem)
+
+	err = os.WriteFile(filepath.Join(dest, filePrefix+name+"_enc-key.pem"), certKeyEnc, 0o600)
+	if err != nil {
+		panic(fmt.Errorf("could not save %s certificate encrypted key: %w", filePrefix+name+"_enc-key.pem", err))
+	}
 }
 
 func loadCA(caPath string, keyPath string) (crypto.PrivateKey, *x509.Certificate) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Add support to generate certificates with passphrase protected keys. It adds the `--pass` CLI flag, when passed, it'll generate a passphrase protected key and also save the key to disk.

It also adds the `--prefix` CLI flag, which value will prefix the files saved to disk. If not passed, it defaults to the current timestamp


## Why is it important?

 - It allows to use certutil for tests where the certificate key needs to be passphrase protected
 - the prefix facilitates to organise and move/copy/delete the files

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have added tests that prove my fix is effective or that my feature works

## How to test this PR:

 - generate certificates:
```shell
go run main.go --prefix server --pass server --ips 10.80.40.162,127.0.0.1
```
you should have
```
-rw------- 1 ainsoph ainsoph  288 Sep 20 18:25 server-ca_key.pem
-rw------- 1 ainsoph ainsoph  904 Sep 20 18:25 server-ca.pem
-rw------- 1 ainsoph ainsoph  399 Sep 20 18:25 server-localhost_enc-key.pem
-rw------- 1 ainsoph ainsoph  288 Sep 20 18:25 server-localhost_key.pem
-rw------- 1 ainsoph ainsoph    6 Sep 20 18:25 server-localhost-passphrase
-rw------- 1 ainsoph ainsoph  916 Sep 20 18:25 server-localhost.pem
```

- validate the server sertificate
```shell
$openssl verify -verbose  --show_chain -CAfile ./server-ca.pem server-localhost.pem

server-localhost.pem: OK
Chain:
depth=0: L = anywhere in time and space, O = TARDIS, CN = Police Public Call Box (untrusted)
depth=1: C = Gallifrey, L = The Capitol, O = High Council of the Time Lords, OU = Time Lords, CN = High Council
```

## Related issues

- Relates https://github.com/elastic/elastic-agent/issues/5490

