### PR TITLE
Replace global logger with local logger in tlscommon package

### DIFF
--- a/transport/client.go
+++ b/transport/client.go
@@ -48,7 +48,7 @@ type Config struct {
 	Stats   IOStatser
 }
 
-func NewClient(c Config, network, host string, defaultPort int) (*Client, error) {
+func NewClient(c Config, network, host string, defaultPort int, logger *logp.Logger) (*Client, error) {
 	// do some sanity checks regarding network and Config matching +
 	// address being parseable
 	switch network {
@@ -62,15 +62,15 @@ func NewClient(c Config, network, host string, defaultPort int) (*Client, error)
 		return nil, fmt.Errorf("unsupported network type %v", network)
 	}
 
-	dialer, err := MakeDialer(c)
+	dialer, err := MakeDialer(c, logger)
 	if err != nil {
 		return nil, err
 	}
 
-	return NewClientWithDialer(dialer, c, network, host, defaultPort)
+	return NewClientWithDialer(dialer, c, network, host, defaultPort, logger)
 }
 
-func NewClientWithDialer(d Dialer, c Config, network, host string, defaultPort int) (*Client, error) {
+func NewClientWithDialer(d Dialer, c Config, network, host string, defaultPort int, logger *logp.Logger) (*Client, error) {
 	// check address being parseable
 	host = fullAddress(host, defaultPort)
 	_, _, err := net.SplitHostPort(host)
@@ -79,7 +79,7 @@ func NewClientWithDialer(d Dialer, c Config, network, host string, defaultPort i
 	}
 
 	client := &Client{
-		log:     logp.NewLogger(logSelector),
+		log:     logger.Named(logSelector),
 		dialer:  d,
 		network: network,
 		host:    host,
@@ -231,7 +231,7 @@ func (c *Client) Test(d testing.Driver) {
 		} else {
 			d.Run("TLS", func(d testing.Driver) {
 				netDialer := NetDialer(c.config.Timeout)
-				tlsDialer := TestTLSDialer(d, netDialer, c.config.TLS, c.config.Timeout)
+				tlsDialer := TestTLSDialer(d, netDialer, c.config.TLS, c.config.Timeout, c.log)
 				_, err := tlsDialer.DialContext(context.Background(), "tcp", c.host)
 				d.Fatal("dial up", err)
 			})

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -65,7 +65,7 @@ func TestTLSDialer(
 			tlsConfig = lastTLSConfig
 		}
 		if tlsConfig == nil {
-			// if tlsconfig is nil, configure passed logger on tls
+			// if tlsconfig is nil, set provided logger
 			if config == nil {
 				tlsConfig = config.BuildModuleClientConfig(host, tlscommon.WithLogger(logger))
 			} else {

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -26,12 +26,13 @@ import (
 	"sync"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp"
 	"github.com/elastic/elastic-agent-libs/testing"
 	"github.com/elastic/elastic-agent-libs/transport/tlscommon"
 )
 
-func TLSDialer(forward Dialer, config *tlscommon.TLSConfig, timeout time.Duration) Dialer {
-	return TestTLSDialer(testing.NullDriver, forward, config, timeout)
+func TLSDialer(forward Dialer, config *tlscommon.TLSConfig, timeout time.Duration, logger *logp.Logger) Dialer {
+	return TestTLSDialer(testing.NullDriver, forward, config, timeout, logger)
 }
 
 func TestTLSDialer(
@@ -39,6 +40,7 @@ func TestTLSDialer(
 	forward Dialer,
 	config *tlscommon.TLSConfig,
 	timeout time.Duration,
+	logger *logp.Logger,
 ) Dialer {
 	var lastTLSConfig *tls.Config
 	var lastNetwork string
@@ -63,7 +65,12 @@ func TestTLSDialer(
 			tlsConfig = lastTLSConfig
 		}
 		if tlsConfig == nil {
-			tlsConfig = config.BuildModuleClientConfig(host)
+			// if tlsconfig is nil, configure passed logger on tls
+			if config == nil {
+				tlsConfig = config.BuildModuleClientConfig(host, tlscommon.WithLogger(logger))
+			} else {
+				tlsConfig = config.BuildModuleClientConfig(host)
+			}
 			lastNetwork = network
 			lastAddress = address
 			lastTLSConfig = tlsConfig

--- a/transport/tls.go
+++ b/transport/tls.go
@@ -223,7 +223,7 @@ func postVerifyTLSConnection(d testing.Driver, conn *tls.Conn, config *tlscommon
 	}
 
 	versions := config.Versions
-	if versions == nil {
+	if len(versions) == 0 {
 		versions = tlscommon.TLSDefaultVersions
 	}
 	versionOK := false

--- a/transport/transport.go
+++ b/transport/transport.go
@@ -45,17 +45,17 @@ func (d DialerFunc) DialContext(ctx context.Context, network, address string) (n
 }
 
 func DialContext(ctx context.Context, c Config, network, address string) (net.Conn, error) {
-	d, err := MakeDialer(c)
+	d, err := MakeDialer(c, logp.NewLogger(""))
 	if err != nil {
 		return nil, err
 	}
 	return d.DialContext(ctx, network, address)
 }
 
-func MakeDialer(c Config) (Dialer, error) {
+func MakeDialer(c Config, logger *logp.Logger) (Dialer, error) {
 	var err error
 	dialer := NetDialer(c.Timeout)
-	dialer, err = ProxyDialer(logp.NewLogger(logSelector), c.Proxy, dialer)
+	dialer, err = ProxyDialer(logger.Named(logSelector), c.Proxy, dialer)
 	if err != nil {
 		return nil, err
 	}
@@ -64,7 +64,7 @@ func MakeDialer(c Config) (Dialer, error) {
 	}
 
 	if c.TLS != nil {
-		return TLSDialer(dialer, c.TLS, c.Timeout), nil
+		return TLSDialer(dialer, c.TLS, c.Timeout, logger), nil
 	}
 	return dialer, nil
 }


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR supports additonal options on certain method in`tlscommon` package  to accept a local logger. 
Note: This PR includes breaking changes as well - but those methods are not used by `elastic-agent` ensuring the blast radius is small

This is part of the effort to get rid of global states.

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works


## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/ingest-dev/issues/5251

