### PR TITLE
Fixes #292

### DIFF
--- a/transport/httpcommon/diag.go
+++ b/transport/httpcommon/diag.go
@@ -192,7 +192,7 @@ func diagError(err error) string {
 			return fmt.Sprintf("%v:  caused by missing mTLS client cert.", uErr)
 		}
 		if strings.Contains(errString, "remote error: tls: expired certificate") {
-			return fmt.Sprintf("%v: caused by expired mTLS client cert..", uErr)
+			return fmt.Sprintf("%v: caused by expired mTLS client cert.", uErr)
 		}
 		if strings.Contains(errString, "remote error: tls: bad certificate") {
 			return fmt.Sprintf("%v: caused by invalid mTLS client cert, does the server trust the CA used for the client cert?.", uErr)

--- a/transport/httpcommon/diag.go
+++ b/transport/httpcommon/diag.go
@@ -30,6 +30,7 @@ import (
 	"net/http/httptrace"
 	"net/textproto"
 	"net/url"
+	"strings"
 
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
@@ -181,15 +182,19 @@ func diagError(err error) string {
 	// keep unwrapping to url.Error as the last error as other failures can be embedded in a url.Error
 	// Can detect if an HTTPS request is made to an HTTP server
 	var uErr *url.Error
+
 	if errors.As(err, &uErr) {
-		switch uErr.Err.Error() {
-		case "http: server gave HTTP response to HTTPS client":
+		errString := uErr.Err.Error()
+		if strings.Contains(errString, "http: server gave HTTP response to HTTPS client") {
 			return fmt.Sprintf("%v: caused by using HTTPS schema on HTTP server.", uErr)
-		case "remote error: tls: certificate required":
-			return fmt.Sprintf("%v: caused by missing mTLS client cert.", uErr)
-		case "remote error: tls: expired certificate":
-			return fmt.Sprintf("%v: caused by expired mTLS client cert.", uErr)
-		case "remote error: tls: bad certificate":
+		}
+		if strings.Contains(errString, "remote error: tls: certificate required") {
+			return fmt.Sprintf("%v:  caused by missing mTLS client cert.", uErr)
+		}
+		if strings.Contains(errString, "remote error: tls: expired certificate") {
+			return fmt.Sprintf("%v: caused by expired mTLS client cert..", uErr)
+		}
+		if strings.Contains(errString, "remote error: tls: bad certificate") {
 			return fmt.Sprintf("%v: caused by invalid mTLS client cert, does the server trust the CA used for the client cert?.", uErr)
 		}
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
The `diagError` method expects the error message to have exact match. This is not always true.
This change matches the subset of the error using `strings.Contains` method.

It was locally tested to work using 
```
go run golang.org/x/tools/cmd/stress@latest ./httpcommon.test -test.run Test_diagError -test.v
```



## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes #292


