### PR TITLE
certutil: restore previous GenerateChildCert signature

### DIFF
--- a/testing/certutil/certutil.go
+++ b/testing/certutil/certutil.go
@@ -101,7 +101,7 @@ func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, c
 
 // GenerateGenericChildCert generates a x509 Certificate using priv and pub
 // as the certificate's private and public keys and as a child of caCert.
-// Use this function if oyu need fine control over keys or ips and certificate name,
+// Use this function if you need fine control over keys or ips and certificate name,
 // otherwise prefer GenerateChildCert or NewRootAndChildCerts/NewRSARootAndChildCerts
 //
 // It returns the following:

--- a/testing/certutil/certutil_test.go
+++ b/testing/certutil/certutil_test.go
@@ -26,7 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestECCertificates(t *testing.T) {
+func TestCertificates(t *testing.T) {
 	ecRootPair, ecChildPair, err := NewRootAndChildCerts()
 	require.NoError(t, err, "could not create EC certificates")
 

--- a/testing/certutil/cmd/main.go
+++ b/testing/certutil/cmd/main.go
@@ -84,7 +84,7 @@ func main() {
 	rootCert, rootKey := getCA(rsa, caPath, caKeyPath, dest, filePrefix)
 	priv, pub := generateKey(rsa)
 
-	childCert, childPair, err := certutil.GenerateChildCert(
+	childCert, childPair, err := certutil.GenerateGenericChildCert(
 		name,
 		netIPs,
 		priv,

--- a/testing/certutil/cmd/main.go
+++ b/testing/certutil/cmd/main.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-// nolint:errorlint,forbidigo // it's a cli application
+//nolint:errorlint,forbidigo // it's a cli application
 package main
 
 import (


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

It restores the previous GenerateChildCert to undo a breaking change and creates GenerateGenericChildCert with the new signature

## Why is it important?

The breaking change on `GenerateChildCert` is affecting several integration tests on elastic-agent

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works



## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/5648
- Relates https://github.com/elastic/elastic-agent/pull/5542
