### PR TITLE
Replace global loggers with local loggers in `tlscommon` package

### DIFF
--- a/transport/httpcommon/httpcommon.go
+++ b/transport/httpcommon/httpcommon.go
@@ -185,7 +185,8 @@ func (settings *HTTPTransportSettings) Unpack(cfg *config.C) error {
 		return err
 	}
 
-	_, err := tlscommon.LoadTLSConfig(tmp.TLS)
+	// TODO: use local logger here
+	_, err := tlscommon.LoadTLSConfig(tmp.TLS, logp.NewLogger(""))
 	if err != nil {
 		return err
 	}
@@ -213,6 +214,11 @@ func (settings *HTTPTransportSettings) RoundTripper(opts ...TransportOption) (ht
 		}
 	}
 
+	logger := logp.NewLogger("")
+	if log := extra.logger; log != nil {
+		logger = log
+	}
+
 	for _, opt := range opts {
 		if dialOpt, ok := opt.(dialerOption); ok {
 			dialer = dialOpt.baseDialer()
@@ -223,7 +229,7 @@ func (settings *HTTPTransportSettings) RoundTripper(opts ...TransportOption) (ht
 		dialer = transport.NetDialer(settings.Timeout)
 	}
 
-	tls, err := tlscommon.LoadTLSConfig(settings.TLS)
+	tls, err := tlscommon.LoadTLSConfig(settings.TLS, logger)
 	if err != nil {
 		return nil, err
 	}

--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -32,6 +32,7 @@ import (
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/iobuf"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommontest"
 )
 
@@ -51,7 +52,7 @@ func TestCAPinning(t *testing.T) {
 		err := cfg.Unpack(config)
 		require.NoError(t, err)
 
-		tlsCfg, err := LoadTLSConfig(config)
+		tlsCfg, err := LoadTLSConfig(config, logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
 
 		tls := tlsCfg.BuildModuleClientConfig(host)
@@ -67,7 +68,7 @@ func TestCAPinning(t *testing.T) {
 		err := cfg.Unpack(config)
 		require.NoError(t, err)
 
-		tlsCfg, err := LoadTLSConfig(config)
+		tlsCfg, err := LoadTLSConfig(config, logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
 
 		tls := tlsCfg.BuildModuleClientConfig(host)

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -20,6 +20,8 @@ package tlscommon
 import (
 	"crypto/tls"
 	"errors"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // Config defines the user configurable options in the yaml file.
@@ -40,7 +42,7 @@ type Config struct {
 // defined. If Certificate and CertificateKey are configured, client authentication
 // will be configured. If no CAs are configured, the host CA will be used by go
 // built-in TLS support.
-func LoadTLSConfig(config *Config) (*TLSConfig, error) {
+func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 	if !config.IsEnabled() {
 		return nil, nil
 	}
@@ -86,6 +88,7 @@ func LoadTLSConfig(config *Config) (*TLSConfig, error) {
 		Renegotiation:        tls.RenegotiationSupport(config.Renegotiation),
 		CASha256:             config.CASha256,
 		CATrustedFingerprint: config.CATrustedFingerprint,
+		Logger:               logger,
 	}, nil
 }
 

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -88,7 +88,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		Renegotiation:        tls.RenegotiationSupport(config.Renegotiation),
 		CASha256:             config.CASha256,
 		CATrustedFingerprint: config.CATrustedFingerprint,
-		Logger:               logger,
+		logger:               logger,
 	}, nil
 }
 

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // ServerConfig defines the user configurable tls options for any TCP based service.
@@ -40,7 +41,7 @@ type ServerConfig struct {
 
 // LoadTLSServerConfig tranforms a ServerConfig into a `tls.Config` to be used directly with golang
 // network types.
-func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
+func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig, error) {
 	if !config.IsEnabled() {
 		return nil, nil
 	}
@@ -95,6 +96,7 @@ func LoadTLSServerConfig(config *ServerConfig) (*TLSConfig, error) {
 		CurvePreferences: curves,
 		ClientAuth:       tls.ClientAuthType(clientAuth),
 		CASha256:         config.CASha256,
+		Logger:           logger,
 	}, nil
 }
 

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -96,7 +96,7 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		CurvePreferences: curves,
 		ClientAuth:       tls.ClientAuthType(clientAuth),
 		CASha256:         config.CASha256,
-		Logger:           logger,
+		logger:           logger,
 	}, nil
 }
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -87,7 +87,7 @@ type TLSConfig struct {
 	// If time is nil, TLS uses time.Now.
 	time func() time.Time
 
-	Logger *logp.Logger
+	logger *logp.Logger
 }
 
 var (
@@ -106,7 +106,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 
 	insecure := c.Verification != VerifyStrict
 	if c.Verification == VerifyNone {
-		c.Logger.Named("tls").Warn("SSL/TLS verifications disabled.")
+		c.logger.Named("tls").Warn("SSL/TLS verifications disabled.")
 	}
 
 	return &tls.Config{
@@ -121,7 +121,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		Renegotiation:      c.Renegotiation,
 		ClientAuth:         c.ClientAuth,
 		Time:               c.time,
-		VerifyConnection:   makeVerifyConnection(c, c.Logger),
+		VerifyConnection:   makeVerifyConnection(c, c.logger),
 	}
 }
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -219,7 +219,7 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Log
 	if len(foundCADigests) == 0 {
 		logger.Warn("The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificate's issuing certificate authority.")
 	} else {
-		logger.Warnw(fmt.Sprintf("The provided 'ca_trusted_fingerprint': '%s' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: %v", cfg.CATrustedFingerprint, foundCADigests), logp.TypeKey, logp.EventType)
+		logger.Warnf("The provided 'ca_trusted_fingerprint': '%s' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: %v", cfg.CATrustedFingerprint, foundCADigests)
 	}
 
 	return nil

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -217,13 +217,13 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 	if len(foundCADigests) == 0 {
 		logger.Warn("The remote server's certificate is presented without its certificate chain. Using 'ca_trusted_fingerprint' requires that the server presents a certificate chain that includes the certificate's issuing certificate authority.")
 	} else {
-		logger.Warnf("The provided 'ca_trusted_fingerprint': '%s' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: %v", cfg.CATrustedFingerprint, foundCADigests)
+		logger.Warnw(fmt.Sprintf("The provided 'ca_trusted_fingerprint': '%s' does not match the fingerprint of any Certificate Authority present in the server's certificate chain. Found the following CA fingerprints instead: %v", cfg.CATrustedFingerprint, foundCADigests), logp.TypeKey, logp.EventType)
 	}
 
 	return nil
 }
 
-func makeVerifyConnection(cfg *TLSConfig) func(tls.ConnectionState) error {
+func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.ConnectionState) error {
 	serverName := cfg.ServerName
 
 	switch cfg.Verification {

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -223,7 +223,7 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 	return nil
 }
 
-func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.ConnectionState) error {
+func makeVerifyConnection(cfg *TLSConfig) func(tls.ConnectionState) error {
 	serverName := cfg.ServerName
 
 	switch cfg.Verification {

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -86,6 +86,8 @@ type TLSConfig struct {
 	// time returns the current time as the number of seconds since the epoch.
 	// If time is nil, TLS uses time.Now.
 	time func() time.Time
+
+	Logger *logp.Logger
 }
 
 var (
@@ -104,7 +106,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 
 	insecure := c.Verification != VerifyStrict
 	if c.Verification == VerifyNone {
-		logp.NewLogger("tls").Warn("SSL/TLS verifications disabled.")
+		c.Logger.Named("tls").Warn("SSL/TLS verifications disabled.")
 	}
 
 	return &tls.Config{
@@ -119,7 +121,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		Renegotiation:      c.Renegotiation,
 		ClientAuth:         c.ClientAuth,
 		Time:               c.time,
-		VerifyConnection:   makeVerifyConnection(c),
+		VerifyConnection:   makeVerifyConnection(c, c.Logger),
 	}
 }
 
@@ -133,7 +135,7 @@ func (c *TLSConfig) BuildModuleClientConfig(host string) *tls.Config {
 			VerifyConnection: makeVerifyConnection(&TLSConfig{
 				Verification: VerifyFull,
 				ServerName:   host,
-			}),
+			}, logp.NewLogger("tls")),
 		}
 	}
 
@@ -175,8 +177,8 @@ func (c *TLSConfig) BuildServerConfig(host string) *tls.Config {
 	return config
 }
 
-func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
-	logger := logp.NewLogger("tls")
+func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Logger) error {
+	logger = logger.Named("tls")
 	logger.Info("'ca_trusted_fingerprint' set, looking for matching fingerprints")
 	fingerprint, err := hex.DecodeString(cfg.CATrustedFingerprint)
 	if err != nil {
@@ -223,7 +225,7 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate) error {
 	return nil
 }
 
-func makeVerifyConnection(cfg *TLSConfig) func(tls.ConnectionState) error {
+func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.ConnectionState) error {
 	serverName := cfg.ServerName
 
 	switch cfg.Verification {
@@ -233,7 +235,7 @@ func makeVerifyConnection(cfg *TLSConfig) func(tls.ConnectionState) error {
 		// tls.Config.InsecureSkipVerify  is set to true
 		return func(cs tls.ConnectionState) error {
 			if cfg.CATrustedFingerprint != "" {
-				if err := trustRootCA(cfg, cs.PeerCertificates); err != nil {
+				if err := trustRootCA(cfg, cs.PeerCertificates, logger); err != nil {
 					return err
 				}
 			}
@@ -259,7 +261,7 @@ func makeVerifyConnection(cfg *TLSConfig) func(tls.ConnectionState) error {
 		// tls.Config.InsecureSkipVerify is set to true
 		return func(cs tls.ConnectionState) error {
 			if cfg.CATrustedFingerprint != "" {
-				if err := trustRootCA(cfg, cs.PeerCertificates); err != nil {
+				if err := trustRootCA(cfg, cs.PeerCertificates, logger); err != nil {
 					return err
 				}
 			}
@@ -284,7 +286,7 @@ func makeVerifyConnection(cfg *TLSConfig) func(tls.ConnectionState) error {
 		if len(cfg.CASha256) > 0 {
 			return func(cs tls.ConnectionState) error {
 				if cfg.CATrustedFingerprint != "" {
-					if err := trustRootCA(cfg, cs.PeerCertificates); err != nil {
+					if err := trustRootCA(cfg, cs.PeerCertificates, logger); err != nil {
 						return err
 					}
 				}

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/logp"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommontest"
 )
 
@@ -264,7 +265,7 @@ func TestTrustRootCA(t *testing.T) {
 			// Capture the logs
 			_ = logp.DevelopmentSetup(logp.ToObserverOutput())
 
-			err := trustRootCA(&cfg, tc.peerCerts)
+			err := trustRootCA(&cfg, tc.peerCerts, logptest.NewTestingLogger(t, ""))
 			if tc.expectingError && err == nil {
 				t.Fatal("expecting an error when calling trustRootCA")
 			}
@@ -385,7 +386,7 @@ func TestMakeVerifyConnectionUsesCATrustedFingerprint(t *testing.T) {
 				CASha256:             test.CASHA256,
 			}
 
-			verifier := makeVerifyConnection(cfg)
+			verifier := makeVerifyConnection(cfg, logptest.NewTestingLogger(t, ""))
 			if test.expectedCallback {
 				require.NotNil(t, verifier, "makeVerifyConnection returned a nil verifier")
 			} else {
@@ -469,7 +470,7 @@ func TestMakeVerifyServerConnectionForIPs(t *testing.T) {
 				Verification: test.verificationMode,
 				ServerName:   test.serverName,
 			}
-			verifier := makeVerifyConnection(cfg)
+			verifier := makeVerifyConnection(cfg, logptest.NewTestingLogger(t, ""))
 
 			err = verifier(tls.ConnectionState{
 				PeerCertificates: []*x509.Certificate{peerCerts.Leaf},

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -651,7 +651,7 @@ func TestVerificationMode(t *testing.T) {
 				Verification: test.verificationMode,
 				RootCAs:      certPool,
 				ServerName:   test.hostname,
-				Logger:       logptest.NewTestingLogger(t, ""),
+				logger:       logptest.NewTestingLogger(t, ""),
 			}
 
 			if test.ignoreCerts {

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -645,6 +645,7 @@ func TestVerificationMode(t *testing.T) {
 				Verification: test.verificationMode,
 				RootCAs:      certPool,
 				ServerName:   test.hostname,
+				Logger:       logptest.NewTestingLogger(t, ""),
 			}
 
 			if test.ignoreCerts {

--- a/transport/tlscommon/tls_fips_test.go
+++ b/transport/tlscommon/tls_fips_test.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -53,7 +54,7 @@ func TestFIPSCertificateAndKeys(t *testing.T) {
 		cfg.Certificate.Key = string(rawKey)
 		cfg.Certificate.Passphrase = password
 
-		_, err = LoadTLSConfig(cfg)
+		_, err = LoadTLSConfig(cfg, logptest.NewTestingLogger(t, ""))
 		require.Error(t, err)
 		assert.ErrorIs(t, err, errors.ErrUnsupported, err)
 	})

--- a/transport/tlscommon/tls_fips_test.go
+++ b/transport/tlscommon/tls_fips_test.go
@@ -69,7 +69,7 @@ func TestFIPSCertificateAndKeys(t *testing.T) {
 		cfg.Certificate.Key = key
 		cfg.Certificate.Passphrase = password
 
-		_, err = LoadTLSConfig(cfg)
+		_, err = LoadTLSConfig(cfg, logptest.NewTestingLogger(t, ""))
 		assert.ErrorIs(t, err, errors.ErrUnsupported)
 	})
 }

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/elastic/elastic-agent-libs/config"
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func TestEmptyTlsConfig(t *testing.T) {
@@ -54,14 +55,14 @@ func TestLoadWithEmptyValues(t *testing.T) {
 }
 
 func TestNoLoadNilConfig(t *testing.T) {
-	cfg, err := LoadTLSConfig(nil)
+	cfg, err := LoadTLSConfig(nil, logptest.NewTestingLogger(t, ""))
 	assert.NoError(t, err)
 	assert.Nil(t, cfg)
 }
 
 func TestNoLoadDisabledConfig(t *testing.T) {
 	enabled := false
-	cfg, err := LoadTLSConfig(&Config{Enabled: &enabled})
+	cfg, err := LoadTLSConfig(&Config{Enabled: &enabled}, logptest.NewTestingLogger(t, ""))
 	assert.NoError(t, err)
 	assert.Nil(t, cfg)
 }
@@ -101,7 +102,7 @@ func TestValuesSet(t *testing.T) {
 }
 
 func TestApplyEmptyConfig(t *testing.T) {
-	tmp, err := LoadTLSConfig(&Config{})
+	tmp, err := LoadTLSConfig(&Config{}, logptest.NewTestingLogger(t, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -128,7 +129,7 @@ func TestApplyWithConfig(t *testing.T) {
       - "ECDHE-ECDSA-AES-256-GCM-SHA384"
     curve_types: [P-384]
     renegotiation: once
-  `))
+  `), logptest.NewTestingLogger(t, ""))
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -294,7 +295,7 @@ func TestCertificateFails(t *testing.T) {
 				t.Log(err)
 				return
 			}
-			_, err = LoadTLSConfig(&tlscfg)
+			_, err = LoadTLSConfig(&tlscfg, logptest.NewTestingLogger(t, ""))
 			t.Log(err)
 			assert.Error(t, err)
 		})
@@ -335,7 +336,7 @@ func TestCertificateAuthorities(t *testing.T) {
 		require.NoError(t, err)
 		cfg.CAs = []string{cert}
 
-		tlsC, err := LoadTLSConfig(cfg)
+		tlsC, err := LoadTLSConfig(cfg, logptest.NewTestingLogger(t, ""))
 		assert.NoError(t, err)
 		assert.NotNil(t, tlsC)
 	})
@@ -348,7 +349,7 @@ func TestCertificateAuthorities(t *testing.T) {
 		require.NoError(t, err)
 		cfg.CAs = []string{certFile}
 
-		tlsC, err := LoadTLSConfig(cfg)
+		tlsC, err := LoadTLSConfig(cfg, logptest.NewTestingLogger(t, ""))
 		assert.NoError(t, err)
 		assert.NotNil(t, tlsC)
 	})
@@ -361,7 +362,7 @@ func TestCertificateAuthorities(t *testing.T) {
 		require.NoError(t, err)
 		cfg.CAs = []string{certFile, cert}
 
-		tlsC, err := LoadTLSConfig(cfg)
+		tlsC, err := LoadTLSConfig(cfg, logptest.NewTestingLogger(t, ""))
 		assert.NoError(t, err)
 
 		assert.NotNil(t, tlsC)
@@ -371,6 +372,7 @@ func TestCertificateAuthorities(t *testing.T) {
 
 // TestFIPSCertifacteAndKeys tests encrypted private keys
 func TestCertificateAndKeys(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
 	t.Run("embed PKCS#1 key", func(t *testing.T) {
 		// Create a dummy configuration and append the CA after.
 		key, cert := makeKeyCertPair(t, blockTypePKCS1, "")
@@ -379,7 +381,7 @@ func TestCertificateAndKeys(t *testing.T) {
 		cfg.Certificate.Certificate = cert
 		cfg.Certificate.Key = key
 
-		tlsC, err := LoadTLSConfig(cfg)
+		tlsC, err := LoadTLSConfig(cfg, logger)
 		require.NoError(t, err)
 		assert.NotNil(t, tlsC)
 	})
@@ -392,7 +394,7 @@ func TestCertificateAndKeys(t *testing.T) {
 		cfg.Certificate.Certificate = cert
 		cfg.Certificate.Key = key
 
-		tlsC, err := LoadTLSConfig(cfg)
+		tlsC, err := LoadTLSConfig(cfg, logger)
 		require.NoError(t, err)
 		assert.NotNil(t, tlsC)
 	})
@@ -405,7 +407,7 @@ func TestCertificateAndKeys(t *testing.T) {
 		cfg.Certificate.Certificate = writeTestFile(t, cert)
 		cfg.Certificate.Key = writeTestFile(t, key)
 
-		tlsC, err := LoadTLSConfig(cfg)
+		tlsC, err := LoadTLSConfig(cfg, logger)
 		require.NoError(t, err)
 		assert.NotNil(t, tlsC)
 	})
@@ -419,7 +421,7 @@ func TestKeyPassphrase(t *testing.T) {
     certificate: testdata/ca.crt
     key: testdata/ca.key
     key_passphrase: Abcd1234!
-    `))
+    `), logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
 		assert.Equal(t, 1, len(cfg.Certificates), "expected 1 certificate to be loaded")
 	})

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -156,7 +156,7 @@ key: mykey.pem
 		err := config.Unpack(&c)
 		require.NoError(t, err)
 		c.Certificate = CertificateConfig{} // prevent reading non-existent files
-		tmp, err := LoadTLSServerConfig(&c)
+		tmp, err := LoadTLSServerConfig(&c, logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
 
 		cfg := tmp.BuildModuleClientConfig("")
@@ -187,7 +187,7 @@ key: mykey.pem
 		require.NoError(t, err)
 		c.Certificate = CertificateConfig{} // prevent reading non-existent files
 		require.NoError(t, err)
-		tmp, err := LoadTLSServerConfig(&c)
+		tmp, err := LoadTLSServerConfig(&c, logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
 
 		cfg := tmp.BuildModuleClientConfig("")
@@ -233,7 +233,7 @@ func TestApplyWithServerConfig(t *testing.T) {
 	if !assert.NoError(t, err) {
 		return
 	}
-	tmp, err := LoadTLSServerConfig(&c)
+	tmp, err := LoadTLSServerConfig(&c, logptest.NewTestingLogger(t, ""))
 	if !assert.NoError(t, err) {
 		return
 	}


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
Currently, logs from `tlscommon` package print `ca_trusted_fingerprint` provided by user and also those that are available on the server. This could be a sensitive information and should not be shipped.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Related issues

Part of https://github.com/elastic/ingest-dev/issues/5251


