### PR TITLE
logp: add Name method to Logger

### DIFF
--- a/logp/core_test.go
+++ b/logp/core_test.go
@@ -252,6 +252,7 @@ func TestCreatingNewLoggerWithDifferentOutput(t *testing.T) {
 	firstLoggerMessage := "not the message we want"
 
 	logger := L().Named(firstLoggerName)
+	assert.Equal(t, firstLoggerName, logger.Name(), "Unexpected logger name.")
 	logger.Info(firstLoggerMessage)
 	if err := logger.Sync(); err != nil {
 		t.Fatalf("could not sync log file from fist logger: %s", err)

--- a/logp/logger.go
+++ b/logp/logger.go
@@ -167,6 +167,12 @@ func (l *Logger) With(args ...interface{}) *Logger {
 	return &Logger{sugar.Desugar(), sugar, l.selectors}
 }
 
+// Name returns the Logger's underlying name, or an empty string if the
+// logger is unnamed.
+func (l *Logger) Name() string {
+	return l.logger.Name()
+}
+
 // Named adds a new path segment to the logger's name. Segments are joined by
 // periods.
 func (l *Logger) Named(name string) *Logger {


### PR DESCRIPTION
Expose the underlying zap Logger.Name method so callers can retrieve the logger's dot-joined name. This is needed to carry the logger name across when bridging to slog via zapslog.

<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

It adds a call-through to the zap logger name method.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

This allows bridging to log/slog without loss of logger naming behaviour.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates elastic/beats#49160
- Relates elastic/entcollect#1

