### PR TITLE
feat(fips): bump supported min tls version to 1.2

### DIFF
--- a/transport/tlscommon/versions_default.go
+++ b/transport/tlscommon/versions_default.go
@@ -30,9 +30,6 @@ const (
 )
 
 var (
-	// TLSVersionMin is the min TLS version supported.
-	TLSVersionMin = TLSVersion11
-
 	// TLSVersionMax is the max TLS version supported.
 	TLSVersionMax = TLSVersion13
 

--- a/transport/tlscommon/versions_fips.go
+++ b/transport/tlscommon/versions_fips.go
@@ -19,6 +19,11 @@
 
 package tlscommon
 
+var (
+	// TLSVersionMin is the min TLS version supported.
+	TLSVersionMin = TLSVersion12
+)
+
 func SetInsecureDefaults() {
 	// noop, use secure defaults in fips
 }

--- a/transport/tlscommon/versions_fips_test.go
+++ b/transport/tlscommon/versions_fips_test.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package tlscommon
+
+import (
+	"crypto/tls"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestFIPSTLSVersion(t *testing.T) {
+	// These tests are a bit verbose, but given the sensitivity to changes here, it's not a bad idea.
+	tests := []struct {
+		name      string
+		v         uint16
+		expectErr string
+	}{
+		{
+			name:      "TLSv1.0",
+			v:         tls.VersionTLS10,
+			expectErr: "unsupported tls version: TLSv1.0",
+		},
+		{
+			name:      "TLSv1.1",
+			v:         tls.VersionTLS11,
+			expectErr: "unsupported tls version: TLSv1.1",
+		},
+		{
+			name: "TLSv1.2",
+			v:    tls.VersionTLS12,
+		},
+		{
+			name: "TLSv1.3",
+			v:    tls.VersionTLS13,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tv := TLSVersion(tt.v)
+			if tt.expectErr != "" {
+				require.EqualError(t, tv.Validate(), tt.expectErr)
+			} else {
+				require.NoError(t, tv.Validate())
+			}
+		})
+	}
+}

--- a/transport/tlscommon/versions_nofips.go
+++ b/transport/tlscommon/versions_nofips.go
@@ -19,6 +19,11 @@
 
 package tlscommon
 
+var (
+	// TLSVersionMin is the min TLS version supported.
+	TLSVersionMin = TLSVersion11
+)
+
 // This function is used to avoid a breaking change on previous releases.
 func SetInsecureDefaults() {
 	TLSVersionMin = TLSVersion10


### PR DESCRIPTION
## What does this PR do?

bump supported min tls version to 1.2

## Why is it important?

The default min version is still tls1.2 but 1.1 shouldn't be supported in fips mode even if explicitly configured since it won't be available

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

- Related to https://github.com/elastic/apm-server/issues/15862

