### PR TITLE
make `addcaller` a gloabl field

### DIFF
--- a/logp/config.go
+++ b/logp/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	WithFields map[string]any `config:"with_fields" yaml:"with_fields"`
 
 	environment Environment
-	addCaller   bool // Adds package and line number info to messages.
+	AddCaller   bool // Adds package and line number info to messages.
 	development bool // Controls how DPanic behaves.
 }
 
@@ -98,7 +98,7 @@ func DefaultConfig(environment Environment) Config {
 			Period:  30 * time.Second,
 		},
 		environment: environment,
-		addCaller:   true,
+		AddCaller:   true,
 	}
 }
 
@@ -122,7 +122,7 @@ func DefaultEventConfig(environment Environment) Config {
 			Enabled: false,
 		},
 		environment: environment,
-		addCaller:   true,
+		AddCaller:   true,
 	}
 }
 

--- a/logp/core.go
+++ b/logp/core.go
@@ -394,7 +394,7 @@ func DevelopmentSetup(options ...Option) error {
 		Level:       DebugLevel,
 		ToStderr:    true,
 		development: true,
-		addCaller:   true,
+		AddCaller:   true,
 	}
 	for _, apply := range options {
 		apply(&cfg)
@@ -429,7 +429,7 @@ func Sync() error {
 
 func makeOptions(cfg Config) []zap.Option {
 	var options []zap.Option
-	if cfg.addCaller {
+	if cfg.AddCaller {
 		options = append(options, zap.AddCaller())
 	}
 	if cfg.development {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Currently, logs from beats-receivers do not contain package and line info.  `addCaller` should be configurable outside the `logp` package to support this.

For example, setting `AddCaller` to true [here](https://github.com/elastic/beats/blob/main/libbeat/cmd/instance/beat.go#L331) will  allow beatreceivers to emit information about log origin

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

