### PR TITLE
feat(fips): do not set insecure defaults in fips mode

### DIFF
--- a/transport/tlscommon/versions_default.go
+++ b/transport/tlscommon/versions_default.go
@@ -59,20 +59,6 @@ var tlsProtocolVersions = map[string]TLSVersion{
 	"TLSv1.3": TLSVersion13,
 }
 
-// SetInsecureDefaults is currently a nop as the default versions have not changed.
-//
-// This function is used to avoid a breaking change on previous releases.
-// We plan on the default minimum versions list to exclude TLS1.1, and not allow TLS1.0 in a future library update.
-func SetInsecureDefaults() {
-	TLSVersionMin = TLSVersion10
-	TLSVersionDefaultMin = TLSVersion11
-	TLSDefaultVersions = []TLSVersion{
-		TLSVersion11,
-		TLSVersion12,
-		TLSVersion13,
-	}
-}
-
 // Intended for ECS's tls.version_protocol_field, which does not include
 // numeric version and should be lower case
 type TLSVersionDetails struct {

--- a/transport/tlscommon/versions_fips.go
+++ b/transport/tlscommon/versions_fips.go
@@ -1,0 +1,24 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package tlscommon
+
+func SetInsecureDefaults() {
+	// noop, use secure defaults in fips
+}

--- a/transport/tlscommon/versions_nofips.go
+++ b/transport/tlscommon/versions_nofips.go
@@ -1,0 +1,31 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package tlscommon
+
+// This function is used to avoid a breaking change on previous releases.
+func SetInsecureDefaults() {
+	TLSVersionMin = TLSVersion10
+	TLSVersionDefaultMin = TLSVersion11
+	TLSDefaultVersions = []TLSVersion{
+		TLSVersion11,
+		TLSVersion12,
+		TLSVersion13,
+	}
+}


### PR DESCRIPTION
## What does this PR do?

make setinsecuredefaults a noop and use tls 1.2+ in fips mode

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

