### PR TITLE
certutil: add functional options

### DIFF
--- a/testing/certutil/certutil.go
+++ b/testing/certutil/certutil.go
@@ -101,7 +101,7 @@ func NewRSARootCA(opts ...Option) (crypto.PrivateKey, *x509.Certificate, Pair, e
 func GenerateChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey, caCert *x509.Certificate, opts ...Option) (*tls.Certificate, Pair, error) {
 	priv, err := ecdsa.GenerateKey(elliptic.P384(), rand.Reader)
 	if err != nil {
-		return nil, Pair{}, fmt.Errorf("could not create RSA private key: %w", err)
+		return nil, Pair{}, fmt.Errorf("could not create ECDSA private key: %w", err)
 	}
 
 	cert, childPair, err :=
@@ -144,7 +144,7 @@ func GenerateRSAChildCert(name string, ips []net.IP, caPrivKey crypto.PrivateKey
 			opts...)
 	if err != nil {
 		return nil, Pair{}, fmt.Errorf(
-			"could not generate child TLS certificate CA: %w", err)
+			"could not generate child TLS certificate: %w", err)
 	}
 
 	return cert, childPair, nil


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Add functional options to New*RootCA and Generate*ChildCert to allow setting a prefix for the CN and multiple DNS names.

Also, it fixes `GenerateChildCert` generating a RSA instead of EC certificate

## Why is it important?

 - set CN prefix: when generating and using multiple certificates, such as to configure mTLS, it's hard to debug any issue if all certificates have the same CN
 - add multiple DNS names: when trying to simulate a real situation, it might require a certificate to have multiple DNSs

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- Relates https://github.com/elastic/elastic-agent/issues/4903

