### PR TITLE
feat(fips): restrict supported ciphers in fips mode

### DIFF
--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -98,6 +98,11 @@ func (c *Config) Validate() error {
 		}
 
 	}
+	for _, cs := range c.CipherSuites {
+		if err := cs.Validate(); err != nil {
+			return err
+		}
+	}
 	return c.Certificate.Validate()
 }
 

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -74,7 +74,7 @@ func TestValuesSet(t *testing.T) {
     key: mycert.key
     verification_mode: none
     cipher_suites:
-      - ECDHE-ECDSA-AES-256-CBC-SHA
+      - ECDHE-ECDSA-AES-128-GCM-SHA256
       - ECDHE-ECDSA-AES-256-GCM-SHA384
     supported_protocols: [TLSv1.3]
     curve_types:
@@ -124,7 +124,7 @@ func TestApplyWithConfig(t *testing.T) {
     certificate_authorities: [testdata/ca_test.pem]
     verification_mode: none
     cipher_suites:
-      - "ECDHE-ECDSA-AES-256-CBC-SHA"
+      - "ECDHE-ECDSA-AES-128-GCM-SHA256"
       - "ECDHE-ECDSA-AES-256-GCM-SHA384"
     curve_types: [P-384]
     renegotiation: once

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -71,6 +71,7 @@ var tlsCipherSuites = map[string]CipherSuite{
 	"TLS-CHACHA20-POLY1305-SHA256": CipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256),
 }
 
+var supportedCipherSuites = make(map[CipherSuite]string, len(tlsCipherSuites))
 var tlsCipherSuitesInverse = make(map[CipherSuite]string, len(tlsCipherSuites))
 var tlsRenegotiationSupportTypesInverse = make(map[TLSRenegotiationSupport]string, len(tlsRenegotiationSupportTypes))
 var tlsVerificationModesInverse = make(map[TLSVerificationMode]string, len(tlsVerificationModes))
@@ -252,6 +253,13 @@ func (cs *CipherSuite) Unpack(i interface{}) error {
 		*cs = CipherSuite(o)
 	default:
 		return fmt.Errorf("cipher suite is an unknown type: %T", o)
+	}
+	return nil
+}
+
+func (cs *CipherSuite) Validate() error {
+	if _, ok := supportedCipherSuites[*cs]; !ok {
+		return fmt.Errorf("unsupported tls cipher suite: %s", tls.CipherSuiteName(uint16(*cs)))
 	}
 	return nil
 }

--- a/transport/tlscommon/types_fips.go
+++ b/transport/tlscommon/types_fips.go
@@ -1,0 +1,40 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package tlscommon
+
+import "crypto/tls"
+
+func init() {
+	// try to stick to NIST SP 800-52 Rev.2
+	// avoid CBC mode
+	// avoid go insecure cipher suites
+	// pick ciphers with NIST-approved algorithms
+	for cipherName, i := range tlsCipherSuites {
+		switch uint16(i) {
+		case tls.TLS_AES_128_GCM_SHA256,
+			tls.TLS_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256,
+			tls.TLS_ECDHE_ECDSA_WITH_AES_256_GCM_SHA384:
+			supportedCipherSuites[i] = cipherName
+		}
+	}
+}

--- a/transport/tlscommon/types_fips_test.go
+++ b/transport/tlscommon/types_fips_test.go
@@ -1,0 +1,55 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package tlscommon
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestLoadUnsupporteTLSVersion(t *testing.T) {
+	cfg, err := load(`
+    enabled: true
+    certificate: mycert.pem
+    key: mycert.key
+    verification_mode: ""
+    supported_protocols: [TLSv1.1, TLSv1.2]
+    renegotiation: freely
+  `)
+
+	assert.ErrorContains(t, err, "unsupported tls version")
+	assert.Nil(t, cfg)
+}
+
+func TestLoadUnsupportedCiphers(t *testing.T) {
+	cfg, err := load(`
+    enabled: true
+    certificate: mycert.pem
+    key: mycert.key
+    verification_mode: ""
+    supported_protocols: [TLSv1.2, TLSv1.3]
+    cipher_suites: ["RSA-AES-256-CBC-SHA"]
+    renegotiation: freely
+  `)
+
+	assert.ErrorContains(t, err, "unsupported tls cipher suite: TLS_RSA_WITH_AES_256_CBC_SHA")
+	assert.Nil(t, cfg)
+}

--- a/transport/tlscommon/types_nofips.go
+++ b/transport/tlscommon/types_nofips.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build !requirefips
+
+package tlscommon
+
+func init() {
+	// all tls cipher suites are supported
+	for cipherName, i := range tlsCipherSuites {
+		supportedCipherSuites[i] = cipherName
+	}
+}

--- a/transport/tlscommon/types_test.go
+++ b/transport/tlscommon/types_test.go
@@ -92,7 +92,7 @@ func TestRepackConfig(t *testing.T) {
     verification_mode: certificate
     supported_protocols: [TLSv1.2, TLSv1.3]
     cipher_suites:
-      - RSA-AES-256-CBC-SHA
+      - ECDHE-ECDSA-AES-256-GCM-SHA384
     certificate_authorities:
       - /path/to/ca.crt
     certificate: /path/to/cert.crt
@@ -121,7 +121,7 @@ func TestRepackConfigFromJSON(t *testing.T) {
     "enabled": true,
     "verification_mode": "certificate",
     "supported_protocols": ["TLSv1.2", "TLSv1.3"],
-    "cipher_suites": ["RSA-AES-256-CBC-SHA"],
+    "cipher_suites": ["ECDHE-ECDSA-AES-256-GCM-SHA384"],
     "certificate_authorities": ["/path/to/ca.crt"],
     "certificate": "/path/to/cert.crt",
     "key": "/path/to/key.crt",


### PR DESCRIPTION
## What does this PR do?

no CBC mode
drop ciphers using non NIST-approved algos
only pick ciphers from secure list
update tests to pass in fips mode
add fips-only tests to validate behaviour with unsupported ciphers

## Why is it important?

this seems to be aligned with the go policy upstream and what's recommended in the nist document

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

- 

