### PR TITLE
Do not throw error if `alterFunc` does not change the original key

### DIFF
--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -218,12 +218,16 @@ func (m M) AlterPath(path string, mode TraversalMode, alterFunc AlterFunc) (err 
 		if newKey == "" {
 			return fmt.Errorf("replacement key for %q cannot be empty", key)
 		}
-		_, exists := level[newKey]
-		if exists {
-			return fmt.Errorf("replacement key %q already exists: %w", newKey, ErrKeyCollision)
+
+		// if altered key is equal to the original key, skip below delete/put func
+		if newKey != key {
+			_, exists := level[newKey]
+			if exists {
+				return fmt.Errorf("replacement key %q already exists: %w", newKey, ErrKeyCollision)
+			}
+			delete(level, key)
+			level[newKey] = val
 		}
-		delete(level, key)
-		level[newKey] = val
 
 		return nil
 	})
@@ -271,7 +275,7 @@ func (m M) Traverse(path string, mode TraversalMode, visitor TraversalVisitor) (
 
 	for i, segment := range segments {
 		if !found {
-			return ErrKeyNotFound
+			return fmt.Errorf("could not fetch value for key: %s, Error: %w ", path, ErrKeyNotFound)
 		}
 		found = false
 
@@ -316,7 +320,7 @@ func (m M) Traverse(path string, mode TraversalMode, visitor TraversalVisitor) (
 	}
 
 	if !found {
-		return ErrKeyNotFound
+		return fmt.Errorf("could not fetch value for key: %s, Error: %w", path, ErrKeyNotFound)
 	}
 
 	return nil

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -220,14 +220,16 @@ func (m M) AlterPath(path string, mode TraversalMode, alterFunc AlterFunc) (err 
 		}
 
 		// if altered key is equal to the original key, skip below delete/put func
-		if newKey != key {
-			_, exists := level[newKey]
-			if exists {
-				return fmt.Errorf("replacement key %q already exists: %w", newKey, ErrKeyCollision)
-			}
-			delete(level, key)
-			level[newKey] = val
+		if newKey == key {
+			return nil
 		}
+
+		_, exists := level[newKey]
+		if exists {
+			return fmt.Errorf("replacement key %q already exists: %w", newKey, ErrKeyCollision)
+		}
+		delete(level, key)
+		level[newKey] = val
 
 		return nil
 	})

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1275,7 +1275,7 @@ func TestAlterPath(t *testing.T) {
 				},
 			},
 			exp: M{
-				"level1_field1": M{
+				"level1_field1": M{ //first level is unchanged - already in lowercase
 					"key": "value1",
 				},
 			},

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1265,6 +1265,22 @@ func TestAlterPath(t *testing.T) {
 			},
 		},
 		{
+			name:      "alters keys on second level with case-insensitive matching",
+			from:      "level1_field1.key",
+			mode:      CaseInsensitiveMode,
+			alterFunc: lower,
+			m: M{
+				"level1_field1": M{
+					"Key": "value1",
+				},
+			},
+			exp: M{
+				"level1_field1": M{
+					"key": "value1",
+				},
+			},
+		},
+		{
 			name:      "alters keys on all nested levels with case-insensitive matching",
 			from:      "level1_field1.level2_field1.level3_field1",
 			mode:      CaseInsensitiveMode,

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -1265,7 +1265,7 @@ func TestAlterPath(t *testing.T) {
 			},
 		},
 		{
-			name:      "alters keys on second level with case-insensitive matching",
+			name:      "does not return an error if alterFunc returns the key unchanged",
 			from:      "level1_field1.key",
 			mode:      CaseInsensitiveMode,
 			alterFunc: lower,


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
We do not throw error if `alterFunc` does not change the original key. This also improves error message for when key is not found 

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works





