### PR TITLE
Add fmt to check target

### DIFF
--- a/magefile.go
+++ b/magefile.go
@@ -43,7 +43,7 @@ var Aliases = map[string]interface{}{
 // Check runs all the checks
 // nolint: deadcode,unparam // it's used as a `mage` target and requires returning an error
 func Check() error {
-	mg.Deps(devtools.Deps.CheckModuleTidy, CheckLicenseHeaders)
+	mg.Deps(devtools.Deps.CheckModuleTidy, CheckLicenseHeaders, Fmt)
 	mg.Deps(devtools.CheckNoChanges)
 	return nil
 }


### PR DESCRIPTION
## What does this PR do?

Add fmt to check target
## Why is it important?

Because `fmt` was not part of `mage check`, the code was not correctly formatted and running `mage fmt` on a new branch/PR would generate  many unrelated changes. https://github.com/elastic/elastic-agent-libs/pull/363 already formatted the code, now this PRs ensures we do it on every PR.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] ~~I have commented my code, particularly in hard-to-understand areas~~
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

~~## Author's Checklist~~
## Related issues

- Follow up from https://github.com/elastic/elastic-agent-libs/pull/363

