### PR TITLE
Report FIPS-capability in ListAgentsResponse

### DIFF
--- a/kibana/fleet.go
+++ b/kibana/fleet.go
@@ -321,6 +321,11 @@ type AgentCommon struct {
 		Host struct {
 			Hostname string `json:"hostname"`
 		} `json:"host"`
+		Elastic struct {
+			Agent struct {
+				FIPS bool `json:"fips"`
+			} `json:"agent"`
+		} `json:"elastic"`
 	} `json:"local_metadata"`
 	PolicyID       string               `json:"policy_id"`
 	PolicyRevision int                  `json:"policy_revision"`

--- a/kibana/fleet_test.go
+++ b/kibana/fleet_test.go
@@ -236,6 +236,7 @@ func TestFleetListAgents(t *testing.T) {
 	require.Equal(t, "eba58282-ec1c-4d9e-aac0-2b29f754b437", item.Agent.ID)
 	require.Equal(t, "8.8.0", item.Agent.Version)
 	require.Equal(t, "c75d66b1dac5", item.LocalMetadata.Host.Hostname)
+	require.Equal(t, true, item.LocalMetadata.Elastic.Agent.FIPS)
 }
 
 func TestFleetGetAgent(t *testing.T) {

--- a/kibana/testdata/fleet_list_agents_response.json
+++ b/kibana/testdata/fleet_list_agents_response.json
@@ -20,7 +20,8 @@
             "log_level": "info",
             "snapshot": false,
             "upgradeable": false,
-            "version": "8.8.0"
+            "version": "8.8.0",
+            "fips": true
           }
         },
         "host": {
@@ -134,7 +135,8 @@
             "log_level": "info",
             "snapshot": false,
             "upgradeable": false,
-            "version": "8.8.0"
+            "version": "8.8.0",
+            "fips": true
           }
         },
         "host": {


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

The `ListAgentsResponse` method on the Kibana Fleet client returns a list of Agents.  This PR adds a new `LocalMetadata.Elastic.Agent.FIPS` boolean field to each Agent in the list.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

So consumers of the `ListAgentsResponse` API, e.g. tests, can check if the returned Agents are FIPS-capable or not.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

