### PR TITLE
fix: validate tls server config fields

### DIFF
--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -131,6 +131,22 @@ func (c *ServerConfig) Validate() error {
 			return ErrCertificateUnspecified
 		}
 	}
+	for _, v := range c.Versions {
+		if err := v.Validate(); err != nil {
+			return err
+		}
+
+	}
+	for _, cs := range c.CipherSuites {
+		if err := cs.Validate(); err != nil {
+			return err
+		}
+	}
+	for _, ct := range c.CurveTypes {
+		if err := ct.Validate(); err != nil {
+			return err
+		}
+	}
 	return c.Certificate.Validate()
 }
 

--- a/transport/tlscommon/server_config_test.go
+++ b/transport/tlscommon/server_config_test.go
@@ -105,9 +105,9 @@ func Test_ServerConfig_Repack(t *testing.T) {
 		yaml: `
     enabled: true
     verification_mode: certificate
-    supported_protocols: [TLSv1.1, TLSv1.2]
+    supported_protocols: [TLSv1.2, TLSv1.3]
     cipher_suites:
-      - RSA-AES-256-CBC-SHA
+      - ECDHE-ECDSA-AES-128-GCM-SHA256
     certificate_authorities:
       - /path/to/ca.crt
     certificate: /path/to/cert.cry
@@ -123,9 +123,9 @@ func Test_ServerConfig_Repack(t *testing.T) {
 		yaml: `
     enabled: true
     verification_mode: certificate
-    supported_protocols: [TLSv1.1, TLSv1.2]
+    supported_protocols: [TLSv1.2, TLSv1.3]
     cipher_suites:
-      - RSA-AES-256-CBC-SHA
+      - ECDHE-ECDSA-AES-128-GCM-SHA256
     certificate_authorities:
       - /path/to/ca.crt
     certificate: /path/to/cert.cry
@@ -140,9 +140,9 @@ func Test_ServerConfig_Repack(t *testing.T) {
 		yaml: `
     enabled: true
     verification_mode: certificate
-    supported_protocols: [TLSv1.1, TLSv1.2]
+    supported_protocols: [TLSv1.2, TLSv1.3]
     cipher_suites:
-      - RSA-AES-256-CBC-SHA
+      - ECDHE-ECDSA-AES-128-GCM-SHA256
     certificate: /path/to/cert.cry
     key: /path/to/key/crt
     curve_types:
@@ -185,8 +185,8 @@ func Test_ServerConfig_RepackJSON(t *testing.T) {
 		json: `{
     "enabled": true,
     "verification_mode": "certificate",
-    "supported_protocols": ["TLSv1.1", "TLSv1.2"],
-    "cipher_suites": ["RSA-AES-256-CBC-SHA"],
+    "supported_protocols": ["TLSv1.2", "TLSv1.3"],
+    "cipher_suites": ["ECDHE-ECDSA-AES-128-GCM-SHA256"],
     "certificate_authorities": ["/path/to/ca.crt"],
     "certificate": "/path/to/cert.crt",
     "key": "/path/to/key.crt",
@@ -202,8 +202,8 @@ func Test_ServerConfig_RepackJSON(t *testing.T) {
 		json: `{
     "enabled": true,
     "verification_mode": "certificate",
-    "supported_protocols": ["TLSv1.1", "TLSv1.2"],
-    "cipher_suites": ["RSA-AES-256-CBC-SHA"],
+    "supported_protocols": ["TLSv1.2", "TLSv1.3"],
+    "cipher_suites": ["ECDHE-ECDSA-AES-128-GCM-SHA256"],
     "certificate_authorities": ["/path/to/ca.crt"],
     "certificate": "/path/to/cert.crt",
     "key": "/path/to/key.crt",
@@ -218,8 +218,8 @@ func Test_ServerConfig_RepackJSON(t *testing.T) {
 		json: `{
     "enabled": true,
     "verification_mode": "certificate",
-    "supported_protocols": ["TLSv1.1", "TLSv1.2"],
-    "cipher_suites": ["RSA-AES-256-CBC-SHA"],
+    "supported_protocols": ["TLSv1.2", "TLSv1.3"],
+    "cipher_suites": ["ECDHE-ECDSA-AES-128-GCM-SHA256"],
     "certificate": "/path/to/cert.crt",
     "key": "/path/to/key.crt",
     "curve_types": "P-384",

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -213,7 +213,7 @@ func TestApplyWithServerConfig(t *testing.T) {
     verification_mode: none
     client_authentication: optional
     cipher_suites:
-      - "ECDHE-ECDSA-AES-256-CBC-SHA"
+      - "ECDHE-ECDSA-AES-128-GCM-SHA256"
       - "ECDHE-ECDSA-AES-256-GCM-SHA384"
     curve_types: [P-384]
   `


### PR DESCRIPTION
## What does this PR do?

validate cipher suites, versions and curve types
update tests to ensure they also pass in fips mode

## Why is it important?

TLS server config fields are not being validated when validate the config

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

