### PR TITLE
Improve trusted_ca_fingerprint warnings and fix tests

### DIFF
--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -183,9 +183,16 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 		return fmt.Errorf("decode 'ca_trusted_fingerprint': %w", err)
 	}
 
+	foundCADigests := []string{}
+
 	for _, cert := range peerCerts {
+
 		// Compute digest for each certificate.
 		digest := sha256.Sum256(cert.Raw)
+
+		if cert.IsCA {
+			foundCADigests = append(foundCADigests, hex.EncodeToString(digest[:]))
+		}
 
 		if !bytes.Equal(digest[0:], fingerprint) {
 			continue
@@ -193,7 +200,7 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 
 		// Make sure the fingerprint matches a CA certificate
 		if !cert.IsCA {
-			logger.Info("Certificate matching 'ca_trusted_fingerprint' found, but is not a CA certificate")
+			logger.Warn("Certificate matching 'ca_trusted_fingerprint' found, but it is not a CA certificate. 'ca_trusted_fingerprint' can only be used to trust CA certificates.")
 			continue
 		}
 
@@ -206,7 +213,13 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 		return nil
 	}
 
-	logger.Warn("no CA certificate matching the fingerprint")
+	// if we are here, we didn't find any CA certificate matching the fingerprint
+	if len(foundCADigests) == 0 {
+		logger.Warn("The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificate's issuing certificate authority.")
+	} else {
+		logger.Warnf("No Certificate Authority matches the fingerprints present in the server's certificate chain. Found CA digests: %v", foundCADigests)
+	}
+
 	return nil
 }
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -217,7 +217,7 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 	if len(foundCADigests) == 0 {
 		logger.Warn("The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificate's issuing certificate authority.")
 	} else {
-		logger.Warnf("No Certificate Authority matches the fingerprints present in the server's certificate chain. Found CA digests: %v", foundCADigests)
+		logger.Warnf("The provided 'ca_trusted_fingerprint': '%s' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: %v", cfg.CATrustedFingerprint, foundCADigests)
 	}
 
 	return nil

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -194,7 +194,9 @@ func TestTrustRootCA(t *testing.T) {
 	nonEmptyCertPool.AddCert(certs["wildcard"])
 	nonEmptyCertPool.AddCert(certs["unknown_authority"])
 
-	fingerprint := tlscommontest.GetCertFingerprint(certs["ca"])
+	certfingerprint := tlscommontest.GetCertFingerprint(certs["correct"])
+	cafingerprint := tlscommontest.GetCertFingerprint(certs["ca"])
+
 	unknownAuthorityDigest := sha256.Sum256(certs["unknown_authority"].Raw)
 	unknownAuthoritySha256 := hex.EncodeToString(unknownAuthorityDigest[:])
 
@@ -203,34 +205,44 @@ func TestTrustRootCA(t *testing.T) {
 		rootCAs              *x509.CertPool
 		caTrustedFingerprint string
 		peerCerts            []*x509.Certificate
-		expectingWarning     string
+		expectingWarnings    []string
 		expectingError       bool
 		expectedRootCAsLen   int
 	}{
 		{
 			name:                 "RootCA cert matches the fingerprint and is added to cfg.RootCAs",
-			caTrustedFingerprint: fingerprint,
+			caTrustedFingerprint: cafingerprint,
 			peerCerts:            []*x509.Certificate{certs["correct"], certs["ca"]},
 			expectedRootCAsLen:   1,
 		},
 		{
 			name:                 "RootCA cert doesn't match the fingerprint and is not added to cfg.RootCAs",
-			caTrustedFingerprint: fingerprint,
+			caTrustedFingerprint: cafingerprint,
 			peerCerts:            []*x509.Certificate{certs["correct"], certs["unknown_authority"]},
-			expectingWarning:     "no CA certificate matches the fingerprints present in the chain. Found CA digests: [" + unknownAuthoritySha256 + "]",
+			expectingWarnings:    []string{"No Certificate Authority matches the fingerprints present in the server's certificate chain. Found CA digests: [" + unknownAuthoritySha256 + "]"},
 			expectedRootCAsLen:   0,
 		},
 		{
 			name:                 "Peer cert does not include a CA Certificate and is not added to cfg.RootCAs",
-			caTrustedFingerprint: fingerprint,
+			caTrustedFingerprint: cafingerprint,
 			peerCerts:            []*x509.Certificate{certs["correct"]},
-			expectingWarning:     "The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificates issuing certificate authority.",
+			expectingWarnings:    []string{"The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificate's issuing certificate authority."},
 			expectedRootCAsLen:   0,
+		},
+		{
+			name:                 "fingerprint matches peer cert instead of the CA Certificate and is not added to cfg.RootCAs",
+			caTrustedFingerprint: certfingerprint,
+			peerCerts:            []*x509.Certificate{certs["correct"]},
+			expectingWarnings: []string{
+				"Certificate matching 'ca_trusted_fingerprint' found, but it is not a CA certificate. 'ca_trusted_fingerprint' can only be used to trust CA certificates.",
+				"The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificate's issuing certificate authority.",
+			},
+			expectedRootCAsLen: 0,
 		},
 		{
 			name:                 "non empty CertPool has the RootCA added",
 			rootCAs:              nonEmptyCertPool,
-			caTrustedFingerprint: fingerprint,
+			caTrustedFingerprint: cafingerprint,
 			peerCerts:            []*x509.Certificate{certs["correct"], certs["ca"]},
 			expectedRootCAsLen:   3,
 		},
@@ -261,17 +273,19 @@ func TestTrustRootCA(t *testing.T) {
 				t.Fatalf("did not expect an error calling trustRootCA: %v", err)
 			}
 
-			if tc.expectingWarning != "" {
+			if len(tc.expectingWarnings) > 0 {
 				warnings := logp.ObserverLogs().FilterLevelExact(logp.WarnLevel.ZapLevel()).TakeAll()
 				if len(warnings) == 0 {
 					t.Fatal("expecting a warning message")
 				}
-				if len(warnings) > 1 {
-					t.Fatalf("expecting only one warning message, got %d", len(warnings))
+				if len(warnings) != len(tc.expectingWarnings) {
+					t.Fatalf("expecting %d warning messages, got %d", len(tc.expectingWarnings), len(warnings))
 				}
 
-				if got, expected := warnings[0].Message, tc.expectingWarning; got != expected {
-					t.Fatalf("expecting warning message to be '%s', got '%s'", expected, got)
+				for i, expectedWarning := range tc.expectingWarnings {
+					if got := warnings[i].Message; got != expectedWarning {
+						t.Fatalf("expecting warning message to be '%s', got '%s'", expectedWarning, got)
+					}
 				}
 			}
 

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -219,7 +219,7 @@ func TestTrustRootCA(t *testing.T) {
 			name:                 "RootCA cert doesn't match the fingerprint and is not added to cfg.RootCAs",
 			caTrustedFingerprint: cafingerprint,
 			peerCerts:            []*x509.Certificate{certs["correct"], certs["unknown_authority"]},
-			expectingWarnings:    []string{"No Certificate Authority matches the fingerprints present in the server's certificate chain. Found CA digests: [" + unknownAuthoritySha256 + "]"},
+			expectingWarnings:    []string{"The provided 'ca_trusted_fingerprint': '" + cafingerprint + "' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: [" + unknownAuthoritySha256 + "]"},
 			expectedRootCAsLen:   0,
 		},
 		{
@@ -262,7 +262,7 @@ func TestTrustRootCA(t *testing.T) {
 			}
 
 			// Capture the logs
-			logp.DevelopmentSetup(logp.ToObserverOutput())
+			_ = logp.DevelopmentSetup(logp.ToObserverOutput())
 
 			err := trustRootCA(&cfg, tc.peerCerts)
 			if tc.expectingError && err == nil {

--- a/transport/tlscommontest/test_helper.go
+++ b/transport/tlscommontest/test_helper.go
@@ -88,7 +88,7 @@ func GenTestCerts(t *testing.T) map[string]*x509.Certificate {
 		"unknown_authority": {
 			ca:       unknownCA,
 			keyUsage: x509.KeyUsageDigitalSignature | x509.KeyUsageKeyEncipherment,
-			isCA:     false,
+			isCA:     true,
 			dnsNames: []string{"localhost"},
 			// IPV4 and IPV6
 			ips: []net.IP{{127, 0, 0, 1}, {0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0}},


### PR DESCRIPTION
## What does this PR do?

This PR updates the warnings that are printed in various edge cases using `ca_trusted_fingerprint`.  I also add tests that assert the right warnings are printed in each edge case.

There were issues with the existing tests as well that I resolved.
1. The tests didn't correctly verify that CA certs were or weren't added. For example the test "RootCA cert doesn not matche the fingerprint and is not added to cfg.RootCAs" actually did add the certificate to the cfg.RootCAs while still passing the test
2. The test helper method that generates certificates generates a CA under `unknown_authority` but incorrectly marks the certificate as not being a CA certificate.

With this PR, the warning printed if the user provides the wrong fingerprint would be:
`The provided 'ca_trusted_fingerprint': 'blah' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: [8e700dc7381856dd16665b9d08286057e743bdb8fdb3dd9bb68ea19887481a48]
`

And when the Elasticsearch Server is missing its certificate chain it would print:
`The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificates issuing certificate authority.`

Today, in both of these cases it just prints: `no CA certificate matching the fingerprint`

## Why is it important?

Users frequently try to use `ca_trusted_fingerprint` without realizing how significantly different the behavior of it is from providing a normal certificate. 

This value is often provided via Fleet and when it doesn't work it is very hard to understand what to do next.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works


## Related issues

https://github.com/elastic/beats/issues/42970


