### PR TITLE
testing/certutil: add support to RSA

### DIFF
--- a/dev-tools/mage/gotool/noticer.go
+++ b/dev-tools/mage/gotool/noticer.go
@@ -26,7 +26,9 @@ var NoticeGenerator goNoticeGenerator = runGoNoticeGenerator
 
 func runGoNoticeGenerator(opts ...ArgOpt) error {
 	args := buildArgs(opts).build()
-	return sh.RunV("go-licence-detector", args...)
+
+	return sh.RunV("go",
+		append([]string{"run", "go.elastic.co/go-licence-detector"}, args...)...)
 }
 
 func (goNoticeGenerator) Dependencies(path string) ArgOpt   { return flagArg("-in", path) }

--- a/dev-tools/mage/install.go
+++ b/dev-tools/mage/install.go
@@ -22,21 +22,11 @@ import "github.com/elastic/elastic-agent-libs/dev-tools/mage/gotool"
 var (
 	// GoLicenserImportPath controls the import path used to install go-licenser.
 	GoLicenserImportPath = "github.com/elastic/go-licenser@latest"
-
-	// GoNoticeGeneratorImportPath controls the import path used to install go-licence-detector.
-	GoNoticeGeneratorImportPath = "go.elastic.co/go-licence-detector@latest"
 )
 
 // InstallGoLicenser target installs go-licenser
 func InstallGoLicenser() error {
 	return gotool.Install(
 		gotool.Install.Package(GoLicenserImportPath),
-	)
-}
-
-// InstallGoNoticeGen target installs go-licenser
-func InstallGoNoticeGen() error {
-	return gotool.Install(
-		gotool.Install.Package(GoNoticeGeneratorImportPath),
 	)
 }

--- a/dev-tools/mage/notice.go
+++ b/dev-tools/mage/notice.go
@@ -27,7 +27,7 @@ import (
 )
 
 func GenerateNotice(overrides, rules, noticeTemplate string) error {
-	mg.Deps(InstallGoNoticeGen, Deps.CheckModuleTidy)
+	mg.Deps(Deps.CheckModuleTidy)
 
 	err := gotool.Mod.Download(gotool.Download.All())
 	if err != nil {

--- a/testing/certutil/certutil.go
+++ b/testing/certutil/certutil.go
@@ -23,6 +23,7 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
@@ -39,81 +40,35 @@ type Pair struct {
 	Key  []byte
 }
 
-// NewRootCA generates a new x509 Certificate and returns:
+// NewRootCA generates a new x509 Certificate using ECDSA P-384 and returns:
 // - the private key
 // - the certificate
-// - the certificate in PEM format as a byte slice.
+// - the certificate and its key in PEM format as a byte slice.
 //
 // If any error occurs during the generation process, a non-nil error is returned.
-func NewRootCA() (*ecdsa.PrivateKey, *x509.Certificate, Pair, error) {
+func NewRootCA() (crypto.PrivateKey, *x509.Certificate, Pair, error) {
 	rootKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
 		return nil, nil, Pair{}, fmt.Errorf("could not create private key: %w", err)
 	}
 
-	notBefore, notAfter := makeNotBeforeAndAfter()
+	_, cert, pair, err := newRootCert(rootKey, &rootKey.PublicKey)
+	return rootKey, cert, pair, err
+}
 
-	rootTemplate := x509.Certificate{
-		SerialNumber: big.NewInt(1653),
-		Subject: pkix.Name{
-			Country:            []string{"Gallifrey"},
-			Locality:           []string{"The Capitol"},
-			OrganizationalUnit: []string{"Time Lords"},
-			Organization:       []string{"High Council of the Time Lords"},
-			CommonName:         "High Council",
-		},
-		NotBefore:             notBefore,
-		NotAfter:              notAfter,
-		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
-		BasicConstraintsValid: true,
-		IsCA:                  true,
-	}
-
-	rootCertRawBytes, err := x509.CreateCertificate(
-		rand.Reader, &rootTemplate, &rootTemplate, &rootKey.PublicKey, rootKey)
+// NewRSARootCA generates a new x509 Certificate using RSA with a 2048-bit key and returns:
+// - the private key
+// - the certificate
+// - the certificate and its key in PEM format as a byte slice.
+//
+// If any error occurs during the generation process, a non-nil error is returned.
+func NewRSARootCA() (crypto.PrivateKey, *x509.Certificate, Pair, error) {
+	rootKey, err := rsa.GenerateKey(rand.Reader, 2048)
 	if err != nil {
-		return nil, nil, Pair{}, fmt.Errorf("could not create CA: %w", err)
+		return nil, nil, Pair{}, fmt.Errorf("could not create private key: %w", err)
 	}
-
-	rootPrivKeyDER, err := x509.MarshalECPrivateKey(rootKey)
-	if err != nil {
-		return nil, nil, Pair{}, fmt.Errorf("could not marshal private key: %w", err)
-	}
-
-	// PEM private key
-	var rootPrivBytesOut []byte
-	rootPrivateKeyBuff := bytes.NewBuffer(rootPrivBytesOut)
-	err = pem.Encode(rootPrivateKeyBuff, &pem.Block{
-		Type: "EC PRIVATE KEY", Bytes: rootPrivKeyDER})
-	if err != nil {
-		return nil, nil, Pair{}, fmt.Errorf("could not pem.Encode private key: %w", err)
-	}
-
-	// PEM certificate
-	var rootCertBytesOut []byte
-	rootCertPemBuff := bytes.NewBuffer(rootCertBytesOut)
-	err = pem.Encode(rootCertPemBuff, &pem.Block{
-		Type: "CERTIFICATE", Bytes: rootCertRawBytes})
-	if err != nil {
-		return nil, nil, Pair{}, fmt.Errorf("could not pem.Encode certificate: %w", err)
-	}
-
-	// tls.Certificate
-	rootTLSCert, err := tls.X509KeyPair(
-		rootCertPemBuff.Bytes(), rootPrivateKeyBuff.Bytes())
-	if err != nil {
-		return nil, nil, Pair{}, fmt.Errorf("could not create key pair: %w", err)
-	}
-
-	rootCACert, err := x509.ParseCertificate(rootTLSCert.Certificate[0])
-	if err != nil {
-		return nil, nil, Pair{}, fmt.Errorf("could not parse certificate: %w", err)
-	}
-
-	return rootKey, rootCACert, Pair{
-		Cert: rootCertPemBuff.Bytes(),
-		Key:  rootPrivateKeyBuff.Bytes(),
-	}, nil
+	_, cert, pair, err := newRootCert(rootKey, &rootKey.PublicKey)
+	return rootKey, cert, pair, err
 }
 
 // GenerateChildCert generates a x509 Certificate as a child of caCert and
@@ -123,7 +78,13 @@ func NewRootCA() (*ecdsa.PrivateKey, *x509.Certificate, Pair, error) {
 // - the certificate and private key as a tls.Certificate
 //
 // If any error occurs during the generation process, a non-nil error is returned.
-func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, caCert *x509.Certificate) (*tls.Certificate, Pair, error) {
+func GenerateChildCert(
+	name string,
+	ips []net.IP,
+	priv crypto.PrivateKey,
+	pub crypto.PublicKey,
+	caPrivKey crypto.PrivateKey,
+	caCert *x509.Certificate) (*tls.Certificate, Pair, error) {
 
 	notBefore, notAfter := makeNotBeforeAndAfter()
 
@@ -143,18 +104,13 @@ func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, c
 			x509.ExtKeyUsageClientAuth, x509.ExtKeyUsageServerAuth},
 	}
 
-	privateKey, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
-	if err != nil {
-		return nil, Pair{}, fmt.Errorf("could not create private key: %w", err)
-	}
-
 	certRawBytes, err := x509.CreateCertificate(
-		rand.Reader, certTemplate, caCert, &privateKey.PublicKey, caPrivKey)
+		rand.Reader, certTemplate, caCert, pub, caPrivKey)
 	if err != nil {
 		return nil, Pair{}, fmt.Errorf("could not create CA: %w", err)
 	}
 
-	privateKeyDER, err := x509.MarshalECPrivateKey(privateKey)
+	privateKeyDER, err := x509.MarshalPKCS8PrivateKey(priv)
 	if err != nil {
 		return nil, Pair{}, fmt.Errorf("could not marshal private key: %w", err)
 	}
@@ -162,8 +118,8 @@ func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, c
 	// PEM private key
 	var privBytesOut []byte
 	privateKeyBuff := bytes.NewBuffer(privBytesOut)
-	err = pem.Encode(privateKeyBuff, &pem.Block{
-		Type: "EC PRIVATE KEY", Bytes: privateKeyDER})
+	err = pem.Encode(privateKeyBuff,
+		&pem.Block{Type: keyBlockType(priv), Bytes: privateKeyDER})
 	if err != nil {
 		return nil, Pair{}, fmt.Errorf("could not pem.Encode private key: %w", err)
 	}
@@ -191,28 +147,151 @@ func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, c
 	}, nil
 }
 
-// NewRootAndChildCerts returns a root CA and a child certificate and their keys
-// for "localhost" and "127.0.0.1".
+// NewRootAndChildCerts returns an ECDSA (P-384) root CA and a child certificate
+// and their keys for "localhost" and "127.0.0.1".
 func NewRootAndChildCerts() (Pair, Pair, error) {
 	rootKey, rootCACert, rootPair, err := NewRootCA()
 	if err != nil {
 		return Pair{}, Pair{}, fmt.Errorf("could not generate root CA: %w", err)
 	}
 
+	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
+	if err != nil {
+		return Pair{}, Pair{}, fmt.Errorf("could not create private key: %w", err)
+	}
+
+	childPair, err := defaultChildCert(rootKey, priv, &priv.PublicKey, rootCACert)
+	return rootPair, childPair, err
+}
+
+// NewRSARootAndChildCerts returns an RSA (2048-bit) root CA and a child
+// certificate and their keys for "localhost" and "127.0.0.1".
+func NewRSARootAndChildCerts() (Pair, Pair, error) {
+	rootKey, rootCACert, rootPair, err := NewRSARootCA()
+	if err != nil {
+		return Pair{}, Pair{}, fmt.Errorf("could not generate RSA root CA: %w", err)
+	}
+
+	priv, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return Pair{}, Pair{}, fmt.Errorf("could not create RSA private key: %w", err)
+	}
+
+	childPair, err := defaultChildCert(rootKey, priv, &priv.PublicKey, rootCACert)
+	return rootPair, childPair, err
+}
+
+// newRootCert creates a new self-signed root certificate using the provided
+// private key and public key.
+// It returns:
+//   - the private key,
+//   - the certificate,
+//   - a Pair containing the certificate and private key in PEM format.
+//
+// If an error occurs during certificate creation, it returns a non-nil error.
+func newRootCert(priv crypto.PrivateKey, pub crypto.PublicKey) (any, *x509.Certificate, Pair, error) {
+	notBefore, notAfter := makeNotBeforeAndAfter()
+
+	rootTemplate := x509.Certificate{
+		SerialNumber: big.NewInt(1653),
+		Subject: pkix.Name{
+			Country:            []string{"Gallifrey"},
+			Locality:           []string{"The Capitol"},
+			OrganizationalUnit: []string{"Time Lords"},
+			Organization:       []string{"High Council of the Time Lords"},
+			CommonName:         "High Council",
+		},
+		NotBefore:             notBefore,
+		NotAfter:              notAfter,
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	rootCertRawBytes, err := x509.CreateCertificate(
+		rand.Reader, &rootTemplate, &rootTemplate, pub, priv)
+	if err != nil {
+		return nil, nil, Pair{}, fmt.Errorf("could not create CA: %w", err)
+	}
+
+	rootPrivKeyDER, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		return nil, nil, Pair{}, fmt.Errorf("could not marshal private key: %w", err)
+	}
+
+	// PEM private key
+	var rootPrivBytesOut []byte
+	rootPrivateKeyBuff := bytes.NewBuffer(rootPrivBytesOut)
+	err = pem.Encode(rootPrivateKeyBuff,
+		&pem.Block{Type: keyBlockType(priv), Bytes: rootPrivKeyDER})
+	if err != nil {
+		return nil, nil, Pair{}, fmt.Errorf("could not pem.Encode private key: %w", err)
+	}
+
+	// PEM certificate
+	var rootCertBytesOut []byte
+	rootCertPemBuff := bytes.NewBuffer(rootCertBytesOut)
+	err = pem.Encode(rootCertPemBuff,
+		&pem.Block{Type: "CERTIFICATE", Bytes: rootCertRawBytes})
+	if err != nil {
+		return nil, nil, Pair{}, fmt.Errorf("could not pem.Encode certificate: %w", err)
+	}
+
+	// tls.Certificate
+	rootTLSCert, err := tls.X509KeyPair(
+		rootCertPemBuff.Bytes(), rootPrivateKeyBuff.Bytes())
+	if err != nil {
+		return nil, nil, Pair{}, fmt.Errorf("could not create key pair: %w", err)
+	}
+
+	rootCACert, err := x509.ParseCertificate(rootTLSCert.Certificate[0])
+	if err != nil {
+		return nil, nil, Pair{}, fmt.Errorf("could not parse certificate: %w", err)
+	}
+
+	return priv, rootCACert, Pair{
+		Cert: rootCertPemBuff.Bytes(),
+		Key:  rootPrivateKeyBuff.Bytes(),
+	}, nil
+}
+
+// defaultChildCert generates a child certificate for localhost and 127.0.0.1.
+// It returns the certificate and its key as a Pair and an error if any happens.
+func defaultChildCert(
+	rootPriv,
+	priv crypto.PrivateKey,
+	pub crypto.PublicKey,
+	rootCACert *x509.Certificate) (Pair, error) {
 	_, childPair, err :=
 		GenerateChildCert(
 			"localhost",
 			[]net.IP{net.ParseIP("127.0.0.1")},
-			rootKey,
+			priv,
+			pub,
+			rootPriv,
 			rootCACert)
 	if err != nil {
-		return Pair{}, Pair{}, fmt.Errorf(
+		return Pair{}, fmt.Errorf(
 			"could not generate child TLS certificate CA: %w", err)
 	}
-
-	return rootPair, childPair, nil
+	return childPair, nil
 }
 
+// keyBlockType returns the correct PEM block type for the given private key.
+func keyBlockType(priv crypto.PrivateKey) string {
+	switch priv.(type) {
+	case *rsa.PrivateKey:
+		return "RSA PRIVATE KEY"
+	case *ecdsa.PrivateKey:
+		return "EC PRIVATE KEY"
+	default:
+		panic(fmt.Errorf("unsupported private key type: %T", priv))
+	}
+}
+
+// makeNotBeforeAndAfter returns:
+//   - notBefore: 1 minute before now
+//   - notAfter: 7 days after now
 func makeNotBeforeAndAfter() (time.Time, time.Time) {
 	now := time.Now()
 	notBefore := now.Add(-1 * time.Minute)

--- a/testing/certutil/certutil_test.go
+++ b/testing/certutil/certutil_test.go
@@ -1,0 +1,86 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package certutil
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestECCertificates(t *testing.T) {
+	ecRootPair, ecChildPair, err := NewRootAndChildCerts()
+	require.NoError(t, err, "could not create EC certificates")
+
+	rsaRootPair, rsaChildPair, err := NewRSARootAndChildCerts()
+	require.NoError(t, err, "could not create EC certificates")
+
+	tcs := []struct {
+		name      string
+		rootPair  Pair
+		childPair Pair
+	}{
+		{
+			name:      "EC keys",
+			rootPair:  ecRootPair,
+			childPair: ecChildPair,
+		},
+		{
+			name:      "RSA keys",
+			rootPair:  rsaRootPair,
+			childPair: rsaChildPair,
+		},
+	}
+
+	for _, tc := range tcs {
+		t.Run(tc.name, func(t *testing.T) {
+			rootBlock, _ := pem.Decode(tc.rootPair.Cert)
+			if rootBlock == nil {
+				panic("Failed to parse certificate PEM")
+
+			}
+			root, err := x509.ParseCertificate(rootBlock.Bytes)
+			if err != nil {
+				panic("Failed to parse certificate: " + err.Error())
+			}
+
+			childBlock, _ := pem.Decode(tc.childPair.Cert)
+			if rootBlock == nil {
+				panic("Failed to parse certificate PEM")
+
+			}
+			child, err := x509.ParseCertificate(childBlock.Bytes)
+			if err != nil {
+				panic("Failed to parse certificate: " + err.Error())
+			}
+
+			caCertPool := x509.NewCertPool()
+			caCertPool.AddCert(root)
+
+			opts := x509.VerifyOptions{
+				Roots: caCertPool,
+			}
+
+			_, err = child.Verify(opts)
+			assert.NoError(t, err, "failed to verify child certificate")
+		})
+	}
+}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Enhance `testing/certutil`:
* add support to generate RSA certificates
* add `-rsa` cli to generate RSA certificates


## Why is it important?

RSA keys are needed to test:
 - https://github.com/elastic/elastic-agent/pull/5542

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test

the following should generate RSA keys:

```
cd testing/certutil/cmd
go run main.go --prefix rsa --pass rsa  --ips 10.80.40.42,127.0.0.1 -name localhost -rsa
```

verify the certificates with:
```
openssl x509 -in rsa-localhost.pem -text -noout | grep -E "Algorithm"

        Signature Algorithm: sha256WithRSAEncryption
            Public Key Algorithm: rsaEncryption
    Signature Algorithm: sha256WithRSAEncryption
```

the keys with:
```
openssl rsa -in rsa-ca_key.pem -text -noout

Private-Key: (2048 bit, 2 primes)
[...]
```

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/5542

