### PR TITLE
enhancement(5039): bump up go version to 1.24, replace pbkdf2 with stdlib pbkdf2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/elastic/elastic-agent-libs
 
-go 1.22.12
+go 1.24
 
 require (
 	github.com/Microsoft/go-winio v0.5.2
@@ -20,7 +20,6 @@ require (
 	go.elastic.co/ecszap v1.0.2
 	go.elastic.co/go-licence-detector v0.6.0
 	go.uber.org/zap v1.27.0
-	golang.org/x/crypto v0.32.0
 	golang.org/x/net v0.34.0
 	golang.org/x/sys v0.29.0
 	golang.org/x/text v0.21.0
@@ -53,6 +52,7 @@ require (
 	go.opentelemetry.io/otel/metric v1.28.0 // indirect
 	go.opentelemetry.io/otel/trace v1.28.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
+	golang.org/x/crypto v0.32.0 // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect


### PR DESCRIPTION
- Enhancement

## What does this PR do?

Bumps up the go version to 1.24 and replaces x/crypto/pbkdf2 with stdlib pbkdf2.

## Why is it important?

We are moving away from using x/crypto to be fips compliant

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- ~~[ ] I have commented my code, particularly in hard-to-understand areas~~
- ~~[ ] I have added tests that prove my fix is effective or that my feature works~~

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/ingest-dev/issues/5039
- Relates https://github.com/elastic/elastic-agent/pull/7072

