### PR TITLE
Prevent logptest.NewTestingLogger from panics.

### DIFF
--- a/logp/logptest/logptest.go
+++ b/logp/logptest/logptest.go
@@ -22,23 +22,19 @@ import (
 
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
-	"go.uber.org/zap/zaptest"
 	"go.uber.org/zap/zaptest/observer"
 
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-// NewTestingLogger returns a testing suitable logp.Logger that uses the
-// [testing.T] as the logger output.
+// NewTestingLogger Just calls [NewFileLogger], the log if is placed in the
+// the folder returned by [os.TempDir].
+//
+// DEPRECATED: The logger returned by [NewTestingLogger] can panic if it is
+// used after the test has ended. Use [NewFileLogger] instead.
 func NewTestingLogger(t testing.TB, selector string, options ...logp.LogOption) *logp.Logger {
-	log := zaptest.NewLogger(t, zaptest.WrapOptions(options...))
-	log = log.Named(selector)
-
-	logger, err := logp.NewZapLogger(log)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return logger
+	l := NewFileLogger(t, "")
+	return l.Logger
 }
 
 // NewTestingLoggerWithObserver returns a testing suitable logp.Logger that uses the


### PR DESCRIPTION
## What does this PR do?

Because NewTestingLogger used testing.T as the logger output, if the logger is used after the test has ended, it will panic.

This behaviour has been seen a few times and causes flakiness in our CI.

To mitigate this, NewTestingLogger now just calls NewFileLogger that uses a file as the logger output, thus being safe for use even after the test has ended.

## Why is it important?

It prevents tests from becoming flaky

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] ~~I have added tests that prove my fix is effective or that my feature works~~

~~## Author's Checklist~~
~~## Related issues~~
