### PR TITLE
fix(mapstr): cast inner maps to M on Clone

### DIFF
--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -169,7 +169,7 @@ func cloneMap(dst, src M) {
 			dst[k] = d
 			cloneMap(d, v)
 		case map[string]interface{}:
-			d := make(map[string]interface{}, len(v))
+			d := make(M, len(v))
 			dst[k] = d
 			cloneMap(d, v)
 		case []M:
@@ -181,9 +181,9 @@ func cloneMap(dst, src M) {
 			}
 			dst[k] = a
 		case []map[string]interface{}:
-			a := make([]map[string]interface{}, 0, len(v))
+			a := make([]M, 0, len(v))
 			for _, m := range v {
-				d := make(map[string]interface{}, len(m))
+				d := make(M, len(m))
 				cloneMap(d, m)
 				a = append(a, d)
 			}

--- a/mapstr/mapstr_test.go
+++ b/mapstr/mapstr_test.go
@@ -349,6 +349,8 @@ func TestClone(t *testing.T) {
 			"c32": 2,
 		},
 		"c4": []M{{"c41": 1}},
+		"c5": map[string]interface{}{"c51": 1},
+		"c6": []map[string]interface{}{{"c61": 1}},
 	}
 
 	// Clone the original mapstr and then increment every value in it. Ensures the test will fail if
@@ -366,6 +368,8 @@ func TestClone(t *testing.T) {
 				"c32": 2,
 			},
 			"c4": []M{{"c41": 1}},
+			"c5": M{"c51": 1},
+			"c6": []M{{"c61": 1}},
 		},
 		cloned,
 	)


### PR DESCRIPTION
## What does this PR do?

PR https://github.com/elastic/elastic-agent-libs/pull/262 changed the Clone behavior to preserve the type of inner `map[string]interface{}` instead of casting them to M. This PR reverts this behavior since we rely on inner maps being casted to M in beats. This was not tested before, that is why we only caught it now. Additionally, add tests to ensure this behavior is preserved.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/elastic-agent-libs/pull/262

