### PR TITLE
Replace global logger with local logger in `tlscommon` package

### DIFF
--- a/logp/logger.go
+++ b/logp/logger.go
@@ -322,7 +322,7 @@ func (l *Logger) DPanicw(msg string, keysAndValues ...interface{}) {
 func (l *Logger) Recover(msg string) {
 	if r := recover(); r != nil {
 		msg := fmt.Sprintf("%s. Recovering, but please report this.", msg)
-		l.Error(msg, zap.Any("panic", r), zap.Stack("stack"))
+		l.WithOptions(zap.AddCallerSkip(1)).Error(msg, zap.Any("panic", r), zap.Stack("stack"))
 	}
 }
 

--- a/monitoring/adapter/go-metrics.go
+++ b/monitoring/adapter/go-metrics.go
@@ -58,23 +58,23 @@ type GoMetricsRegistry struct {
 //
 //	it's recommended to have the underlying registry being generated with
 //	`monitoring.IgnorePublishExpvar`.
-func GetGoMetrics(parent *monitoring.Registry, name string, filters ...MetricFilter) *GoMetricsRegistry {
+func GetGoMetrics(parent *monitoring.Registry, name string, logger *logp.Logger, filters ...MetricFilter) *GoMetricsRegistry {
 	v := parent.Get(name)
 	if v == nil {
-		return NewGoMetrics(parent, name, filters...)
+		return NewGoMetrics(parent, name, logger, filters...)
 	}
-	return newGoMetrics(v.(*monitoring.Registry), filters...) //nolint:errcheck //code depends on panic
+	return newGoMetrics(v.(*monitoring.Registry), logger, filters...) //nolint:errcheck //code depends on panic
 }
 
 // NewGoMetrics creates and registers a new GoMetricsRegistry with the parent
 // registry.
-func NewGoMetrics(parent *monitoring.Registry, name string, filters ...MetricFilter) *GoMetricsRegistry {
-	return newGoMetrics(parent.NewRegistry(name, monitoring.IgnorePublishExpvar), filters...)
+func NewGoMetrics(parent *monitoring.Registry, name string, logger *logp.Logger, filters ...MetricFilter) *GoMetricsRegistry {
+	return newGoMetrics(parent.NewRegistry(name, monitoring.IgnorePublishExpvar), logger, filters...)
 }
 
-func newGoMetrics(reg *monitoring.Registry, filters ...MetricFilter) *GoMetricsRegistry {
+func newGoMetrics(reg *monitoring.Registry, logger *logp.Logger, filters ...MetricFilter) *GoMetricsRegistry {
 	return &GoMetricsRegistry{
-		log:     logp.NewLogger("monitoring"),
+		log:     logger.Named("monitoring"),
 		reg:     reg,
 		shadow:  metrics.NewRegistry(),
 		filters: makeFilters(filters...),

--- a/monitoring/adapter/go-metrics_test.go
+++ b/monitoring/adapter/go-metrics_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/monitoring"
 )
 
@@ -53,7 +54,7 @@ func TestGoMetricsAdapter(t *testing.T) {
 	}
 
 	monReg := monitoring.NewRegistry()
-	var reg metrics.Registry = GetGoMetrics(monReg, "test", filters...)
+	var reg metrics.Registry = GetGoMetrics(monReg, "test", logp.NewNopLogger(), filters...)
 
 	// register some metrics and check they're satisfying the go-metrics interface
 	// no matter if owned by monitoring or go-metrics
@@ -116,8 +117,8 @@ func TestGoMetricsHistogramClearOnVisit(t *testing.T) {
 	monReg := monitoring.NewRegistry()
 	histogramSample := metrics.NewUniformSample(10)
 	clearedHistogramSample := metrics.NewUniformSample(10)
-	_ = NewGoMetrics(monReg, "original", Accept).Register("histogram", metrics.NewHistogram(histogramSample))
-	_ = NewGoMetrics(monReg, "cleared", Accept).Register("histogram", NewClearOnVisitHistogram(clearedHistogramSample))
+	_ = NewGoMetrics(monReg, "original", logp.NewNopLogger(), Accept).Register("histogram", metrics.NewHistogram(histogramSample))
+	_ = NewGoMetrics(monReg, "cleared", logp.NewNopLogger(), Accept).Register("histogram", NewClearOnVisitHistogram(clearedHistogramSample))
 	dataPoints := [...]int{2, 4, 8, 4, 2}
 	dataPointsMedian := 4.0
 	for _, i := range dataPoints {


### PR DESCRIPTION

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR creates additonal options on certain method in`tlscommon1 package  to accept a local logger. 
Note: This PR includes breaking changes - but those methods are not used by `elastic-agent` ensuring the blast radius is small
This is part of the effort to get rid of global states.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/ingest-dev/issues/5251

