### PR TITLE
chore: add linter that denies importing math/rand

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -47,7 +47,8 @@ linters:
     - noctx # noctx finds sending http request without context.Context
     - unconvert # Remove unnecessary type conversions
     - wastedassign # wastedassign finds wasted assignment statements.
-    - gomodguard # check for blocked dependencies
+    - gomodguard # check for blocked dependencies in go.mod
+    - depguard # check for blocked dependencies in Go files
 
 # all available settings of specific linters
 linters-settings:
@@ -114,6 +115,14 @@ linters-settings:
             reason: "This package is deprecated, use fmt.Errorf with %%w instead"
         - github.com/elastic/beats/v7:
             reason: "There must be no Beats dependency"
+
+  depguard:
+    rules:
+      main:
+        list-mode: lax
+        deny:
+          - pkg: "math/rand$"
+            desc: "superseded by math/rand/v2"
 
   staticcheck:
     # Select the Go version to target. The default is '1.13'.

--- a/transport/tlscommon/test_helper.go
+++ b/transport/tlscommon/test_helper.go
@@ -29,7 +29,7 @@ import (
 	"encoding/pem"
 	"fmt"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"os"
 	"path/filepath"

--- a/transport/util.go
+++ b/transport/util.go
@@ -20,7 +20,7 @@ package transport
 import (
 	"context"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"net"
 	"strings"
 )


### PR DESCRIPTION
## Proposed commit message

In order to ensure consistency between beats, elastic-agent and libs this commit migrates from math/rand to the newer math/rand/v2 package as well as introducing a linter that catches math/rand imports in Go files.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have made corresponding change to the default configuration files
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added an entry in `CHANGELOG.next.asciidoc` or `CHANGELOG-developer.next.asciidoc`.

## Related issues

- Relates https://github.com/elastic/elastic-agent/pull/6650
- Relates https://github.com/elastic/beats/pull/42513

## Logs

Offending code gets warned like this:

```txt
file.go:24:2: import 'math/rand' is not allowed from list 'main': superseded by math/rand/v2 (depguard)
        "math/rand"
```
