### PR TITLE
Introduce tlscommon.SetInsecureDefaults

### DIFF
--- a/transport/tlscommon/versions_default.go
+++ b/transport/tlscommon/versions_default.go
@@ -29,7 +29,9 @@ const (
 	TLSVersion11 TLSVersion = tls.VersionTLS11
 	TLSVersion12 TLSVersion = tls.VersionTLS12
 	TLSVersion13 TLSVersion = tls.VersionTLS13
+)
 
+var (
 	// TLSVersionMin is the min TLS version supported.
 	TLSVersionMin = TLSVersion10
 
@@ -58,6 +60,20 @@ var tlsProtocolVersions = map[string]TLSVersion{
 	"TLSv1.1": TLSVersion11,
 	"TLSv1.2": TLSVersion12,
 	"TLSv1.3": TLSVersion13,
+}
+
+// SetInsecureDefaults is currently a nop as the default versions have not changed.
+//
+// This function is used to avoid a breaking change on previous releases.
+// We plan on the default minimum versions list to exclude TLS1.1, and not allow TLS1.0 in a future library update.
+func SetInsecureDefaults() {
+	TLSVersionMin = TLSVersion10
+	TLSVersionDefaultMin = TLSVersion11
+	TLSDefaultVersions = []TLSVersion{
+		TLSVersion11,
+		TLSVersion12,
+		TLSVersion13,
+	}
 }
 
 // Intended for ECS's tls.version_protocol_field, which does not include


### PR DESCRIPTION
## What does this PR do?

Introduce `tlscommon.SetInsecureDefaults` ahead of breaking changes.

## Why is it important?

We plan on raising the minimum TLS version supported by this library in a future update.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have added tests that prove my fix is effective or that my feature works~~
