### PR TITLE
[chore] - update agent policy schema to include `overrides` functionality.

### DIFF
--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -78,6 +78,7 @@ type AgentPolicy struct {
 	UnenrollTimeout    int                       `json:"unenroll_timeout,omitempty"`
 	InactivityTImeout  int                       `json:"inactivity_timeout,omitempty"`
 	AgentFeatures      []map[string]interface{}  `json:"agent_features,omitempty"`
+	Overrides          []map[string]interface{}  `json:"overrides,omitempty"`
 	IsProtected        bool                      `json:"is_protected"`
 }
 
@@ -110,6 +111,7 @@ type AgentPolicyUpdateRequest struct {
 	UnenrollTimeout    int                       `json:"unenroll_timeout,omitempty"`
 	InactivityTImeout  int                       `json:"inactivity_timeout,omitempty"`
 	AgentFeatures      []map[string]interface{}  `json:"agent_features,omitempty"`
+	Overrides          []map[string]interface{}  `json:"overrides,omitempty"`
 	IsProtected        *bool                     `json:"is_protected,omitempty"` // Optional bool for compatibility with the older pre 8.9.0 stack
 }
 

--- a/logp/core_test.go
+++ b/logp/core_test.go
@@ -711,7 +711,7 @@ func TestConfigureWithCore(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected err: %s", err)
 	}
-	Info(testMsg)
+	Info("The quick brown %s jumped over the lazy %s.", "fox", "dog")
 	var r map[string]interface{}
 
 	err = json.Unmarshal(b.Bytes(), &r)


### PR DESCRIPTION
You can use this setting to override custom settings which aren't available in fleet UI. 
For eg. https://www.elastic.co/guide/en/fleet/current/enable-custom-policy-settings.html and https://support.elastic.dev/knowledge/view/06b69893

This will make things much easier for https://github.com/elastic/elastic-agent/pull/5648