### PR TITLE
fix(logp): TestConfigureWithCore fails with Go 1.24

### DIFF
--- a/logp/core_test.go
+++ b/logp/core_test.go
@@ -711,7 +711,7 @@ func TestConfigureWithCore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected err: %s", err)
 	}
-	Info(testMsg)
+	Info("The quick brown %s jumped over the lazy %s.", "fox", "dog")
 	var r map[string]interface{}
 
 	err = json.Unmarshal(b.Bytes(), &r)


### PR DESCRIPTION
## What does this PR do?

The cmd/vet in Go 1.24 reports printf calls with non-const format and no args, causing one test in logp to fail.

See https://github.com/golang/go/issues/60529.

```
$ go install golang.org/dl/gotip@latest
$ gotip download
$ gotip test ./logp -count=1
logp/core_test.go:714:7: non-constant format string in call to github.com/elastic/elastic-agent-libs/logp.Info
FAIL    github.com/elastic/elastic-agent-libs/logp [build failed]
```

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

