### PR TITLE
fix(file): rotate active file if it points to a symbolic link

### DIFF
--- a/logp/logger_test.go
+++ b/logp/logger_test.go
@@ -114,7 +114,7 @@ func TestLoggerRotateSymlink(t *testing.T) {
 
 	// The file rotation should have detected the destination is a symlink and rotated before writing.
 	rotatedFilename := filepath.Join(dir, fmt.Sprintf("%s-%s-1.ndjson", logname, time.Now().Format(file.DateFormat)))
-	AssertDirContents(t, dir, filepath.Base(privateFile), filepath.Base(guessedFilename), filepath.Base(rotatedFilename))
+	assertDirContents(t, dir, filepath.Base(privateFile), filepath.Base(guessedFilename), filepath.Base(rotatedFilename))
 
 	got, err := os.ReadFile(privateFile)
 	require.NoError(t, err)
@@ -125,7 +125,7 @@ func TestLoggerRotateSymlink(t *testing.T) {
 	assert.Contains(t, string(got), logLine, "The rotated file should contain the log message")
 }
 
-func AssertDirContents(t *testing.T, dir string, files ...string) {
+func assertDirContents(t *testing.T, dir string, files ...string) {
 	t.Helper()
 
 	f, err := os.Open(dir)

--- a/logp/logger_test.go
+++ b/logp/logger_test.go
@@ -18,9 +18,14 @@
 package logp
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/elastic/elastic-agent-libs/file"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
@@ -78,4 +83,60 @@ func TestNewInMemory(t *testing.T) {
 	assert.Contains(t, logs[3], "an error message")
 	assert.Contains(t, logs[3], "error_key")
 	assert.Contains(t, logs[3], "error_val")
+}
+
+func TestLoggerRotateSymlink(t *testing.T) {
+	dir := t.TempDir()
+
+	cfg := DefaultConfig(DefaultEnvironment)
+	cfg.Beat = "logger"
+	cfg.ToFiles = true
+	cfg.Files.Path = dir
+	cfg.Files.RotateOnStartup = false
+
+	logname := cfg.Beat
+
+	privateFileContents := []byte("original contents")
+	privateFile := filepath.Join(dir, "private")
+	err := os.WriteFile(privateFile, privateFileContents, 0644)
+	require.NoError(t, err)
+
+	// Plant a symlink to the private file by guessing the log filename.
+	guessedFilename := filepath.Join(dir, fmt.Sprintf("%s-%s.ndjson", logname, time.Now().Format(file.DateFormat)))
+	err = os.Symlink(privateFile, guessedFilename)
+	require.NoError(t, err)
+
+	err = Configure(cfg)
+	require.NoError(t, err)
+
+	logLine := "a info message"
+	L().Info(logLine)
+
+	// The file rotation should have detected the destination is a symlink and rotated before writing.
+	rotatedFilename := filepath.Join(dir, fmt.Sprintf("%s-%s-1.ndjson", logname, time.Now().Format(file.DateFormat)))
+	AssertDirContents(t, dir, filepath.Base(privateFile), filepath.Base(guessedFilename), filepath.Base(rotatedFilename))
+
+	got, err := os.ReadFile(privateFile)
+	require.NoError(t, err)
+	assert.Equal(t, privateFileContents, got, "The symlink target should not have been modified")
+
+	got, err = os.ReadFile(rotatedFilename)
+	require.NoError(t, err)
+	assert.Contains(t, string(got), logLine, "The rotated file should contain the log message")
+}
+
+func AssertDirContents(t *testing.T, dir string, files ...string) {
+	t.Helper()
+
+	f, err := os.Open(dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	names, err := f.Readdirnames(-1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	assert.ElementsMatch(t, files, names)
 }


### PR DESCRIPTION
## What does this PR do?

This PR changes the file rotation logic of the file package to force a rotation if the active file is a symlink.

## Related issues

- For https://github.com/elastic/security/issues/6104

