### PR TITLE
Add nop logger

### DIFF
--- a/logp/logger.go
+++ b/logp/logger.go
@@ -53,6 +53,12 @@ func NewLogger(selector string, options ...LogOption) *Logger {
 	return newLogger(loadLogger().rootLogger, selector, options...)
 }
 
+// NewNopLogger returns a no-op logger
+func NewNopLogger() *Logger {
+	logger := zap.NewNop()
+	return &Logger{logger, logger.Sugar()}
+}
+
 // NewProductionLogger returns a production suitable logp.Logger
 func NewProductionLogger(selector string, options ...LogOption) (*Logger, error) {
 	log, err := zap.NewProduction(options...)


### PR DESCRIPTION
## What does this PR do?

This PR adds a no-op logger

## Why is it important?

We're moving away from using global logger instances, this is making more functions to require a logger as an argument, for testing having a no-op logger is very helpful

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

~~## Author's Checklist~~
~~## Related issues~~

