### PR TITLE
[kibana]: Fix CreateFleetServerHosts and CreateFleetProxy for 8.x

### DIFF
--- a/kibana/fleet_integration_test.go
+++ b/kibana/fleet_integration_test.go
@@ -447,25 +447,49 @@ func TestCreateFleetProxy(t *testing.T) {
 	client, err := NewClientWithConfig(&cfg, "", "", "", "")
 	require.NoError(t, err)
 
-	id := uuid.Must(uuid.NewV4()).String()
-	req := ProxiesRequest{
-		ID:                     "CreateFleetServerHosts" + id,
-		Name:                   "CreateFleetServerHosts" + id,
-		URL:                    "https://proxy.elastic.co",
-		CertificateAuthorities: "some CA",
-		Certificate:            "some certificate",
-		CertificateKey:         "some certificate key",
-		IsPreconfigured:        true,
-		ProxyHeaders: map[string]string{
-			"h1": "v1",
-			"h2": "v2",
+	tcs := []struct {
+		Name string
+		Req  ProxiesRequest
+	}{
+		{
+			Name: "nil ProxyHeaders",
+			Req: ProxiesRequest{
+				ID:                     "CreateFleetServerHosts",
+				Name:                   "CreateFleetServerHosts",
+				URL:                    "https://proxy.elastic.co",
+				CertificateAuthorities: "some CA",
+				Certificate:            "some certificate",
+				CertificateKey:         "some certificate key",
+			},
+		},
+		{
+			Name: "with ProxyHeaders",
+			Req: ProxiesRequest{
+				ID:                     "CreateFleetServerHosts",
+				Name:                   "CreateFleetServerHosts",
+				URL:                    "https://proxy.elastic.co",
+				CertificateAuthorities: "some CA",
+				Certificate:            "some certificate",
+				CertificateKey:         "some certificate key",
+				ProxyHeaders: map[string]string{
+					"h1": "v1",
+					"h2": "v2",
+				},
+			},
 		},
 	}
-	got, err := client.CreateFleetProxy(ctx, req)
-	require.NoError(t, err, "error creating new fleet host")
 
-	require.Equal(t, req.ID, got.Item.ID)
-	require.Equal(t, req, got.Item)
+	for _, tc := range tcs {
+		id := uuid.Must(uuid.NewV4()).String()
+		tc.Req.ID += id
+		tc.Req.Name += id
+
+		got, err := client.CreateFleetProxy(ctx, tc.Req)
+		require.NoError(t, err, "error creating new fleet host")
+
+		require.Equal(t, tc.Req.ID, got.Item.ID)
+		require.Equal(t, tc.Req, got.Item)
+	}
 }
 
 func TestGetFleetServerHost(t *testing.T) {


### PR DESCRIPTION
fix request schema and return error body

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

Fix the schema for CreateFleetServerHosts and CreateFleetProxy requests so 8.x accepts it instead of returning 400 - Bad request.

The validation on 9.0 is different since https://github.com/elastic/kibana/pull/193326 was introduced.

## Why is it important?

So the kibana APIs work with a 8.x stack

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works


## Related Issues
- Relates https://github.com/elastic/elastic-agent/issues/5716
