### PR TITLE
ci(buildkite): exclude files/folders that are not tested in Buildkite

### DIFF
--- a/.buildkite/pull-requests.json
+++ b/.buildkite/pull-requests.json
@@ -13,7 +13,7 @@
             "always_trigger_comment_regex": "^(?:(?:buildkite\\W+)?(?:build|test)\\W+(?:this|it))|^/test$",
             "skip_ci_labels": [  ],
             "skip_target_branches": [ ],
-            "skip_ci_on_only_changed": [ ],
+            "skip_ci_on_only_changed": ["^.github/"],
             "always_require_ci_on_changed": [ ]
         }
     ]


### PR DESCRIPTION
## What does this PR do?

Skip files that are not used in Buildkite

## Why is it important?


Run faster builds and avoid waste of CI cycles.

I decided to support the whole .github folder since there are some other files, such as CODEOWNERS or .dependabot.yml and the rest are not used by Buildkite

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

