### PR TITLE
[logging] - Fix a regression related to `--environment` and logging config

### DIFF
--- a/logp/configure/logging_test.go
+++ b/logp/configure/logging_test.go
@@ -1,0 +1,95 @@
+package configure
+
+import (
+	"testing"
+
+	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoggerOutputEnvrionment(t *testing.T) {
+	testCases := []struct {
+		name        string
+		cfg         *config.C
+		expectedCfg *logp.Config
+		env         logp.Environment
+	}{
+		{
+			name: "no logging config - output should be to_files",
+			cfg:  config.MustNewConfigFrom(map[string]interface{}{}),
+			expectedCfg: &logp.Config{
+				ToFiles:  true,
+				ToStderr: false,
+			},
+			env: logp.DefaultEnvironment,
+		},
+		{
+			name: "output should be to_files",
+			cfg: config.MustNewConfigFrom(map[string]interface{}{
+				"to_files": true,
+			}),
+			expectedCfg: &logp.Config{
+				ToFiles:  true,
+				ToStderr: false,
+			},
+			env: logp.DefaultEnvironment,
+		},
+		{
+			name: "output should be to_stderr",
+			cfg: config.MustNewConfigFrom(map[string]interface{}{
+				"to_stderr": true,
+			}),
+			expectedCfg: &logp.Config{
+				ToFiles:  false,
+				ToStderr: true,
+			},
+			env: logp.DefaultEnvironment,
+		},
+		{
+			name: "output should be to_stderr - systemd",
+			cfg:  config.MustNewConfigFrom(map[string]interface{}{}),
+			expectedCfg: &logp.Config{
+				ToFiles:  false,
+				ToStderr: true,
+			},
+			env: logp.SystemdEnvironment,
+		},
+		{
+			name: "output should be to_stderr - systemd",
+			cfg: config.MustNewConfigFrom(map[string]interface{}{
+				"to_stderr": true,
+			}),
+			expectedCfg: &logp.Config{
+				ToFiles:  false,
+				ToStderr: true,
+			},
+			env: logp.SystemdEnvironment,
+		},
+		{
+			name: "output should be to_files - systemd",
+			cfg: config.MustNewConfigFrom(map[string]interface{}{
+				"to_files": true,
+			}),
+			expectedCfg: &logp.Config{
+				ToFiles:  true,
+				ToStderr: false,
+			},
+			env: logp.SystemdEnvironment,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run("test environment", func(t *testing.T) {
+			environment = tc.env
+			defer func() {
+				environment = logp.DefaultEnvironment
+			}()
+			config := logp.DefaultConfig(environment)
+			err := tc.cfg.Unpack(&config)
+			require.NoError(t, err, "unpacking config should not fail")
+			applyFlags(&config)
+			require.Equal(t, tc.expectedCfg.ToFiles, config.ToFiles)
+			require.Equal(t, tc.expectedCfg.ToStderr, config.ToStderr)
+		})
+	}
+}


### PR DESCRIPTION
## What does this PR do?

The logs are writter to `stderr` even If user is running beats with `--environment <container|systemd>` and has set `logging.to_files: true` in config. Since https://github.com/elastic/beats/pull/41186 got merged, `--environment`  is taking precedence over `logging.to_files: true`. 

We update `ToFIles` and `ToStderr` in `DefaultConfig()` based on the environment
https://github.com/elastic/elastic-agent-libs/blob/d2796b9e6a1b25e5afca128bbb8bbde4ca382f50/logp/config.go#L74-L83

This PR fixes the behaviour based on following assumptions:
- We can't have both `to_files` and `to_stderr` enabled.
- We make use of defaultConfig to decide which option to pick. 
    - If current `to_files` option is different than default `to_files`, then the user has chanegd the config and this should take precedence.
    - Same for `to_stderr`

## Why is it important?

If the user wants to redirect logs to files for systemd, then he/she should only set `logging.to_files: true` and it should work. However, both `ToFIles` and `ToStderr` are set to true when we unpack user's config on defaultConfig. This becomes a problem because `ToStderr` case is still true and we write logs to stdout https://github.com/elastic/elastic-agent-libs/blob/d2796b9e6a1b25e5afca128bbb8bbde4ca382f50/logp/core.go#L364-L376.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates https://github.com/elastic/beats/issues/41767

