### PR TITLE
[windows] - Introduce PdhGetRawCounterArrayW

### DIFF
--- a/helpers/windows/pdh/pdh_query_windows.go
+++ b/helpers/windows/pdh/pdh_query_windows.go
@@ -219,7 +219,7 @@ func (q *Query) GetRawCounterValue(counterName string) (PdhRawCounter, error) {
 	return c, nil
 }
 
-func (q *Query) GetRawCounterArray(counterName string, filterTotal bool) (RawCouterArray, error) {
+func (q *Query) GetRawCounterArray(counterName string, filterTotal bool) (RawCounterArray, error) {
 	if _, ok := q.Counters[counterName]; !ok {
 		return nil, fmt.Errorf("%s doesn't exist in the map; call AddCounter()", counterName)
 	}

--- a/helpers/windows/pdh/pdh_query_windows.go
+++ b/helpers/windows/pdh/pdh_query_windows.go
@@ -80,7 +80,7 @@ func (q *Query) AddEnglishCounter(counterPath string) (PdhCounterHandle, error) 
 }
 
 // AddCounter adds the specified counter to the query.
-func (q *Query) AddCounter(counterPath string, instance string, format string, wildcard bool) error {
+func (q *Query) AddCounter(counterPath string, instance string, format string, wildcard bool, english bool) error {
 	if _, found := q.Counters[counterPath]; found {
 		return nil
 	}
@@ -95,7 +95,12 @@ func (q *Query) AddCounter(counterPath string, instance string, format string, w
 	} else {
 		instanceName = instance
 	}
-	h, err := PdhAddCounter(q.Handle, counterPath, 0)
+	var h PdhCounterHandle
+	if english {
+		h, err = PdhAddEnglishCounter(q.Handle, counterPath, 0)
+	} else {
+		h, err = PdhAddCounter(q.Handle, counterPath, 0)
+	}
 	if err != nil {
 		return err
 	}

--- a/helpers/windows/pdh/pdh_query_windows.go
+++ b/helpers/windows/pdh/pdh_query_windows.go
@@ -203,11 +203,22 @@ func (q *Query) GetCountersAndInstances(objectName string) ([]string, []string, 
 	return UTF16ToStringArray(counters), UTF16ToStringArray(instances), nil
 }
 
-func (q *Query) GetRawCounterValue(counterName string) (*PdhRawCounter, error) {
+func (q *Query) GetRawCounterValue(counterName string) (PdhRawCounter, error) {
+	if _, ok := q.Counters[counterName]; !ok {
+		return PdhRawCounter{}, fmt.Errorf("%s doesn't exist in the map; call AddCounter()", counterName)
+	}
+	c, err := PdhGetRawCounterValue(q.Counters[counterName].handle)
+	if err != nil {
+		return PdhRawCounter{}, err
+	}
+	return c, nil
+}
+
+func (q *Query) GetRawCounterArray(counterName string) ([]*PdhRawCounterItem, error) {
 	if _, ok := q.Counters[counterName]; !ok {
 		return nil, fmt.Errorf("%s doesn't exist in the map; call AddCounter()", counterName)
 	}
-	c, err := PdhGetRawCounterValue(q.Counters[counterName].handle)
+	c, err := PdhGetRawCounterArray(q.Counters[counterName].handle)
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/windows/pdh/pdh_query_windows.go
+++ b/helpers/windows/pdh/pdh_query_windows.go
@@ -214,11 +214,11 @@ func (q *Query) GetRawCounterValue(counterName string) (PdhRawCounter, error) {
 	return c, nil
 }
 
-func (q *Query) GetRawCounterArray(counterName string) ([]*PdhRawCounterItem, error) {
+func (q *Query) GetRawCounterArray(counterName string, filterTotal bool) (RawCouterArray, error) {
 	if _, ok := q.Counters[counterName]; !ok {
 		return nil, fmt.Errorf("%s doesn't exist in the map; call AddCounter()", counterName)
 	}
-	c, err := PdhGetRawCounterArray(q.Counters[counterName].handle)
+	c, err := PdhGetRawCounterArray(q.Counters[counterName].handle, filterTotal)
 	if err != nil {
 		return nil, err
 	}

--- a/helpers/windows/pdh/pdh_query_windows_test.go
+++ b/helpers/windows/pdh/pdh_query_windows_test.go
@@ -38,7 +38,7 @@ func TestAddCounterInvalidArgWhenQueryClosed(t *testing.T) {
 	queryPath, err := q.GetCounterPaths(validQuery)
 	// if windows os language is ENG then err will be nil, else the GetCounterPaths will execute the AddCounter
 	if assert.NoError(t, err) {
-		err = q.AddCounter(queryPath[0], "TestInstanceName", "float", false)
+		err = q.AddCounter(queryPath[0], "TestInstanceName", "float", false, false)
 		assert.Error(t, err, PDH_INVALID_HANDLE)
 	} else {
 		assert.Error(t, err, PDH_INVALID_ARGUMENT)
@@ -73,7 +73,7 @@ func TestSuccessfulQuery(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	err = q.AddCounter(queryPath[0], "TestInstanceName", "floar", false)
+	err = q.AddCounter(queryPath[0], "TestInstanceName", "floar", false, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/helpers/windows/pdh/pdh_query_windows_test.go
+++ b/helpers/windows/pdh/pdh_query_windows_test.go
@@ -218,7 +218,7 @@ func TestSortOrder(t *testing.T) {
 			var q Query
 			assert.NoError(t, q.Open())
 			for _, counter := range s.counters {
-				assert.NoError(t, q.AddCounter(counter, "", "", false))
+				assert.NoError(t, q.AddCounter(counter, "", "", false, false))
 			}
 			assert.NoError(t, q.CollectData())
 			rawCounters := make([][]PdhRawCounterItem, 0)

--- a/helpers/windows/pdh/pdh_query_windows_test.go
+++ b/helpers/windows/pdh/pdh_query_windows_test.go
@@ -233,7 +233,7 @@ func TestSortOrder(t *testing.T) {
 			// confirm that each index corresponds to one particular instance (i.e. core)
 			for i := 0; i < len(rawCounters)-1; i++ {
 				for j := 0; j < len(rawCounters[i]); j++ {
-					assert.Equalf(t, rawCounters[i][j].InstanceName, rawCounters[i+1][j].InstanceName, "Instanse name should be equal")
+					assert.Equalf(t, rawCounters[i][j].InstanceName, rawCounters[i+1][j].InstanceName, "Instance name should be equal")
 				}
 			}
 		})

--- a/helpers/windows/pdh/pdh_windows.go
+++ b/helpers/windows/pdh/pdh_windows.go
@@ -122,17 +122,17 @@ type PdhRawCounterItem struct {
 	RawValue     PdhRawCounter
 }
 
-type RawCouterArray []PdhRawCounterItem
+type RawCounterArray []PdhRawCounterItem
 
-func (a RawCouterArray) Len() int {
+func (a RawCounterArray) Len() int {
 	return len(a)
 }
 
-func (a RawCouterArray) Swap(i, j int) {
+func (a RawCounterArray) Swap(i, j int) {
 	a[i], a[j] = a[j], a[i]
 }
 
-func (a RawCouterArray) Less(i, j int) bool {
+func (a RawCounterArray) Less(i, j int) bool {
 	return a[i].InstanceName < a[j].InstanceName
 }
 
@@ -243,7 +243,7 @@ func PdhGetRawCounterValue(counter PdhCounterHandle) (PdhRawCounter, error) {
 	return value, nil
 }
 
-func PdhGetRawCounterArray(counter PdhCounterHandle, filterTotal bool) (RawCouterArray, error) {
+func PdhGetRawCounterArray(counter PdhCounterHandle, filterTotal bool) (RawCounterArray, error) {
 	var bufferSize, itemCount uint32
 	if err := _PdhGetRawCounterArray(counter, &bufferSize, &itemCount, nil); err != nil {
 		if PdhErrno(err.(syscall.Errno)) != PDH_MORE_DATA {
@@ -267,7 +267,7 @@ func PdhGetRawCounterArray(counter PdhCounterHandle, filterTotal bool) (RawCoute
 		}
 		// we sort the array by the instance name to ensure that each index in the final array corresponds to a specific core
 		// This is important because we will be collecting three different types of counters, and sorting ensures that each index in each counter aligns with the correct core.
-		sort.Sort(RawCouterArray(ret))
+		sort.Sort(RawCounterArray(ret))
 		return ret, nil
 	}
 	return nil, PdhErrno(syscall.ERROR_NOT_FOUND)

--- a/helpers/windows/pdh/zpdh_windows.go
+++ b/helpers/windows/pdh/zpdh_windows.go
@@ -68,6 +68,10 @@ var (
 	procPdhGetCounterInfoW          = modpdh.NewProc("PdhGetCounterInfoW")
 	procPdhEnumObjectItemsW         = modpdh.NewProc("PdhEnumObjectItemsW")
 	procPdhGetRawCounter          	= modpdh.NewProc("PdhGetRawCounterValue")
+	procPdhGetRawCounterArray       = modpdh.NewProc("PdhGetRawCounterArrayW")
+
+	libPdhDll = syscall.MustLoadDLL("pdh.dll")
+	pdhGetRawCounterArrayW      	= libPdhDll.MustFindProc("PdhGetRawCounterArrayW")
 )
 
 func _PdhOpenQuery(dataSource *uint16, userData uintptr, query *PdhQueryHandle) (errcode error) {
@@ -84,6 +88,20 @@ func _PdhGetRawCounter(query PdhCounterHandle, userData uintptr) (errcode error)
 
 func __PdhGetRawCounter(query PdhCounterHandle, userData uintptr) (errcode error) {
 	r0, _, _ := syscall.SyscallN(procPdhGetRawCounter.Addr(), uintptr(query), 0, userData)
+	if r0 != 0 {
+		errcode = syscall.Errno(r0)
+	}
+	return
+}
+
+
+func _PdhGetRawCounterArray(hCounter PdhCounterHandle, lpdwBufferSize, lpdwBufferCount *uint32, itemBuffer *byte)  (errcode error) {
+	r0, _, _ := syscall.SyscallN(
+		procPdhGetRawCounterArray.Addr(), 
+		uintptr(hCounter), 
+		uintptr(unsafe.Pointer(lpdwBufferSize)), 
+		uintptr(unsafe.Pointer(lpdwBufferCount)), 
+		uintptr(unsafe.Pointer(itemBuffer)))
 	if r0 != 0 {
 		errcode = syscall.Errno(r0)
 	}

--- a/helpers/windows/pdh/zpdh_windows.go
+++ b/helpers/windows/pdh/zpdh_windows.go
@@ -69,9 +69,6 @@ var (
 	procPdhEnumObjectItemsW         = modpdh.NewProc("PdhEnumObjectItemsW")
 	procPdhGetRawCounter          	= modpdh.NewProc("PdhGetRawCounterValue")
 	procPdhGetRawCounterArray       = modpdh.NewProc("PdhGetRawCounterArrayW")
-
-	libPdhDll = syscall.MustLoadDLL("pdh.dll")
-	pdhGetRawCounterArrayW      	= libPdhDll.MustFindProc("PdhGetRawCounterArrayW")
 )
 
 func _PdhOpenQuery(dataSource *uint16, userData uintptr, query *PdhQueryHandle) (errcode error) {


### PR DESCRIPTION
While performing benchmarking, I noticed that by using https://learn.microsoft.com/en-us/windows/win32/api/pdh/nf-pdh-pdhgetrawcounterarrayw we can achieve faster results with reduced memory usage. 

This PR adds the methods for PdhGetRawCounterArrayW function.

It also does following thing to improve memory benchmarks:
- Performs sort on the returned array based on instance name. This is helpful as each index of the returned array will correspond to one particular instance (i.e. CPU Core). This helps us save big on memory as we wouldn't need to build a map or perform any segregation based on CPU Cores.
     - The term "instance name" refers to a specific CPU core.
     - For the Processor Information performance counter, there will be `n+1` instance names corresponding to `n` CPU cores.
          - `Processor Information(0)/ % Idle Time` refers to the idle time spent by CPU core `0`
          - `Processor Information(1)/ % Idle Time` refers to the idle time spent by CPU core `1`
          - ...
          - `Processor Information(n)/ % Idle Time` refers to the idle time spent by CPU core `n`
          - `Processor Information(_Total)/ % Idle Time` refers to the average idle time spent for all CPUs.