### PR TITLE
logp: enable go vet checks for printf directives

### DIFF
--- a/loader/loader.go
+++ b/loader/loader.go
@@ -62,7 +62,7 @@ func (l *Loader) Load(files []string) (*Config, error) {
 				return nil, fmt.Errorf("cannot get configuration from '%s': %w", f, err)
 			}
 			inputsList = append(inputsList, inp...)
-			l.logger.Debugf("Loaded %s input(s) from configuration from %s", len(inp), f)
+			l.logger.Debugf("Loaded %d input(s) from configuration from %s", len(inp), f)
 		} else {
 			if err := merger.Add(cfg.access(), err); err != nil {
 				return nil, fmt.Errorf("failed to merge configuration file '%s' to existing one: %w", f, err)

--- a/logp/logger.go
+++ b/logp/logger.go
@@ -82,9 +82,6 @@ func NewDevelopmentLogger(selector string, options ...LogOption) (*Logger, error
 		return nil, err
 	}
 	logger = logger.Named(selector)
-	if err != nil {
-		return nil, err
-	}
 	return &Logger{logger, logger.Sugar(), make(map[string]struct{})}, nil
 }
 
@@ -224,37 +221,58 @@ func (l *Logger) IsDebug() bool {
 
 // Debugf uses fmt.Sprintf to construct and log a message.
 func (l *Logger) Debugf(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.Debugf(format, args...)
 }
 
 // Infof uses fmt.Sprintf to log a templated message.
 func (l *Logger) Infof(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.Infof(format, args...)
 }
 
 // Warnf uses fmt.Sprintf to log a templated message.
 func (l *Logger) Warnf(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.Warnf(format, args...)
 }
 
 // Errorf uses fmt.Sprintf to log a templated message.
 func (l *Logger) Errorf(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.Errorf(format, args...)
 }
 
 // Fatalf uses fmt.Sprintf to log a templated message, then calls os.Exit(1).
 func (l *Logger) Fatalf(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.Fatalf(format, args...)
 }
 
 // Panicf uses fmt.Sprintf to log a templated message, then panics.
 func (l *Logger) Panicf(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.Panicf(format, args...)
 }
 
 // DPanicf uses fmt.Sprintf to log a templated message. In development, the
 // logger then panics.
 func (l *Logger) DPanicf(format string, args ...interface{}) {
+	if false {
+		_ = fmt.Sprintf(format, args...) // enable printf checking
+	}
 	l.sugar.DPanicf(format, args...)
 }
 


### PR DESCRIPTION
## What does this PR do?

Currently, misuse of printf directives in logger functions is not reported by go vet. Use a small trick to enable the `x/tools/go/analysis/passes/printf` analyzer on printf wrappers, allowing this check to catch format string issues.

See https://pkg.go.dev/golang.org/x/tools/go/analysis/passes/printf#hdr-Inferred_printf_wrappers

## Why is it important?

Reports misuse of printing directives in the logger functions.

## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works
