### PR TITLE
fix(logp): avoid unconditional fmt.Sprintf in MakeDebug

### DIFF
--- a/logp/global.go
+++ b/logp/global.go
@@ -29,7 +29,10 @@ import (
 // Deprecated: Use logp.NewLogger.
 func MakeDebug(selector string) func(string, ...interface{}) {
 	return func(format string, v ...interface{}) {
-		globalLogger().Named(selector).Debug(fmt.Sprintf(format, v...))
+		log := globalLogger().Named(selector)
+		if log.Core().Enabled(zap.DebugLevel) {
+			log.Debug(fmt.Sprintf(format, v...))
+		}
 	}
 }
 


### PR DESCRIPTION
## What does this PR do?

    fix(logp): avoid unconditional fmt.Sprintf in MakeDebug

    MakeDebug called fmt.Sprintf on every invocation regardless of log
    level. Add a debug-level check so the formatting is skipped when debug
    logging is disabled, consistent with the other helpers in global.go.

Note: `.Sugar()` would make the change a 1-liner but it would introduce a logger clone 

## Why is it important?

fmt.Sprintf is wasteful and allocates strings that are immediately thrown away.

## Checklist

- [x] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works