### PR TITLE
Add a function to perform case-insensitive search in mapstr.M

### DIFF
--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -188,7 +188,7 @@ func (m M) FindFold(key string) (matchedKey string, value interface{}, err error
 	// start with the root
 	current := m
 	// allocate only once
-	mapType := false
+	var mapType bool
 
 	for i, segment := range path {
 		if !found {

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -41,6 +41,10 @@ const (
 var (
 	// ErrKeyNotFound indicates that the specified key was not found.
 	ErrKeyNotFound = errors.New("key not found")
+	// ErrKeyCollision indicates that during the case-insensitive search multiple keys matched
+	ErrKeyCollision = errors.New("key collision")
+	// ErrNotMapType indicates that the given value is not map type
+	ErrNotMapType = errors.New("value is not a map")
 )
 
 // EventMetadata contains fields and tags that can be added to an event via
@@ -172,6 +176,62 @@ func (m M) HasKey(key string) (bool, error) {
 	return hasKey, err
 }
 
+// FindFold accepts a key and traverses the map trying to match every key segment
+// using `strings.FindFold` (case-insensitive match) and returns the actual
+// key of the map that matched the given key and the value stored under this key.
+// Returns `ErrKeyCollision` if multiple keys match the same request.
+// Returns `ErrNotMapType` when one of the values on the path is not a map and cannot be traversed.
+func (m M) FindFold(key string) (matchedKey string, value interface{}, err error) {
+	path := strings.Split(key, ".")
+	// the initial value must be `true` for the first iteration to work
+	found := true
+	// start with the root
+	current := m
+	// allocate only once
+	mapType := false
+
+	for i, segment := range path {
+		if !found {
+			return "", nil, ErrKeyNotFound
+		}
+		found = false
+
+		// we have to go through the list of all key on each level to detect case-insensitive collisions
+		for k := range current {
+			if !strings.EqualFold(segment, k) {
+				continue
+			}
+			// if already found on this level, it's a collision
+			if found {
+				return "", nil, fmt.Errorf("key collision on the same path %q, previous match - %q, another subkey - %q: %w", key, matchedKey, k, ErrKeyCollision)
+			}
+
+			// mark for collision detection
+			found = true
+
+			// build the result with the currently matched segment
+			matchedKey += k
+			value = current[k]
+
+			// if it's the last segment, we don't need to go deeper
+			if i == len(path)-1 {
+				continue
+			}
+
+			// if it's not the last segment we put the separator dot
+			matchedKey += "."
+
+			// go one level deeper
+			current, mapType = tryToMapStr(current[k])
+			if !mapType {
+				return "", nil, fmt.Errorf("cannot continue path %q (full: %q), next element is not a map: %w", matchedKey, key, ErrNotMapType)
+			}
+		}
+	}
+
+	return matchedKey, value, nil
+}
+
 // GetValue gets a value from the map. If the key does not exist then an error
 // is returned.
 func (m M) GetValue(key string) (interface{}, error) {
@@ -266,10 +326,12 @@ func (m M) Format(f fmt.State, c rune) {
 // Flatten flattens the given M and returns a flat M.
 //
 // Example:
-//   "hello": M{"world": "test" }
+//
+//	"hello": M{"world": "test" }
 //
 // This is converted to:
-//   "hello.world": "test"
+//
+//	"hello.world": "test"
 //
 // This can be useful for testing or logging.
 func (m M) Flatten() M {
@@ -299,10 +361,12 @@ func flatten(prefix string, in, out M) M {
 // FlattenKeys flattens given MapStr keys and returns a containing array pointer
 //
 // Example:
-//   "hello": MapStr{"world": "test" }
+//
+//	"hello": MapStr{"world": "test" }
 //
 // This is converted to:
-//   ["hello.world"]
+//
+//	["hello.world"]
 func (m M) FlattenKeys() *[]string {
 	out := make([]string, 0)
 	flattenKeys("", m, &out)

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1154,6 +1154,12 @@ func TestFindFold(t *testing.T) {
 			expVal: field1level2,
 		},
 		{
+			name:   "returns normal key, one level",
+			key:    "level1_Field1",
+			expKey: "level1_Field1",
+			expVal: field1level1,
+		},
+		{
 			name:   "returns case-insensitive full match",
 			key:    "level1_field1.level2_field1.level3_field1",
 			expKey: "level1_Field1.level2_Field1.level3_Field1",
@@ -1164,6 +1170,12 @@ func TestFindFold(t *testing.T) {
 			key:    "level1_field1.level2_field1",
 			expKey: "level1_Field1.level2_Field1",
 			expVal: field1level2,
+		},
+		{
+			name:   "returns case-insensitive one-level match",
+			key:    "level1_field1",
+			expKey: "level1_Field1",
+			expVal: field1level1,
 		},
 		{
 			name:   "returns collision error",


### PR DESCRIPTION
## What does this PR do?

`FindFold` (similar to `strings.EqualFold`) traverses the map and tries to perform a case-insensitive match of each key segment on each map level.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

It's a prerequisite for https://github.com/elastic/beats/pull/41424

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/beats/pull/41424
- Relates https://github.com/elastic/beats/issues/22254

