### PR TITLE
Update gvm version used in buildkite to v0.6.0

### DIFF
--- a/.buildkite/hooks/pre-command.ps1
+++ b/.buildkite/hooks/pre-command.ps1
@@ -2,7 +2,7 @@ $env:GO_VERSION = Get-Content -Path .go-version
 
 # Install gvm and go
 # TODO: Move GVM download to the base VM image
-$env:GvmVersion = "0.5.2"
+$env:GvmVersion = "0.6.0"
 [Net.ServicePointManager]::SecurityProtocol = "tls12"
 $env:GoVersion = Get-Content -Path .go-version
 Invoke-WebRequest -URI https://github.com/andrewkroh/gvm/releases/download/v$env:GvmVersion/gvm-windows-amd64.exe -Outfile C:\Windows\System32\gvm.exe

--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -1,7 +1,7 @@
 # yaml-language-server: $schema=https://raw.githubusercontent.com/buildkite/pipeline-schema/main/schema.json
 env:
   SETUP_MAGE_VERSION: '1.14.0'
-  SETUP_GVM_VERSION: 'v0.5.0'
+  SETUP_GVM_VERSION: 'v0.6.0'
 
 steps:
   - label: ":buildkite: Lint"


### PR DESCRIPTION
## What does this PR do?

Update gvm version used in buildkite to v0.6.0

## Why is it important?

Buildkite is encoutering gvm errors when getting go version.