### PR TITLE
Include whether Beat is running from a FIPS distribution in User Agent

### DIFF
--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -93,7 +93,13 @@ func UserAgent(binaryNameCapitalized string, version, commit, buildTime string, 
 	return builder.String()
 }
 
-func UserAgentWithBeatTelemetry(binaryNameCapitalized string, version string, mode AgentManagementMode, unprivileged AgentUnprivilegedMode) string {
+func UserAgentWithBeatTelemetry(
+	binaryNameCapitalized string,
+	version string,
+	mode AgentManagementMode,
+	unprivileged AgentUnprivilegedMode,
+	isFIPSDistribution bool,
+) string {
 	var builder strings.Builder
 	builder.WriteString("Elastic-" + binaryNameCapitalized + "/" + version + " ")
 	uaValues := []string{
@@ -106,6 +112,10 @@ func UserAgentWithBeatTelemetry(binaryNameCapitalized string, version string, mo
 	if unprivileged != AgentUnprivilegedModeUnknown {
 		uaValues = append(uaValues, unprivileged.String())
 	}
+	if isFIPSDistribution {
+		uaValues = append(uaValues, "FIPS")
+	}
+
 	builder.WriteByte('(')
 	builder.WriteString(strings.Join(uaValues, "; "))
 	builder.WriteByte(')')

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -41,9 +41,10 @@ func TestUserAgent(t *testing.T) {
 }
 
 func TestUserAgentWithBeatTelemetry(t *testing.T) {
-	ua2 := UserAgentWithBeatTelemetry("FakeBeat", v, mode, unprivileged)
+	isFIPSDistribution := true
+	ua2 := UserAgentWithBeatTelemetry("FakeBeat", v, mode, unprivileged, isFIPSDistribution)
 	assert.Regexp(t, regexp.MustCompile(`^Elastic-FakeBeat`), ua2)
-	assert.Regexp(t, regexp.MustCompile(`; Managed; Unprivileged\)$`), ua2)
+	assert.Regexp(t, regexp.MustCompile(`; Managed; Unprivileged; FIPS\)$`), ua2)
 
 	// Require deliberate update in case we want to extend the User Agent later
 	assert.LessOrEqual(t, len(ua2), 100, "User agent string should be less than 100 characters")


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

This PR enhances the `useragent.UserAgentWithBeatTelemetry` function to take in an additional argument, `isFIPSDistribution bool` and include `FIPS` in the user agent set by Beats if this argument is set to `true`.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

To track FIPS usage in Beats.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
