### PR TITLE
Add integration build tag

### DIFF
--- a/.buildkite/scripts/test.ps1
+++ b/.buildkite/scripts/test.ps1
@@ -21,7 +21,7 @@ Write-Host "--- Run test"
 $ErrorActionPreference = "Continue" # set +e
 mkdir -p build
 $OUT_FILE="output-report.out"
-go test "./..." -v > $OUT_FILE
+go test -tags integration "./..." -v > $OUT_FILE
 $EXITCODE=$LASTEXITCODE
 $ErrorActionPreference = "Stop"
 

--- a/.buildkite/scripts/test.sh
+++ b/.buildkite/scripts/test.sh
@@ -11,7 +11,7 @@ with_go_junit_report
 
 echo "--- Go Test"
 set +e
-go test -race -v ./... > tests-report.txt
+go test -tags integration -race -v ./... > tests-report.txt
 exit_code=$?
 set -e
 

--- a/file/helper_test.go
+++ b/file/helper_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package file
 
 import (

--- a/kibana/url_test.go
+++ b/kibana/url_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package kibana
 
 import (

--- a/logp/core_linux_test.go
+++ b/logp/core_linux_test.go
@@ -15,7 +15,7 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build linux
+//go:build linux && integration
 
 package logp
 

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package mapstr
 
 import (

--- a/monitoring/opts_test.go
+++ b/monitoring/opts_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package monitoring
 
 import (

--- a/monitoring/registry_test.go
+++ b/monitoring/registry_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package monitoring
 
 import (

--- a/monitoring/visitor_expvar_test.go
+++ b/monitoring/visitor_expvar_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package monitoring
 
 import (

--- a/transform/typeconv/datetime_test.go
+++ b/transform/typeconv/datetime_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package typeconv
 
 import (

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build !integration
-
 package tlscommon
 
 import (


### PR DESCRIPTION
## What does this PR do?

The test TestSyslogOutputCanBeClosed requires no syslog running on the host and root privileges to execute. Most Linux distros already have a syslog daemon running, causing test failures during development. These failures make it difficult to identify real issues with the tests.

Given this, introduce an integration build tag and run this test only by default on CI.

The integration build tag was previously used only for negative matches in certain tests, which is not meaningful. Remove the !integration annotations.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works