### PR TITLE
feat: allow P-521 curve in fips mode

### DIFF
--- a/transport/tlscommon/types_fips.go
+++ b/transport/tlscommon/types_fips.go
@@ -37,10 +37,13 @@ func init() {
 			supportedCipherSuites[i] = cipherName
 		}
 	}
-	// only allow P256, P384.
+	// Elliptic curves approved for use in ECDSA are specified in SP 800-186,
+	// as implemented in FIPS 186-5.
+	// Based on NIST SP 800-186 section 3 and SP 800-56A Rev.3
+	// only allows P-256, P-384, P-521
 	for name, curveType := range tlsCurveTypes {
 		switch tls.CurveID(curveType) {
-		case tls.CurveP256, tls.CurveP384:
+		case tls.CurveP256, tls.CurveP384, tls.CurveP521:
 			supportedCurveTypes[curveType] = name
 		}
 	}


### PR DESCRIPTION
## What does this PR do?

allow P-521 in fips mode

## Why is it important?

Elliptic curves approved for use in ECDSA are specified in SP 800-186, as implemented in FIPS 186-5.
Based on NIST SP 800-186 section 3 and SP 800-56A Rev.3 only allows P-256, P-384, P-521

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

