### PR TITLE
[monitoring] Add ClearOnVisitHistogram to adapter for go-metrics

### DIFF
--- a/monitoring/adapter/go-metrics-wrapper.go
+++ b/monitoring/adapter/go-metrics-wrapper.go
@@ -25,7 +25,7 @@ import (
 
 // go-metrics wrapper interface required to unpack the original metric
 type goMetricsWrapper interface {
-	wrapped() interface{}
+	wrapped() any
 }
 
 // go-metrics wrappers
@@ -40,13 +40,14 @@ type (
 		g metrics.FunctionalGaugeFloat64
 	}
 
-	goMetricsHistogram struct{ h metrics.Histogram }
+	goMetricsHistogram             struct{ h metrics.Histogram }
+	goMetricsClearOnVisitHistogram struct{ h *ClearOnVisitHistogram }
 
 	goMetricsMeter struct{ m metrics.Meter }
 )
 
 // goMetricsWrap tries to wrap a metric for use with monitoring package.
-func goMetricsWrap(metric interface{}) (monitoring.Var, bool) {
+func goMetricsWrap(metric any) (monitoring.Var, bool) {
 	switch v := metric.(type) {
 	case *metrics.StandardCounter:
 		return goMetricsCounter{v}, true
@@ -62,42 +63,44 @@ func goMetricsWrap(metric interface{}) (monitoring.Var, bool) {
 		return goMetricsHistogram{v}, true
 	case *metrics.StandardMeter:
 		return goMetricsMeter{v}, true
+	case *ClearOnVisitHistogram:
+		return goMetricsClearOnVisitHistogram{v}, true
 	}
 	return nil, false
 }
 
-func (w goMetricsCounter) wrapped() interface{} { return w.c }
-func (w goMetricsCounter) Get() int64           { return w.c.Count() }
+func (w goMetricsCounter) wrapped() any { return w.c }
+func (w goMetricsCounter) Get() int64   { return w.c.Count() }
 func (w goMetricsCounter) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnInt(w.Get())
 }
 
-func (w goMetricsGauge) wrapped() interface{} { return w.g }
-func (w goMetricsGauge) Get() int64           { return w.g.Value() }
+func (w goMetricsGauge) wrapped() any { return w.g }
+func (w goMetricsGauge) Get() int64   { return w.g.Value() }
 func (w goMetricsGauge) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnInt(w.Get())
 }
 
-func (w goMetricsGaugeFloat64) wrapped() interface{} { return w.g }
-func (w goMetricsGaugeFloat64) Get() float64         { return w.g.Value() }
+func (w goMetricsGaugeFloat64) wrapped() any { return w.g }
+func (w goMetricsGaugeFloat64) Get() float64 { return w.g.Value() }
 func (w goMetricsGaugeFloat64) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnFloat(w.Get())
 }
 
-func (w goMetricsFuncGauge) wrapped() interface{} { return w.g }
-func (w goMetricsFuncGauge) Get() int64           { return w.g.Value() }
+func (w goMetricsFuncGauge) wrapped() any { return w.g }
+func (w goMetricsFuncGauge) Get() int64   { return w.g.Value() }
 func (w goMetricsFuncGauge) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnInt(w.Get())
 }
 
-func (w goMetricsFuncGaugeFloat) wrapped() interface{} { return w.g }
-func (w goMetricsFuncGaugeFloat) Get() float64         { return w.g.Value() }
+func (w goMetricsFuncGaugeFloat) wrapped() any { return w.g }
+func (w goMetricsFuncGaugeFloat) Get() float64 { return w.g.Value() }
 func (w goMetricsFuncGaugeFloat) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnFloat(w.Get())
 }
 
-func (w goMetricsHistogram) wrapped() interface{} { return w.h }
-func (w goMetricsHistogram) Get() int64           { return w.h.Sum() }
+func (w goMetricsHistogram) wrapped() any { return w.h }
+func (w goMetricsHistogram) Get() int64   { return w.h.Sum() }
 func (w goMetricsHistogram) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnRegistryStart()
 	defer vs.OnRegistryFinished()
@@ -126,8 +129,30 @@ func (w goMetricsHistogram) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnFloat(ps[4])
 }
 
-func (w goMetricsMeter) wrapped() interface{} { return w.m }
-func (w goMetricsMeter) Get() int64           { return w.m.Count() }
+func (w goMetricsMeter) wrapped() any { return w.m }
+func (w goMetricsMeter) Get() int64   { return w.m.Count() }
 func (w goMetricsMeter) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
 	vs.OnInt(w.Get())
+}
+
+func (w goMetricsClearOnVisitHistogram) wrapped() any { return w.h }
+func (w goMetricsClearOnVisitHistogram) Get() int64   { return w.h.Sum() }
+func (w goMetricsClearOnVisitHistogram) Visit(_ monitoring.Mode, vs monitoring.Visitor) {
+	vs.OnRegistryStart()
+	defer vs.OnRegistryFinished()
+
+	h := w.h.Snapshot()
+	w.h.Clear()
+	ps := h.Percentiles([]float64{0.5, 0.99})
+	vs.OnKey("count")
+	vs.OnInt(h.Count())
+	vs.OnKey("min")
+	vs.OnInt(h.Min())
+	vs.OnKey("max")
+	vs.OnInt(h.Max())
+	vs.OnKey("median")
+	vs.OnFloat(ps[0])
+	vs.OnKey("p99")
+	vs.OnFloat(ps[1])
+
 }

--- a/monitoring/adapter/go-metrics.go
+++ b/monitoring/adapter/go-metrics.go
@@ -36,9 +36,10 @@ import (
 // the go-metrics.Registry interface.
 //
 // Note: with the go-metrics using `interface{}`, there is no guarantee
-//       a variable satisfying any of go-metrics interfaces is returned.
-//       It's recommended to not mix go-metrics with other metrics types
-//       in the same namespace.
+//
+//	a variable satisfying any of go-metrics interfaces is returned.
+//	It's recommended to not mix go-metrics with other metrics types
+//	in the same namespace.
 type GoMetricsRegistry struct {
 	mutex sync.Mutex
 
@@ -54,8 +55,9 @@ type GoMetricsRegistry struct {
 // If the monitoring.Registry does not exist yet, a new one will be generated.
 //
 // Note: with users of go-metrics potentially removing any metric at runtime,
-//       it's recommended to have the underlying registry being generated with
-//       `monitoring.IgnorePublishExpvar`.
+//
+//	it's recommended to have the underlying registry being generated with
+//	`monitoring.IgnorePublishExpvar`.
 func GetGoMetrics(parent *monitoring.Registry, name string, filters ...MetricFilter) *GoMetricsRegistry {
 	v := parent.Get(name)
 	if v == nil {
@@ -97,9 +99,10 @@ func (r *GoMetricsRegistry) find(name string) interface{} {
 // Get retrieves a registered metric by name. If the name is unknown, Get returns nil.
 //
 // Note: with the return values being `interface{}`, there is no guarantee
-//       a variable satisfying any of go-metrics interfaces is returned.
-//       It's recommended to not mix go-metrics with other metrics types in one
-//       namespace.
+//
+//	a variable satisfying any of go-metrics interfaces is returned.
+//	It's recommended to not mix go-metrics with other metrics types in one
+//	namespace.
 func (r *GoMetricsRegistry) Get(name string) interface{} {
 	r.mutex.Lock()
 	defer r.mutex.Unlock()

--- a/monitoring/adapter/go-metrics.go
+++ b/monitoring/adapter/go-metrics.go
@@ -63,7 +63,7 @@ func GetGoMetrics(parent *monitoring.Registry, name string, filters ...MetricFil
 	if v == nil {
 		return NewGoMetrics(parent, name, filters...)
 	}
-	return newGoMetrics(v.(*monitoring.Registry), filters...)
+	return newGoMetrics(v.(*monitoring.Registry), filters...) //nolint:errcheck //code depends on panic
 }
 
 // NewGoMetrics creates and registers a new GoMetricsRegistry with the parent

--- a/monitoring/adapter/go-metrics_test.go
+++ b/monitoring/adapter/go-metrics_test.go
@@ -116,8 +116,8 @@ func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
 	monReg := monitoring.NewRegistry()
 	histogramSample := metrics.NewUniformSample(10)
 	clearedHistogramSample := metrics.NewUniformSample(10)
-	NewGoMetrics(monReg, "original", Accept).Register("histogram", metrics.NewHistogram(histogramSample))
-	NewGoMetrics(monReg, "cleared", Accept).Register("histogram", NewClearOnVisitHistogram(clearedHistogramSample))
+	_ = NewGoMetrics(monReg, "original", Accept).Register("histogram", metrics.NewHistogram(histogramSample))
+	_ = NewGoMetrics(monReg, "cleared", Accept).Register("histogram", NewClearOnVisitHistogram(clearedHistogramSample))
 	dataPoints := [...]int{2, 4, 8, 4, 2}
 	dataPointsMedian := 4.0
 	for _, i := range dataPoints {
@@ -125,7 +125,7 @@ func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
 		clearedHistogramSample.Update(int64(i))
 	}
 
-	pre_snapshot := []struct {
+	preSnapshot := []struct {
 		expected any
 		actual   any
 		msg      string
@@ -152,7 +152,7 @@ func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
 		},
 	}
 
-	for _, tc := range pre_snapshot {
+	for _, tc := range preSnapshot {
 		require.Equal(t, tc.expected, tc.actual, tc.msg)
 	}
 
@@ -163,7 +163,7 @@ func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
 	// clearedHistogramSample have been reset to zero, but the
 	// snapshot reports the values before the clear
 
-	post_snapshot := []struct {
+	postSnapshot := []struct {
 		expected any
 		actual   any
 		msg      string
@@ -210,7 +210,7 @@ func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
 		},
 	}
 
-	for _, tc := range post_snapshot {
+	for _, tc := range postSnapshot {
 		require.Equal(t, tc.expected, tc.actual, tc.msg)
 	}
 }

--- a/monitoring/adapter/go-metrics_test.go
+++ b/monitoring/adapter/go-metrics_test.go
@@ -58,7 +58,7 @@ func TestGoMetricsAdapter(t *testing.T) {
 	// register some metrics and check they're satisfying the go-metrics interface
 	// no matter if owned by monitoring or go-metrics
 	for name := range counters {
-		cnt, ok := reg.GetOrRegister(name, func() interface{} {
+		cnt, ok := reg.GetOrRegister(name, func() any {
 			return metrics.NewCounter()
 		}).(metrics.Counter)
 		require.True(t, ok)
@@ -66,7 +66,7 @@ func TestGoMetricsAdapter(t *testing.T) {
 	}
 
 	for name := range meters {
-		meter, ok := reg.GetOrRegister(name, func() interface{} {
+		meter, ok := reg.GetOrRegister(name, func() any {
 			return metrics.NewMeter()
 		}).(metrics.Meter)
 		require.True(t, ok)
@@ -100,14 +100,117 @@ func TestGoMetricsAdapter(t *testing.T) {
 	}
 
 	// check Each only returns metrics not registered with monitoring.Registry
-	reg.Each(func(name string, v interface{}) {
+	reg.Each(func(name string, v any) {
 		if strings.HasPrefix(name, "mon") {
 			t.Errorf("metric %v should not have been reported by each", name)
 		}
 	})
-	monReg.Do(monitoring.Full, func(name string, v interface{}) {
+	monReg.Do(monitoring.Full, func(name string, v any) {
 		if !strings.HasPrefix(name, "test.mon") {
 			t.Errorf("metric %v should not have been reported by each", name)
 		}
 	})
+}
+
+func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
+	monReg := monitoring.NewRegistry()
+	histogramSample := metrics.NewUniformSample(10)
+	clearedHistogramSample := metrics.NewUniformSample(10)
+	NewGoMetrics(monReg, "original", Accept).Register("histogram", metrics.NewHistogram(histogramSample))
+	NewGoMetrics(monReg, "cleared", Accept).Register("histogram", NewClearOnVisitHistogram(clearedHistogramSample))
+	dataPoints := [...]int{2, 4, 8, 4, 2}
+	dataPointsMedian := 4.0
+	for _, i := range dataPoints {
+		histogramSample.Update(int64(i))
+		clearedHistogramSample.Update(int64(i))
+	}
+
+	pre_snapshot := []struct {
+		expected any
+		actual   any
+		msg      string
+	}{
+		{
+			actual:   histogramSample.Count(),
+			expected: int64(len(dataPoints)),
+			msg:      "histogram sample count incorrect",
+		},
+		{
+			actual:   clearedHistogramSample.Count(),
+			expected: int64(len(dataPoints)),
+			msg:      "cleared histogram sample count incorrect",
+		},
+		{
+			actual:   histogramSample.Percentiles([]float64{0.5}),
+			expected: []float64{dataPointsMedian},
+			msg:      "histogram median incorrect",
+		},
+		{
+			actual:   clearedHistogramSample.Percentiles([]float64{0.5}),
+			expected: []float64{dataPointsMedian},
+			msg:      "cleared histogram median incorrect",
+		},
+	}
+
+	for _, tc := range pre_snapshot {
+		require.Equal(t, tc.expected, tc.actual, tc.msg)
+	}
+
+	// collecting the snapshot triggers the visit of each histogram
+	flatSnapshot := monitoring.CollectFlatSnapshot(monReg, monitoring.Full, false)
+
+	// Check to make sure after the snapshot the samples in
+	// clearedHistogramSample have been reset to zero, but the
+	// snapshot reports the values before the clear
+
+	post_snapshot := []struct {
+		expected any
+		actual   any
+		msg      string
+	}{
+		{
+			actual:   histogramSample.Count(),
+			expected: int64(len(dataPoints)),
+			msg:      "histogram sample count incorrect",
+		},
+		{
+			actual:   clearedHistogramSample.Count(),
+			expected: int64(0),
+			msg:      "cleared histogram sample count incorrect",
+		},
+		{
+			actual:   histogramSample.Percentiles([]float64{0.5}),
+			expected: []float64{dataPointsMedian},
+			msg:      "histogram median incorrect",
+		},
+		{
+			actual:   clearedHistogramSample.Percentiles([]float64{0.5}),
+			expected: []float64{0},
+			msg:      "cleared histogram median incorrect",
+		},
+		{
+			actual:   flatSnapshot.Ints["original.histogram.count"],
+			expected: int64(len(dataPoints)),
+			msg:      "visited histogram count is wrong",
+		},
+		{
+			actual:   flatSnapshot.Ints["cleared.histogram.count"],
+			expected: int64(len(dataPoints)),
+			msg:      "visited cleared histogram count is wrong",
+		},
+		{
+			actual:   flatSnapshot.Floats["original.histogram.median"],
+			expected: float64(dataPointsMedian),
+			msg:      "visited histogram median is wrong",
+		},
+		{
+			actual:   flatSnapshot.Floats["cleared.histogram.median"],
+			expected: float64(dataPointsMedian),
+			msg:      "visited cleared histogram median is wrong",
+		},
+	}
+
+	for _, tc := range post_snapshot {
+		require.Equal(t, tc.expected, tc.actual, tc.msg)
+	}
 }

--- a/monitoring/adapter/histogram.go
+++ b/monitoring/adapter/histogram.go
@@ -78,7 +78,7 @@ func (h *ClearOnVisitHistogram) Sample() metrics.Sample {
 
 // Snapshot returns a read-only copy of the histogram.
 func (h *ClearOnVisitHistogram) Snapshot() metrics.Histogram {
-	return &ClearOnVisitHistogramSnapshot{sample: h.sample.Snapshot().(*metrics.SampleSnapshot)}
+	return &ClearOnVisitHistogramSnapshot{sample: h.sample.Snapshot().(*metrics.SampleSnapshot)} //nolint:errcheck // codepath depends on panic
 }
 
 // StdDev returns the standard deviation of the values in the sample.

--- a/monitoring/adapter/histogram.go
+++ b/monitoring/adapter/histogram.go
@@ -1,0 +1,180 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package adapter
+
+import (
+	metrics "github.com/rcrowley/go-metrics"
+)
+
+// ClearOnVisitHistogram is the same as a go-metrics StandardHistogram
+// except that when you visit it, it calls clear on the underlying
+// sample.
+type ClearOnVisitHistogram struct {
+	sample metrics.Sample
+}
+
+// NewClearOnVisitHistogram constructs a new ClearOnVisitHistogram
+// from a go-metrics Sample.
+func NewClearOnVisitHistogram(s metrics.Sample) *ClearOnVisitHistogram {
+	return &ClearOnVisitHistogram{sample: s}
+}
+
+// Clear clears the histogram and its sample.
+func (h *ClearOnVisitHistogram) Clear() {
+	h.sample.Clear()
+}
+
+// Count returns the number of samples recorded since the histogram was last
+// cleared.
+func (h *ClearOnVisitHistogram) Count() int64 {
+	return h.sample.Count()
+}
+
+// Max returns the maximum value in the sample.
+func (h *ClearOnVisitHistogram) Max() int64 {
+	return h.sample.Max()
+}
+
+// Mean returns the mean of the values in the sample.
+func (h *ClearOnVisitHistogram) Mean() float64 {
+	return h.sample.Mean()
+}
+
+// Min returns the minimum value in the sample.
+func (h *ClearOnVisitHistogram) Min() int64 {
+	return h.sample.Min()
+}
+
+// Percentile returns an arbitrary percentile of the values in the sample.
+func (h *ClearOnVisitHistogram) Percentile(p float64) float64 {
+	return h.sample.Percentile(p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of the values in the
+// sample.
+func (h *ClearOnVisitHistogram) Percentiles(ps []float64) []float64 {
+	return h.sample.Percentiles(ps)
+}
+
+// Sample returns the Sample underlying the histogram.
+func (h *ClearOnVisitHistogram) Sample() metrics.Sample {
+	return h.sample
+}
+
+// Snapshot returns a read-only copy of the histogram.
+func (h *ClearOnVisitHistogram) Snapshot() metrics.Histogram {
+	return &ClearOnVisitHistogramSnapshot{sample: h.sample.Snapshot().(*metrics.SampleSnapshot)}
+}
+
+// StdDev returns the standard deviation of the values in the sample.
+func (h *ClearOnVisitHistogram) StdDev() float64 {
+	return h.sample.StdDev()
+}
+
+// Sum returns the sum in the sample.
+func (h *ClearOnVisitHistogram) Sum() int64 {
+	return h.sample.Sum()
+}
+
+// Update samples a new value.
+func (h *ClearOnVisitHistogram) Update(v int64) {
+	h.sample.Update(v)
+}
+
+// Variance returns the variance of the values in the sample.
+func (h *ClearOnVisitHistogram) Variance() float64 {
+	return h.sample.Variance()
+}
+
+// ClearOnVisitHistogramSnapshot is a read-only copy of another
+// Histogram.  This is analogous to a go-metrics HistogramSnapshot
+type ClearOnVisitHistogramSnapshot struct {
+	sample *metrics.SampleSnapshot
+}
+
+// Clear panics.
+func (*ClearOnVisitHistogramSnapshot) Clear() {
+	panic("Clear called on a HistogramSnapshot")
+}
+
+// Count returns the number of samples recorded at the time the snapshot was
+// taken.
+func (h *ClearOnVisitHistogramSnapshot) Count() int64 {
+	return h.sample.Count()
+}
+
+// Max returns the maximum value in the sample at the time the snapshot was
+// taken.
+func (h *ClearOnVisitHistogramSnapshot) Max() int64 {
+	return h.sample.Max()
+}
+
+// Mean returns the mean of the values in the sample at the time the snapshot
+// was taken.
+func (h *ClearOnVisitHistogramSnapshot) Mean() float64 {
+	return h.sample.Mean()
+}
+
+// Min returns the minimum value in the sample at the time the snapshot was
+// taken.
+func (h *ClearOnVisitHistogramSnapshot) Min() int64 {
+	return h.sample.Min()
+}
+
+// Percentile returns an arbitrary percentile of values in the sample at the
+// time the snapshot was taken.
+func (h *ClearOnVisitHistogramSnapshot) Percentile(p float64) float64 {
+	return h.sample.Percentile(p)
+}
+
+// Percentiles returns a slice of arbitrary percentiles of values in the sample
+// at the time the snapshot was taken.
+func (h *ClearOnVisitHistogramSnapshot) Percentiles(ps []float64) []float64 {
+	return h.sample.Percentiles(ps)
+}
+
+// Sample returns the Sample underlying the histogram.
+func (h *ClearOnVisitHistogramSnapshot) Sample() metrics.Sample {
+	return h.sample
+}
+
+// Snapshot returns the snapshot.
+func (h *ClearOnVisitHistogramSnapshot) Snapshot() metrics.Histogram {
+	return h
+}
+
+// StdDev returns the standard deviation of the values in the sample at the
+// time the snapshot was taken.
+func (h *ClearOnVisitHistogramSnapshot) StdDev() float64 {
+	return h.sample.StdDev()
+}
+
+// Sum returns the sum in the sample at the time the snapshot was taken.
+func (h *ClearOnVisitHistogramSnapshot) Sum() int64 {
+	return h.sample.Sum()
+}
+
+// Update panics.
+func (*ClearOnVisitHistogramSnapshot) Update(int64) {
+	panic("Update called on a HistogramSnapshot")
+}
+
+// Variance returns the variance of inputs at the time the snapshot was taken.
+func (h *ClearOnVisitHistogramSnapshot) Variance() float64 {
+	return h.sample.Variance()
+}


### PR DESCRIPTION
## What does this PR do?

Adds a new type of ClearOnVisitHistogram to monitoring/adapter.  

## Why is it important?

This type is the same as a go-metrics StandardHistogram, but the Visit function for the new type will call `Clear` on the underlying sample.  This means the sample is reset each time you visit it.  This is useful for things like the beats "Non-zero metrics in the last 30s" log entries.

The other difference is that the `Visit` function only reports the following metrics: 

  - count
  - min
  - max
  - median
  - p99

This is smaller than the fields produced for the StandardHistogram.  This was done to limit the field expansion, and this list of fields was picked because it is the list actually used in the elastic-agent monitoring dashboards.


## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [X] My code follows the style guidelines of this project
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

