### PR TITLE
[Windows] Rotate (rename) files with retries

### DIFF
--- a/file/helper_aix.go
+++ b/file/helper_aix.go
@@ -24,7 +24,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := rotateOpts{enableRetries: false}
+	options := rotateOpts{}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_aix.go
+++ b/file/helper_aix.go
@@ -24,7 +24,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := RotateOpts{}
+	options := rotateOpts{}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_aix.go
+++ b/file/helper_aix.go
@@ -24,7 +24,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := rotateOpts{}
+	options := rotateOpts{enableRetries: false}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_aix.go
+++ b/file/helper_aix.go
@@ -23,10 +23,14 @@ import (
 )
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
-func SafeFileRotate(path, tempfile string) error {
+func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
+	options := RotateOpts{}
+	for _, opt := range opts {
+		opt(&options)
+	}
 
-	if e := os.Rename(tempfile, path); e != nil {
-		return e
+	if err := rename(tempfile, path, options); err != nil {
+		return err
 	}
 
 	// best-effort fsync on parent directory. The fsync is required by some

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -6,7 +6,7 @@
 // not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//	http://www.apache.org/licenses/LICENSE-2.0
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -42,6 +42,8 @@ func rename(src, dst string, options RotateOpts) error {
 		return os.Rename(src, dst)
 	}
 
+	// Attempt rename with retries every options.RenameRetryInterval until options.RenameRetryDuration
+	// has elapsed. This is useful in cases where the destination file may be locked or in use.
 	var err error
 	for start := time.Now(); time.Since(start) < options.RenameRetryDuration; time.Sleep(options.RenameRetryInterval) {
 		err = os.Rename(src, dst)

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -38,7 +38,8 @@ func WithRenameRetries(duration, interval time.Duration) RotateOpt {
 }
 
 func rename(src, dst string, options rotateOpts) error {
-	if options.renameRetryDuration == 0 && options.renameRetryInterval == 0 {
+	// Perform a regular (non-retrying) rename unless all retry options are specified.
+	if options.renameRetryDuration == 0 || options.renameRetryInterval == 0 {
 		return os.Rename(src, dst)
 	}
 

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -1,0 +1,65 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+import (
+	"fmt"
+	"os"
+	"time"
+)
+
+type RotateOpts struct {
+	RenameRetryDuration time.Duration
+	RenameRetryInterval time.Duration
+}
+
+type RotateOpt func(*RotateOpts)
+
+func WithRenameRetries(duration, interval time.Duration) RotateOpt {
+	return func(opts *RotateOpts) {
+		opts.RenameRetryDuration = duration
+		opts.RenameRetryInterval = interval
+	}
+}
+
+func rename(src, dst string, options RotateOpts) error {
+	if options.RenameRetryDuration == 0 && options.RenameRetryInterval == 0 {
+		return os.Rename(src, dst)
+	}
+
+	return retryingRename(src, dst, options.RenameRetryDuration, options.RenameRetryInterval)
+}
+
+// retryingRename attempts to rename a file from src to dst, retrying
+// every retryInterval until the retryDuration duration has elapsed.
+func retryingRename(src, dst string, retryDuration, retryInterval time.Duration) error {
+	var err error
+	for start := time.Now(); time.Since(start) < retryDuration; time.Sleep(retryInterval) {
+		err = os.Rename(src, dst)
+		if err == nil {
+			// Rename succeeded; no more retries needed
+			return nil
+		}
+	}
+
+	if err != nil {
+		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, retryDuration, err)
+	}
+
+	return nil
+}

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -23,29 +23,29 @@ import (
 	"time"
 )
 
-type RotateOpts struct {
-	RenameRetryDuration time.Duration
-	RenameRetryInterval time.Duration
+type rotateOpts struct {
+	renameRetryDuration time.Duration
+	renameRetryInterval time.Duration
 }
 
-type RotateOpt func(*RotateOpts)
+type RotateOpt func(*rotateOpts)
 
 func WithRenameRetries(duration, interval time.Duration) RotateOpt {
-	return func(opts *RotateOpts) {
-		opts.RenameRetryDuration = duration
-		opts.RenameRetryInterval = interval
+	return func(opts *rotateOpts) {
+		opts.renameRetryDuration = duration
+		opts.renameRetryInterval = interval
 	}
 }
 
-func rename(src, dst string, options RotateOpts) error {
-	if options.RenameRetryDuration == 0 && options.RenameRetryInterval == 0 {
+func rename(src, dst string, options rotateOpts) error {
+	if options.renameRetryDuration == 0 && options.renameRetryInterval == 0 {
 		return os.Rename(src, dst)
 	}
 
 	// Attempt rename with retries every options.RenameRetryInterval until options.RenameRetryDuration
 	// has elapsed. This is useful in cases where the destination file may be locked or in use.
 	var err error
-	for start := time.Now(); time.Since(start) < options.RenameRetryDuration; time.Sleep(options.RenameRetryInterval) {
+	for start := time.Now(); time.Since(start) < options.renameRetryDuration; time.Sleep(options.renameRetryInterval) {
 		err = os.Rename(src, dst)
 		if err == nil {
 			// Rename succeeded; no more retries needed
@@ -54,7 +54,7 @@ func rename(src, dst string, options RotateOpts) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, options.RenameRetryDuration, err)
+		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, options.renameRetryDuration, err)
 	}
 
 	return nil

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -42,14 +42,8 @@ func rename(src, dst string, options RotateOpts) error {
 		return os.Rename(src, dst)
 	}
 
-	return retryingRename(src, dst, options.RenameRetryDuration, options.RenameRetryInterval)
-}
-
-// retryingRename attempts to rename a file from src to dst, retrying
-// every retryInterval until the retryDuration duration has elapsed.
-func retryingRename(src, dst string, retryDuration, retryInterval time.Duration) error {
 	var err error
-	for start := time.Now(); time.Since(start) < retryDuration; time.Sleep(retryInterval) {
+	for start := time.Now(); time.Since(start) < options.RenameRetryDuration; time.Sleep(options.RenameRetryInterval) {
 		err = os.Rename(src, dst)
 		if err == nil {
 			// Rename succeeded; no more retries needed
@@ -58,7 +52,7 @@ func retryingRename(src, dst string, retryDuration, retryInterval time.Duration)
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, retryDuration, err)
+		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, options.RenameRetryDuration, err)
 	}
 
 	return nil

--- a/file/helper_common.go
+++ b/file/helper_common.go
@@ -23,31 +23,30 @@ import (
 	"time"
 )
 
-const renameRetryInterval = 50 * time.Millisecond
-const renameRetryDuration = 2 * time.Second
-
 type rotateOpts struct {
-	enableRetries bool
+	renameRetryDuration time.Duration
+	renameRetryInterval time.Duration
 }
 
 type RotateOpt func(*rotateOpts)
 
-func DisableRetries() RotateOpt {
+func WithRenameRetries(duration, interval time.Duration) RotateOpt {
 	return func(opts *rotateOpts) {
-		opts.enableRetries = false
+		opts.renameRetryDuration = duration
+		opts.renameRetryInterval = interval
 	}
 }
 
 func rename(src, dst string, options rotateOpts) error {
-	// Perform a regular (non-retrying) rename if retries are disabled.
-	if !options.enableRetries {
+	// Perform a regular (non-retrying) rename unless all retry options are specified.
+	if options.renameRetryDuration == 0 || options.renameRetryInterval == 0 {
 		return os.Rename(src, dst)
 	}
 
 	// Attempt rename with retries every options.RenameRetryInterval until options.RenameRetryDuration
 	// has elapsed. This is useful in cases where the destination file may be locked or in use.
 	var err error
-	for start := time.Now(); time.Since(start) < renameRetryDuration; time.Sleep(renameRetryInterval) {
+	for start := time.Now(); time.Since(start) < options.renameRetryDuration; time.Sleep(options.renameRetryInterval) {
 		err = os.Rename(src, dst)
 		if err == nil {
 			// Rename succeeded; no more retries needed
@@ -56,7 +55,7 @@ func rename(src, dst string, options rotateOpts) error {
 	}
 
 	if err != nil {
-		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, renameRetryDuration, err)
+		return fmt.Errorf("failed to rename %s to %s after %v: %w", src, dst, options.renameRetryDuration, err)
 	}
 
 	return nil

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -26,7 +26,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := rotateOpts{enableRetries: false}
+	options := rotateOpts{}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -26,7 +26,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := RotateOpts{}
+	options := rotateOpts{}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -25,10 +25,14 @@ import (
 )
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
-func SafeFileRotate(path, tempfile string) error {
+func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
+	options := RotateOpts{}
+	for _, opt := range opts {
+		opt(&options)
+	}
 
-	if e := os.Rename(tempfile, path); e != nil {
-		return e
+	if err := rename(tempfile, path, options); err != nil {
+		return err
 	}
 
 	// best-effort fsync on parent directory. The fsync is required by some

--- a/file/helper_other.go
+++ b/file/helper_other.go
@@ -26,7 +26,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := rotateOpts{}
+	options := rotateOpts{enableRetries: false}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_windows.go
+++ b/file/helper_windows.go
@@ -24,9 +24,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	// Enable retries by default on Windows. This is useful in cases where path, the destination
-	// file may be locked or in use.
-	options := rotateOpts{enableRetries: true}
+	options := rotateOpts{}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_windows.go
+++ b/file/helper_windows.go
@@ -24,7 +24,7 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := RotateOpts{}
+	options := rotateOpts{}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_windows.go
+++ b/file/helper_windows.go
@@ -24,7 +24,9 @@ import (
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := rotateOpts{}
+	// Enable retries by default on Windows. This is useful in cases where path, the destination
+	// file may be locked or in use.
+	options := rotateOpts{enableRetries: true}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_windows.go
+++ b/file/helper_windows.go
@@ -20,11 +20,20 @@ package file
 import (
 	"os"
 	"path/filepath"
+	"time"
 )
+
+const windowsRenameRetryInterval = 50 * time.Millisecond
+const windowsRenameRetryDuration = 2 * time.Second
 
 // SafeFileRotate safely rotates an existing file under path and replaces it with the tempfile
 func SafeFileRotate(path, tempfile string, opts ...RotateOpt) error {
-	options := rotateOpts{}
+	// On Windows, retry the rename operation by default. This is useful in cases where
+	// path, the destination file, may be locked or in use.
+	options := rotateOpts{
+		renameRetryDuration: windowsRenameRetryDuration,
+		renameRetryInterval: windowsRenameRetryInterval,
+	}
 	for _, opt := range opts {
 		opt(&options)
 	}

--- a/file/helper_windows_test.go
+++ b/file/helper_windows_test.go
@@ -52,7 +52,7 @@ func TestSafeFileRotate(t *testing.T) {
 	defer destFile.Close()
 
 	// Try to replace dest with new
-	err = SafeFileRotate(dest, src)
+	err = SafeFileRotate(dest, src, WithRenameRetries(2*time.Second, 100*time.Millisecond))
 	require.NoError(t, err)
 
 	// Check that dest file has been replaced with new file

--- a/file/helper_windows_test.go
+++ b/file/helper_windows_test.go
@@ -1,0 +1,60 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package file
+
+import (
+	"github.com/stretchr/testify/require"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestSafeFileRotate creates two files, dest and src, and calls
+// SafeFileRotate to replace dest with src. However, before the test
+// makes that call, it deliberately keeps a handle open on dest for
+// a short period of time to ensure that the rotation takes place anyway
+// after the handle has been released.
+func TestSafeFileRotate(t *testing.T) {
+	// Create destination file
+	tmpDir := t.TempDir()
+	dest := filepath.Join(tmpDir, "dest.txt")
+	err := os.WriteFile(dest, []byte("existing content"), 0644)
+	require.NoError(t, err)
+
+	// Create source file
+	src := filepath.Join(tmpDir, "src.txt")
+	err = os.WriteFile(src, []byte("new content"), 0644)
+	require.NoError(t, err)
+
+	// Open handle on dest file for 1.5 seconds
+	destFile, err := os.Open(dest)
+	time.AfterFunc(1500*time.Millisecond, func() {
+		destFile.Close() // Close the handle after 1.5 seconds
+	})
+	defer destFile.Close()
+
+	// Try to replace dest with new
+	err = SafeFileRotate(dest, src)
+	require.NoError(t, err)
+
+	// Check that dest file has been replaced with new file
+	data, err := os.ReadFile(dest)
+	require.NoError(t, err)
+	require.Equal(t, "new content", string(data))
+}

--- a/file/helper_windows_test.go
+++ b/file/helper_windows_test.go
@@ -45,6 +45,7 @@ func TestSafeFileRotate(t *testing.T) {
 
 	// Open handle on dest file for 1.5 seconds
 	destFile, err := os.Open(dest)
+	require.NoError(t, err)
 	time.AfterFunc(1500*time.Millisecond, func() {
 		destFile.Close() // Close the handle after 1.5 seconds
 	})

--- a/file/helper_windows_test.go
+++ b/file/helper_windows_test.go
@@ -52,7 +52,7 @@ func TestSafeFileRotate(t *testing.T) {
 	defer destFile.Close()
 
 	// Try to replace dest with new
-	err = SafeFileRotate(dest, src, WithRenameRetries(2*time.Second, 100*time.Millisecond))
+	err = SafeFileRotate(dest, src, DisableRetries(2*time.Second, 100*time.Millisecond))
 	require.NoError(t, err)
 
 	// Check that dest file has been replaced with new file

--- a/file/helper_windows_test.go
+++ b/file/helper_windows_test.go
@@ -52,7 +52,7 @@ func TestSafeFileRotate(t *testing.T) {
 	defer destFile.Close()
 
 	// Try to replace dest with new
-	err = SafeFileRotate(dest, src, DisableRetries(2*time.Second, 100*time.Millisecond))
+	err = SafeFileRotate(dest, src, WithRenameRetries(2*time.Second, 100*time.Millisecond))
 	require.NoError(t, err)
 
 	// Check that dest file has been replaced with new file

--- a/file/helper_windows_test.go
+++ b/file/helper_windows_test.go
@@ -18,11 +18,12 @@
 package file
 
 import (
-	"github.com/stretchr/testify/require"
 	"os"
 	"path/filepath"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/require"
 )
 
 // TestSafeFileRotate creates two files, dest and src, and calls


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR enhances the `SafeFileRotate` implementation take a variadic `opts` argument.  This argument can be used to configure the function to retry it's final rename step with a specific interval and up to a specified duration.  On Windows, the default behavior is to retry.

This is similar to a fix made for [Agent uninstallation](https://github.com/elastic/elastic-agent/blob/8fbdaaa979db0976e33612be647bb69ffaac70f8/internal/pkg/agent/install/uninstall.go#L277-L284).

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Windows does not permit renaming files that are currently being held open by other processes, e.g. antivirus scanners.  Retrying the rename increases the likelihood that the rename will succeed on one of the retry attempts when the file is not being help open by another process.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## How to test this PR locally

1. On a Windows machine, reproduce the failing scenario.

   1. Revert the commit with the fix.
   ```
   git checkout a711c5aa00e500d7136d95e2b658db15e974261a
   ```
   2. Run the unit test introduced in this PR and ensure that it fails with the `Access denied` error.
   ```
   go test -v ./file/... -run ^TestSafeFileRotate$
   ```

2. On a Windows machine, re-run the same test with the fix.
   1. Checkout this PR's branch.
   2. Run the unit test introduced in this PR multiple times and ensure that it no longer fails with the `Access denied` error.
   ```
   go test -v ./file/... -run ^TestSafeFileRotate$ -count 10
   ```

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Closes https://github.com/elastic/elastic-agent/issues/5862

