### PR TITLE
mapstr: fix M.Clone behaviour for arrays of M

### DIFF
--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -350,6 +350,7 @@ func TestClone(t *testing.T) {
 			"c31": 1,
 			"c32": 2,
 		},
+		"c4": []M{{"c41": 1}},
 	}
 
 	// Clone the original mapstr and then increment every value in it. Ensures the test will fail if
@@ -366,6 +367,7 @@ func TestClone(t *testing.T) {
 				"c31": 1,
 				"c32": 2,
 			},
+			"c4": []M{{"c41": 1}},
 		},
 		cloned,
 	)
@@ -379,6 +381,10 @@ func incrementMapstrValues(m M) {
 			m[k] = v + 1
 		case M:
 			incrementMapstrValues(m[k].(M))
+		case []M:
+			for _, c := range v {
+				incrementMapstrValues(c)
+			}
 		}
 
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

The current implementation does not clone in branches of slices in a mapstr.M, resulting in cases where the clone will share values with the original and allowing unexpected mutation of the original. This change fixes that by adding slices type handling. Note that this will not fix cases of unexpected sharing where the node value type is not a mapstr.M or map[string]any, so structs that are included with pointer fields will still show this effect.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

The current implementation results in data corruption when logging mapstr.M values with redacted fields.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- For #232

