### PR TITLE
fix: ignore os.IsNotExist error when removing stale UNIX socket

### DIFF
--- a/api/make_listener_posix.go
+++ b/api/make_listener_posix.go
@@ -26,9 +26,10 @@ import (
 	"os"
 
 	"github.com/elastic/elastic-agent-libs/api/npipe"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func makeListener(cfg Config) (net.Listener, error) {
+func makeListener(log *logp.Logger, cfg Config) (net.Listener, error) {
 	if len(cfg.User) > 0 {
 		return nil, errors.New("specifying a user is not supported under this platform")
 	}
@@ -48,7 +49,8 @@ func makeListener(cfg Config) (net.Listener, error) {
 
 	if network == unixNetwork {
 		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			if err := os.Remove(path); err != nil {
+			log.Debugf("stat %q failed: %v", path, err)
+			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
 				return nil, fmt.Errorf("cannot remove existing unix socket file at location %s: %w", path, err)
 			}
 		}

--- a/api/make_listener_posix.go
+++ b/api/make_listener_posix.go
@@ -26,10 +26,9 @@ import (
 	"os"
 
 	"github.com/elastic/elastic-agent-libs/api/npipe"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func makeListener(log *logp.Logger, cfg Config) (net.Listener, error) {
+func makeListener(cfg Config) (net.Listener, error) {
 	if len(cfg.User) > 0 {
 		return nil, errors.New("specifying a user is not supported under this platform")
 	}
@@ -48,11 +47,8 @@ func makeListener(log *logp.Logger, cfg Config) (net.Listener, error) {
 	}
 
 	if network == unixNetwork {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			log.Debugf("stat %q failed: %v", path, err)
-			if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
-				return nil, fmt.Errorf("cannot remove existing unix socket file at location %s: %w", path, err)
-			}
+		if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+			return nil, fmt.Errorf("cannot remove existing unix socket file at location %s: %w", path, err)
 		}
 	}
 

--- a/api/make_listener_windows.go
+++ b/api/make_listener_windows.go
@@ -25,9 +25,10 @@ import (
 	"net"
 
 	"github.com/elastic/elastic-agent-libs/api/npipe"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func makeListener(cfg Config) (net.Listener, error) {
+func makeListener(_ *logp.Logger, cfg Config) (net.Listener, error) {
 	if len(cfg.User) > 0 && len(cfg.SecurityDescriptor) > 0 {
 		return nil, errors.New("user and security_descriptor are mutually exclusive, define only one of them")
 	}

--- a/api/make_listener_windows.go
+++ b/api/make_listener_windows.go
@@ -25,10 +25,9 @@ import (
 	"net"
 
 	"github.com/elastic/elastic-agent-libs/api/npipe"
-	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-func makeListener(_ *logp.Logger, cfg Config) (net.Listener, error) {
+func makeListener(cfg Config) (net.Listener, error) {
 	if len(cfg.User) > 0 && len(cfg.SecurityDescriptor) > 0 {
 		return nil, errors.New("user and security_descriptor are mutually exclusive, define only one of them")
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -67,7 +67,7 @@ func NewFromConfig(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, e
 // new creates the server from a config struct
 func new(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, error) {
 	srv := &http.Server{ReadHeaderTimeout: cfg.Timeout}
-	l, err := makeListener(log, cfg)
+	l, err := makeListener(cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -67,7 +67,7 @@ func NewFromConfig(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, e
 // new creates the server from a config struct
 func new(log *logp.Logger, mux *http.ServeMux, cfg Config) (*Server, error) {
 	srv := &http.Server{ReadHeaderTimeout: cfg.Timeout}
-	l, err := makeListener(cfg)
+	l, err := makeListener(log, cfg)
 	if err != nil {
 		return nil, err
 	}

--- a/api/server.go
+++ b/api/server.go
@@ -123,7 +123,7 @@ func (s *Server) AttachHandler(route string, h http.Handler) (err error) {
 	}()
 	s.log.Infof("Attempting to attach %q to server.", route)
 	s.mux.Handle(route, h)
-	return //nolint:nakedret // returning from recover
+	return // returning from recover
 }
 
 func parse(host string, port int) (string, string, error) {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR improves the cleanup logic for removing existing UNIX socket files before binding a new listener.

Previously, if the socket file was deleted between the `os.Stat` and `os.Remove` calls, `os.Remove` would return an `os.IsNotExist` error and the listener setup would fail unnecessarily.

This PR updates the logic to **ignore `os.IsNotExist` errors from `os.Remove`**, preventing spurious failures in this scenario. It also adds a debug log message when `os.Stat` reports an error, to aid troubleshooting.


## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This change improves the robustness of UNIX socket listener creation. Without this change, users may encounter hard-to-debug startup failures if the socket file is unexpectedly absent between `os.Stat` and `os.Remove`.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
N/A

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent-libs/issues/315

