### PR TITLE
fix: support logptest wrapcore option

### DIFF
--- a/logp/logptest/logptest.go
+++ b/logp/logptest/logptest.go
@@ -30,9 +30,10 @@ import (
 func NewTestingLogger(t testing.TB, selector string, options ...logp.LogOption) *logp.Logger {
 	log := zaptest.NewLogger(t)
 	log = log.Named(selector)
-	options = append(options, zap.WrapCore(func(zapcore.Core) zapcore.Core {
+	wrapCore := zap.WrapCore(func(zapcore.Core) zapcore.Core {
 		return log.Core()
-	}))
+	})
+	options = append([]logp.LogOption{wrapCore}, options...)
 	logger, err := logp.NewDevelopmentLogger(selector, options...)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
## What does this PR do?

move zaptest wrapcore to the beginning so the provided LogOptions always get appllied

## Why is it important?

any logoption involving wrapcore is being overwritten by the zaptest wrapcore

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

