### PR TITLE
feat(file/stderr): add RedirectStandardError stub for js

### DIFF
--- a/file/stderr_js.go
+++ b/file/stderr_js.go
@@ -1,0 +1,30 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build js
+
+package file
+
+import (
+	"os"
+)
+
+// RedirectStandardError causes all standard error output to be directed to the
+// given file.
+func RedirectStandardError(toFile *os.File) error {
+	panic("RedirectStandardError not supported in js")
+}


### PR DESCRIPTION
## What does this PR do?

Add a `file.RedirectStandardError()` stub for `GOOS=js` that panics if used. 

## Why is it important?

The purpose is to allow code to compile under GOOS=js.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

