### PR TITLE
change toMapStr to public method & bug fix

### DIFF
--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -229,6 +229,10 @@ func (m M) FindFold(key string) (matchedKey string, value interface{}, err error
 		}
 	}
 
+	if !found {
+		return "", nil, ErrKeyNotFound
+	}
+
 	return matchedKey, value, nil
 }
 
@@ -462,7 +466,7 @@ func mergeFieldsGetDestMap(target, from M, underRoot bool) (M, error) {
 		} else {
 			// Use existing 'fields' value.
 			var err error
-			destMap, err = toMapStr(f)
+			destMap, err = ToMapStr(f)
 			if err != nil {
 				return nil, err
 			}
@@ -515,7 +519,7 @@ func AddTagsWithKey(ms M, key string, tags []string) error {
 // toMapStr performs a type assertion on v and returns a MapStr. v can be either
 // a MapStr or a map[string]interface{}. If it's any other type or nil then
 // an error is returned.
-func toMapStr(v interface{}) (M, error) {
+func ToMapStr(v interface{}) (M, error) {
 	m, ok := tryToMapStr(v)
 	if !ok {
 		return nil, fmt.Errorf("expected map but type is %T", v)
@@ -571,7 +575,7 @@ func mapFind(
 			}
 		}
 
-		v, err := toMapStr(d)
+		v, err := ToMapStr(d)
 		if err != nil {
 			return "", nil, nil, false, err
 		}

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -516,7 +516,7 @@ func AddTagsWithKey(ms M, key string, tags []string) error {
 	return nil
 }
 
-// toMapStr performs a type assertion on v and returns a MapStr. v can be either
+// ToMapStr performs a type assertion on v and returns a MapStr. v can be either
 // a MapStr or a map[string]interface{}. If it's any other type or nil then
 // an error is returned.
 func ToMapStr(v interface{}) (M, error) {

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1193,7 +1193,7 @@ func TestFindFold(t *testing.T) {
 			expErr: "key not found",
 		},
 		{
-			name:   "returns non-found error",
+			name:   "returns not found error",
 			key:    "level1_field4",
 			expErr: "key not found",
 		},

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1192,6 +1192,11 @@ func TestFindFold(t *testing.T) {
 			key:    "level1_field1.not_exists.some_key",
 			expErr: "key not found",
 		},
+		{
+			name:   "returns non-found error",
+			key:    "level1_field4",
+			expErr: "key not found",
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->
This PR changes `toMapStr` method to public from private. It also adds one more scenario to `FindFold` method 

## Why is it important?
It's a prerequisite for https://github.com/elastic/beats/pull/41424

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works



<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->


## Related issues
Relates
https://github.com/elastic/beats/pull/41424


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

