### PR TITLE
certutil: Add functional options

### DIFF
--- a/testing/certutil/cmd/main.go
+++ b/testing/certutil/cmd/main.go
@@ -39,19 +39,20 @@ import (
 )
 
 func main() {
-	var caPath, caKeyPath, dest, name, ipList, filePrefix, pass string
-	var rsa bool
+	var caPath, caKeyPath, dest, name, ipList, prefix, pass string
+	var rsaflag bool
 	flag.StringVar(&caPath, "ca", "",
 		"File path for CA in PEM format")
 	flag.StringVar(&caKeyPath, "ca-key", "",
 		"File path for the CA key in PEM format")
-	flag.BoolVar(&rsa, "rsa", false,
+	flag.BoolVar(&rsaflag, "rsaflag", false,
 		"")
+	// TODO: accept multiple DNS names
 	flag.StringVar(&name, "name", "localhost",
 		"used as \"distinguished name\" and \"Subject Alternate Name values\" for the child certificate")
 	flag.StringVar(&ipList, "ips", "127.0.0.1",
 		"a comma separated list of IP addresses for the child certificate")
-	flag.StringVar(&filePrefix, "prefix", "current timestamp",
+	flag.StringVar(&prefix, "prefix", "current timestamp",
 		"a prefix to be added to the file name. If not provided a timestamp will be used")
 	flag.StringVar(&pass, "pass", "",
 		"a passphrase to encrypt the certificate key")
@@ -64,10 +65,10 @@ func main() {
 			caPath, caKeyPath)
 
 	}
-	if filePrefix == "" {
-		filePrefix = fmt.Sprintf("%d", time.Now().Unix())
+	if prefix == "current timestamp" {
+		prefix = fmt.Sprintf("%d", time.Now().Unix())
 	}
-	filePrefix += "-"
+	filePrefix := prefix + "-"
 
 	wd, err := os.Getwd()
 	if err != nil {
@@ -81,16 +82,17 @@ func main() {
 		netIPs = append(netIPs, net.ParseIP(ip))
 	}
 
-	rootCert, rootKey := getCA(rsa, caPath, caKeyPath, dest, filePrefix)
-	priv, pub := generateKey(rsa)
+	rootCert, rootKey := getCA(rsaflag, caPath, caKeyPath, dest, prefix)
+	priv, pub := generateKey(rsaflag)
 
 	childCert, childPair, err := certutil.GenerateGenericChildCert(
 		name,
-		netIPs,
+		nil, // netIPs,
 		priv,
 		pub,
 		rootKey,
-		rootCert)
+		rootCert,
+		certutil.WithCNPrefix(prefix))
 	if err != nil {
 		panic(fmt.Errorf("error generating child certificate: %w", err))
 	}
@@ -114,7 +116,7 @@ func main() {
 	}
 
 	blockType := "EC PRIVATE KEY"
-	if rsa {
+	if rsaflag {
 		blockType = "RSA PRIVATE KEY"
 	}
 	encPem, err := x509.EncryptPEMBlock( //nolint:staticcheck // we need to drop support for this, but while we don't, it needs to be tested.
@@ -153,7 +155,7 @@ func generateKey(useRSA bool) (crypto.PrivateKey, crypto.PublicKey) {
 	return priv, &priv.PublicKey
 }
 
-func getCA(rsa bool, caPath, caKeyPath, dest, filePrefix string) (*x509.Certificate, crypto.PrivateKey) {
+func getCA(rsa bool, caPath, caKeyPath, dest, prefix string) (*x509.Certificate, crypto.PrivateKey) {
 	var rootCert *x509.Certificate
 	var rootKey crypto.PrivateKey
 	var err error
@@ -165,12 +167,12 @@ func getCA(rsa bool, caPath, caKeyPath, dest, filePrefix string) (*x509.Certific
 		}
 
 		var pair certutil.Pair
-		rootKey, rootCert, pair, err = caFn()
+		rootKey, rootCert, pair, err = caFn(certutil.WithCNPrefix(prefix))
 		if err != nil {
 			panic(fmt.Errorf("could not create root CA certificate: %w", err))
 		}
 
-		savePair(dest, filePrefix+"ca", pair)
+		savePair(dest, prefix+"-ca", pair)
 	} else {
 		rootKey, rootCert = loadCA(caPath, caKeyPath)
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Add functional options to New*RootCA and Generate*ChildCert to allow setting a prefix for the CN and multiple DNS names.

Also, it fixes `GenerateChildCert` generating a RSA instead of EC certificate

## Why is it important?

 - set CN prefix: when generating and using multiple certificates, such as to configure mTLS, it's hard to debug any issue if all certificates have the same CN
 - add multiple DNS names: when trying to simulate a real situation, it might require a certificate to have multiple DNSs

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- Relates https://github.com/elastic/elastic-agent/issues/4903

