### PR TITLE
Fix `postVerifyTLSConnection`

### DIFF
--- a/transport/tls.go
+++ b/transport/tls.go
@@ -216,7 +216,7 @@ func postVerifyTLSConnection(d testing.Driver, conn *tls.Conn, config *tlscommon
 	}
 
 	versions := config.Versions
-	if versions == nil {
+	if len(versions) == 0 {
 		versions = tlscommon.TLSDefaultVersions
 	}
 	versionOK := false


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR checks if TLS version is empty instead of checking it is nil. It is possible that an empty array of TLS version is passed, in that case current condition evaluates to false

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

