### PR TITLE
Update TLS min version to 1.1, set default min to 1.2

### DIFF
--- a/transport/tlscommon/versions_default.go
+++ b/transport/tlscommon/versions_default.go
@@ -31,14 +31,14 @@ const (
 
 var (
 	// TLSVersionMin is the min TLS version supported.
-	TLSVersionMin = TLSVersion10
+	TLSVersionMin = TLSVersion11
 
 	// TLSVersionMax is the max TLS version supported.
 	TLSVersionMax = TLSVersion13
 
 	// TLSVersionDefaultMin is the minimal default TLS version that is
 	// enabled by default. TLSVersionDefaultMin is >= TLSVersionMin
-	TLSVersionDefaultMin = TLSVersion11
+	TLSVersionDefaultMin = TLSVersion12
 
 	// TLSVersionDefaultMax is the max default TLS version that
 	// is enabled by default.
@@ -47,7 +47,6 @@ var (
 
 // TLSDefaultVersions list of versions of TLS we should support.
 var TLSDefaultVersions = []TLSVersion{
-	TLSVersion11,
 	TLSVersion12,
 	TLSVersion13,
 }


### PR DESCRIPTION
## What does this PR do?

Set the min TLS version to 1.1, set the default min to 1.2

## Why is it important?

Support TLSv1.0 and TLSv1.1 is being removed/restricted in the upcoming 9.0 release.

If using these versions is still required; for example on the 8.x backports the importing program should call `tlscommon.SetInsecureDefaults()` to restore support for handling TLSv1.0/1.1.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have added tests that prove my fix is effective or that my feature works~~

