### PR TITLE
guard against nil pointer dereference

### DIFF
--- a/monitoring/metrics.go
+++ b/monitoring/metrics.go
@@ -296,7 +296,12 @@ func NewFunc(r *Registry, name string, f func(Mode, Visitor), opts ...Option) *F
 	return v
 }
 
-func (f *Func) Visit(m Mode, vs Visitor) { f.f(m, vs) }
+func (f *Func) Visit(m Mode, vs Visitor) {
+	if f == nil || f.f == nil {
+		return
+	}
+	f.f(m, vs)
+}
 
 func (m makeExpvar) String() string { return m() }
 

--- a/monitoring/metrics_test.go
+++ b/monitoring/metrics_test.go
@@ -195,3 +195,26 @@ func TestNilReg(t *testing.T) {
 	require.NotNil(t, testUint)
 
 }
+
+func TestFuncVisitNilGuard(t *testing.T) {
+	t.Run("nil receiver does not panic", func(t *testing.T) {
+		var f *Func
+		assert.NotPanics(t, func() {
+			f.Visit(Full, nil)
+		})
+	})
+
+	t.Run("nil inner func does not panic", func(t *testing.T) {
+		f := &Func{}
+		assert.NotPanics(t, func() {
+			f.Visit(Full, nil)
+		})
+	})
+
+	t.Run("non-nil func is called", func(t *testing.T) {
+		called := false
+		f := &Func{f: func(m Mode, v Visitor) { called = true }}
+		f.Visit(Full, nil)
+		assert.True(t, called)
+	})
+}


### PR DESCRIPTION
## What does this PR do?

Adds a nil guard in `(*Func).Visit` to prevent a panic when either the `Func` receiver or its inner function `f.f` is nil.

This is a short term fix.  Longer term evaluation needed to see if we can avoid having nil guards.

## Why is it important?

addresses bug reported in #392

## Checklist


- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

- Closes #392

