### PR TITLE
User Agent: Rearrange the user agent to prioritize displaying the most useful information.

### DIFF
--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -27,17 +27,13 @@ import (
 func UserAgent(binaryNameCapitalized string, version, commit, buildTime string, additionalComments ...string) string {
 	var builder strings.Builder
 	builder.WriteString("Elastic-" + binaryNameCapitalized + "/" + version + " ")
-	uaValues := []string{
-		runtime.GOOS,
-		runtime.GOARCH,
-		commit,
-		buildTime,
-	}
+	var uaValues []string
 	for _, val := range additionalComments {
 		if val != "" {
 			uaValues = append(uaValues, val)
 		}
 	}
+	uaValues = append(uaValues, runtime.GOOS, runtime.GOARCH, commit, buildTime)
 	builder.WriteByte('(')
 	builder.WriteString(strings.Join(uaValues, "; "))
 	builder.WriteByte(')')

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -35,5 +35,5 @@ func TestUserAgent(t *testing.T) {
 	assert.Regexp(t, regexp.MustCompile(`^Elastic-FakeBeat`), ua)
 
 	ua2 := UserAgent("FakeBeat", v, commit, buildTime, "integration_name/1.2.3")
-	assert.Regexp(t, regexp.MustCompile(`; integration_name\/1\.2\.3\)$`), ua2)
+	assert.Regexp(t, regexp.MustCompile(`\(integration_name\/1\.2\.3;`), ua2)
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Change the `user_agent` to display information in another order.

From: `Elastic-<binaryNameCapitalized>/<version> (<runtime.GOOS>; <runtime.GOARCH>; <commit>; <buildTime>; <Managed|Standalone>; <Unprivileged>`

To: `Elastic-<binaryNameCapitalized>/<version> (<Managed|Standalone>; <Unprivileged>; <runtime.GOOS>; <runtime.GOARCH>; <commit>; <buildTime>`

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Some proxy log solutions are stripping the user_agent size and the most useful information are therefore lost.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

