### PR TITLE
fix: do not leak testify package in tlscommon

### DIFF
--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/iobuf"
+	"github.com/elastic/elastic-agent-libs/transport/tlscommontest"
 )
 
 func TestCAPinning(t *testing.T) {
@@ -83,10 +84,10 @@ func TestCAPinning(t *testing.T) {
 			t.Run(mode.String(), func(t *testing.T) {
 				msg := []byte("OK received message")
 
-				ca, err := genCA()
+				ca, err := tlscommontest.GenCA()
 				require.NoError(t, err)
 
-				serverCert, err := genSignedCert(ca, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
+				serverCert, err := tlscommontest.GenSignedCert(ca, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
 				require.NoError(t, err)
 
 				mux := http.NewServeMux()
@@ -161,13 +162,13 @@ func TestCAPinning(t *testing.T) {
 	t.Run("CA Root -> Intermediate -> Certificate and we receive the CA Root Pin", func(t *testing.T) {
 		msg := []byte("OK received message")
 
-		ca, err := genCA()
+		ca, err := tlscommontest.GenCA()
 		require.NoError(t, err)
 
-		intermediate, err := genSignedCert(ca, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign, true, "localhost", []string{"localhost"}, nil, false)
+		intermediate, err := tlscommontest.GenSignedCert(ca, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign, true, "localhost", []string{"localhost"}, nil, false)
 		require.NoError(t, err)
 
-		serverCert, err := genSignedCert(intermediate, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
+		serverCert, err := tlscommontest.GenSignedCert(intermediate, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
 		require.NoError(t, err)
 
 		mux := http.NewServeMux()
@@ -235,13 +236,13 @@ func TestCAPinning(t *testing.T) {
 	t.Run("When we have the wrong pin we refuse to connect", func(t *testing.T) {
 		msg := []byte("OK received message")
 
-		ca, err := genCA()
+		ca, err := tlscommontest.GenCA()
 		require.NoError(t, err)
 
-		intermediate, err := genSignedCert(ca, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign, true, "localhost", []string{"localhost"}, nil, false)
+		intermediate, err := tlscommontest.GenSignedCert(ca, x509.KeyUsageDigitalSignature|x509.KeyUsageCertSign, true, "localhost", []string{"localhost"}, nil, false)
 		require.NoError(t, err)
 
-		serverCert, err := genSignedCert(intermediate, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
+		serverCert, err := tlscommontest.GenSignedCert(intermediate, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
 		require.NoError(t, err)
 
 		mux := http.NewServeMux()

--- a/transport/tlscommon/diag_test.go
+++ b/transport/tlscommon/diag_test.go
@@ -24,6 +24,7 @@ import (
 	"encoding/pem"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/transport/tlscommontest"
 	"github.com/stretchr/testify/require"
 )
 
@@ -95,7 +96,7 @@ func Test_ServerConfig_DiagCerts(t *testing.T) {
 
 func makeCAs(t *testing.T) (tls.Certificate, []string) {
 	t.Helper()
-	ca, err := genCA()
+	ca, err := tlscommontest.GenCA()
 	require.NoError(t, err)
 	p := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",
@@ -108,7 +109,7 @@ func makeCAs(t *testing.T) (tls.Certificate, []string) {
 
 func makeCertificateConfig(t *testing.T, ca tls.Certificate) CertificateConfig {
 	t.Helper()
-	crt, err := genSignedCert(ca, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
+	crt, err := tlscommontest.GenSignedCert(ca, x509.KeyUsageDigitalSignature, false, "localhost", []string{"localhost"}, nil, false)
 	require.NoError(t, err)
 	crtBytes := pem.EncodeToMemory(&pem.Block{
 		Type:  "CERTIFICATE",

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -391,7 +391,7 @@ func TestMakeVerifyServerConnectionForIPs(t *testing.T) {
 		},
 	}
 
-	ca, err := genCA()
+	ca, err := tlscommontest.GenCA()
 	if err != nil {
 		t.Fatalf("cannot generate CA certificate: %s", err)
 	}
@@ -401,7 +401,7 @@ func TestMakeVerifyServerConnectionForIPs(t *testing.T) {
 
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
-			peerCerts, err := genSignedCert(
+			peerCerts, err := tlscommontest.GenSignedCert(
 				ca,
 				x509.KeyUsageCertSign,
 				false,
@@ -573,7 +573,7 @@ func TestVerificationMode(t *testing.T) {
 			ignoreCerts:      true,
 		},
 	}
-	caCert, err := genCA()
+	caCert, err := tlscommontest.GenCA()
 	if err != nil {
 		t.Fatalf("could not generate root CA certificate: %s", err)
 	}
@@ -583,7 +583,7 @@ func TestVerificationMode(t *testing.T) {
 
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
-			certs, err := genSignedCert(caCert, x509.KeyUsageCertSign, false, test.commonName, test.dnsNames, test.ips, false)
+			certs, err := tlscommontest.GenSignedCert(caCert, x509.KeyUsageCertSign, false, test.commonName, test.dnsNames, test.ips, false)
 			if err != nil {
 				t.Fatalf("could not generate certificates: %s", err)
 			}

--- a/transport/tlscommontest/test_helper.go
+++ b/transport/tlscommontest/test_helper.go
@@ -49,12 +49,12 @@ func GetCertFingerprint(cert *x509.Certificate) string {
 
 func GenTestCerts(t *testing.T) map[string]*x509.Certificate {
 	t.Helper()
-	ca, err := genCA()
+	ca, err := GenCA()
 	if err != nil {
 		t.Fatalf("cannot generate root CA: %s", err)
 	}
 
-	unknownCA, err := genCA()
+	unknownCA, err := GenCA()
 	if err != nil {
 		t.Fatalf("cannot generate second root CA: %s", err)
 	}
@@ -106,7 +106,7 @@ func GenTestCerts(t *testing.T) map[string]*x509.Certificate {
 
 	tmpDir := t.TempDir()
 	for certName, data := range certData {
-		cert, err := genSignedCert(
+		cert, err := GenSignedCert(
 			data.ca,
 			data.keyUsage,
 			data.isCA,
@@ -156,7 +156,7 @@ func GenTestCerts(t *testing.T) map[string]*x509.Certificate {
 	return certs
 }
 
-func genCA() (tls.Certificate, error) {
+func GenCA() (tls.Certificate, error) {
 	ca := &x509.Certificate{
 		SerialNumber: serial(),
 		Subject: pkix.Name{
@@ -225,7 +225,7 @@ func generateSubjectKeyID(publicKey *rsa.PublicKey) []byte {
 }
 
 // genSignedCert generates a CA and KeyPair and remove the need to depends on code of agent.
-func genSignedCert(
+func GenSignedCert(
 	ca tls.Certificate,
 	keyUsage x509.KeyUsage,
 	isCA bool,


### PR DESCRIPTION
## What does this PR do?

move testify methods to a separate test package to avoid polluting the module graph for downstream clients and leaking the dependency

## Why is it important?

test dependencies shouldn't be used in non-test packages

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

