### PR TITLE
fix(mapstr): DeepCloneUpdate must merge into map[string]interface{} destinations

### DIFF
--- a/mapstr/deepcloneupdate_test.go
+++ b/mapstr/deepcloneupdate_test.go
@@ -589,6 +589,67 @@ func BenchmarkHeavyPipeline(b *testing.B) {
 	})
 }
 
+// BenchmarkMixedTypePipeline benchmarks merging into an event whose field tree
+// contains map[string]interface{} subtrees — the common case when events are
+// decoded from JSON before processors run. This exercises the map[string]interface{}
+// destination branch added to fix the v0.36.0 regression.
+func BenchmarkMixedTypePipeline(b *testing.B) {
+	// Processor metadata: pure mapstr.M (as built by add_fields, add_cloud_metadata, etc.)
+	sharedMeta := []M{
+		{"elastic_agent": M{"id": "agent-uuid", "snapshot": false, "version": "8.12.0"}},
+		{"agent": M{"id": "agent-uuid"}},
+		{"data_stream": M{"type": "logs", "dataset": "system.syslog", "namespace": "default"}},
+		{"event": M{"dataset": "system.syslog"}},
+		{"cloud": M{
+			"provider": "aws", "region": "us-east-1",
+			"account": M{"id": "123456789012"}, "instance": M{"id": "i-0abcdef"},
+		}},
+	}
+
+	// makeDst returns an event whose subtrees are map[string]interface{} —
+	// simulating JSON-decoded input where the decoder returns native Go maps.
+	makeDst := func() M {
+		return M{
+			"message": "request completed in 42ms",
+			"event": map[string]interface{}{
+				"start": "2024-01-01T00:00:00Z",
+				"end":   "2024-01-01T00:00:01Z",
+			},
+			"process": map[string]interface{}{
+				"start": "2024-01-01T00:00:00Z",
+				"pid":   1234,
+				"name":  "myapp",
+			},
+			"host": map[string]interface{}{
+				"name": "prod-server-01",
+				"os":   map[string]interface{}{"type": "linux", "version": "22.04"},
+			},
+		}
+	}
+
+	b.Run("clone_and_deep_update", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			dst := makeDst()
+			for _, src := range sharedMeta {
+				dst.DeepUpdate(src.Clone())
+			}
+			benchSinkM = dst
+		}
+	})
+
+	b.Run("deep_clone_update", func(b *testing.B) {
+		b.ReportAllocs()
+		for i := 0; i < b.N; i++ {
+			dst := makeDst()
+			for _, src := range sharedMeta {
+				dst.DeepCloneUpdate(src)
+			}
+			benchSinkM = dst
+		}
+	})
+}
+
 func TestDeepCloneUpdateNoOverwriteMapReplacesScalar(t *testing.T) {
 	dst := M{
 		"host":    "26.101.84.62",

--- a/mapstr/deepcloneupdate_test.go
+++ b/mapstr/deepcloneupdate_test.go
@@ -190,6 +190,65 @@ func TestDeepCloneUpdateNoOverwriteNoAliasing(t *testing.T) {
 	assert.Equal(t, srcCopy, src, "source must not be affected")
 }
 
+// TestDeepCloneUpdateNoOverwriteDeepNested is the specific regression test for
+// the scenario CodeRabbit flagged as critical: an optimization in add_fields
+// short-circuited on top-level key presence, silently dropping enrichment for
+// partially-populated nested objects. This test verifies that
+// DeepCloneUpdateNoOverwrite descends into existing sub-maps and adds missing
+// leaves at any depth rather than stopping at the first level.
+func TestDeepCloneUpdateNoOverwriteDeepNested(t *testing.T) {
+	// Three levels deep: dst has host.os.type, src has host.os.version.
+	// The correct behavior is to add host.os.version without touching host.os.type.
+	dst := M{
+		"host": M{
+			"os": M{"type": "linux"},
+		},
+	}
+	src := M{
+		"host": M{
+			"os": M{"version": "22.04", "type": "windows"},
+		},
+	}
+
+	dst.DeepCloneUpdateNoOverwrite(src)
+
+	// Existing leaf at depth 3 must not be overwritten.
+	v, err := dst.GetValue("host.os.type")
+	require.NoError(t, err)
+	assert.Equal(t, "linux", v)
+
+	// Missing leaf at depth 3 must be added.
+	v, err = dst.GetValue("host.os.version")
+	require.NoError(t, err)
+	assert.Equal(t, "22.04", v)
+}
+
+// TestDeepCloneUpdateNoOverwriteNewSubMapNoAliasing verifies that when
+// DeepCloneUpdateNoOverwrite adds a new sub-map inside an existing sub-map,
+// the newly inserted map is a fresh copy and not aliased to the source.
+func TestDeepCloneUpdateNoOverwriteNewSubMapNoAliasing(t *testing.T) {
+	src := M{
+		"agent": M{
+			"id":      "existing",
+			"details": M{"version": "8.12.0"},
+		},
+	}
+	srcCopy := src.Clone()
+
+	dst := M{"agent": M{"id": "existing"}}
+	dst.DeepCloneUpdateNoOverwrite(src)
+
+	// Mutate the newly-inserted sub-map in the destination.
+	details, err := dst.GetValue("agent.details")
+	require.NoError(t, err)
+	detailsMap, ok := details.(M)
+	require.True(t, ok)
+	detailsMap["version"] = "MUTATED"
+
+	// Source must be unchanged.
+	assert.Equal(t, srcCopy, src, "source must not be affected by mutations to destination")
+}
+
 func TestDeepCloneUpdateNoOverwriteEquivalence(t *testing.T) {
 	src := M{
 		"agent": M{"id": "new", "version": "8.12.0"},

--- a/mapstr/deepcloneupdate_test.go
+++ b/mapstr/deepcloneupdate_test.go
@@ -264,6 +264,71 @@ func TestDeepCloneUpdateNoOverwriteEquivalence(t *testing.T) {
 	assert.Equal(t, dst1, dst2)
 }
 
+// TestDeepCloneUpdateMapStringInterfaceDst is the regression test for the bug
+// where DeepCloneUpdate overwrote a map[string]interface{} destination subtree
+// instead of merging into it. This caused event fields like @timestamp,
+// event.start, and process.start to be silently dropped or replaced with
+// empty maps when processors merged their metadata into events whose fields
+// contained map[string]interface{} values (e.g. decoded from JSON).
+func TestDeepCloneUpdateMapStringInterfaceDst(t *testing.T) {
+	// Simulates an event where "event" subtree is map[string]interface{} (as
+	// decoded from JSON/wire), and a processor adds "event.dataset".
+	dst := M{
+		"event": map[string]interface{}{
+			"start": "2024-01-01T00:00:00Z",
+			"end":   "2024-01-01T01:00:00Z",
+		},
+	}
+	src := M{
+		"event": M{"dataset": "mydata"},
+	}
+
+	dst.DeepCloneUpdate(src)
+
+	// Existing fields in the map[string]interface{} subtree must be preserved.
+	v, err := dst.GetValue("event.start")
+	require.NoError(t, err)
+	assert.Equal(t, "2024-01-01T00:00:00Z", v)
+
+	v, err = dst.GetValue("event.end")
+	require.NoError(t, err)
+	assert.Equal(t, "2024-01-01T01:00:00Z", v)
+
+	// New field from source must be added.
+	v, err = dst.GetValue("event.dataset")
+	require.NoError(t, err)
+	assert.Equal(t, "mydata", v)
+}
+
+func TestDeepCloneUpdateNoOverwriteMapStringInterfaceDst(t *testing.T) {
+	dst := M{
+		"process": map[string]interface{}{
+			"start": "2024-01-01T00:00:00Z",
+			"pid":   1234,
+		},
+	}
+	src := M{
+		"process": M{"start": "SHOULD-NOT-OVERWRITE", "name": "myapp"},
+	}
+
+	dst.DeepCloneUpdateNoOverwrite(src)
+
+	// Existing field must not be overwritten.
+	v, err := dst.GetValue("process.start")
+	require.NoError(t, err)
+	assert.Equal(t, "2024-01-01T00:00:00Z", v)
+
+	// Existing field from original map preserved.
+	v, err = dst.GetValue("process.pid")
+	require.NoError(t, err)
+	assert.Equal(t, 1234, v)
+
+	// New field added.
+	v, err = dst.GetValue("process.name")
+	require.NoError(t, err)
+	assert.Equal(t, "myapp", v)
+}
+
 func TestDeepCloneUpdateNilSource(t *testing.T) {
 	dst := M{"key": "value"}
 	dst.DeepCloneUpdate(nil)

--- a/mapstr/deepcloneupdate_test.go
+++ b/mapstr/deepcloneupdate_test.go
@@ -329,6 +329,67 @@ func TestDeepCloneUpdateNoOverwriteMapStringInterfaceDst(t *testing.T) {
 	assert.Equal(t, "myapp", v)
 }
 
+// TestDeepCloneUpdateMapStringInterfaceDstEquivalence is the oracle test for
+// the map[string]interface{} destination fix: verifies DeepCloneUpdate
+// produces bit-for-bit the same result as DeepUpdate(src.Clone()) when the
+// destination tree contains map[string]interface{} nodes (as commonly occurs
+// with JSON-decoded event data).
+func TestDeepCloneUpdateMapStringInterfaceDstEquivalence(t *testing.T) {
+	makeDst := func() M {
+		return M{
+			"event": map[string]interface{}{
+				"start": "2024-01-01T00:00:00Z",
+				"end":   "2024-01-01T01:00:00Z",
+			},
+			"process": map[string]interface{}{
+				"start": "2024-01-01T00:00:00Z",
+				"pid":   1234,
+			},
+			"host": M{"name": "server1"},
+		}
+	}
+	src := M{
+		"event":   M{"dataset": "mydata"},
+		"process": M{"name": "myapp"},
+		"host":    M{"os": M{"type": "linux"}},
+	}
+
+	dst1 := makeDst()
+	dst1.DeepUpdate(src.Clone())
+
+	dst2 := makeDst()
+	dst2.DeepCloneUpdate(src)
+
+	assert.Equal(t, dst1, dst2, "DeepCloneUpdate must be equivalent to DeepUpdate(src.Clone()) for map[string]interface{} destinations")
+}
+
+func TestDeepCloneUpdateNoOverwriteMapStringInterfaceDstEquivalence(t *testing.T) {
+	makeDst := func() M {
+		return M{
+			"event": map[string]interface{}{
+				"start":   "2024-01-01T00:00:00Z",
+				"dataset": "original",
+			},
+			"process": map[string]interface{}{
+				"start": "2024-01-01T00:00:00Z",
+				"pid":   1234,
+			},
+		}
+	}
+	src := M{
+		"event":   M{"dataset": "new-dataset", "end": "2024-01-01T01:00:00Z"},
+		"process": M{"start": "SHOULD-NOT-OVERWRITE", "name": "myapp"},
+	}
+
+	dst1 := makeDst()
+	dst1.DeepUpdateNoOverwrite(src.Clone())
+
+	dst2 := makeDst()
+	dst2.DeepCloneUpdateNoOverwrite(src)
+
+	assert.Equal(t, dst1, dst2, "DeepCloneUpdateNoOverwrite must be equivalent to DeepUpdateNoOverwrite(src.Clone()) for map[string]interface{} destinations")
+}
+
 func TestDeepCloneUpdateNilSource(t *testing.T) {
 	dst := M{"key": "value"}
 	dst.DeepCloneUpdate(nil)

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -100,9 +100,11 @@ func (m M) DeepCloneUpdate(d M) {
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdate(srcVal)
 			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
-				// Destination is map[string]interface{}: recurse in-place (same
-				// semantics as deepUpdateValue) rather than overwriting the subtree.
-				M(dstRaw).DeepCloneUpdate(srcVal)
+				// Destination is map[string]interface{}: promote to M and recurse,
+				// matching deepUpdateValue semantics which also promotes the type.
+				dstMap := M(dstRaw)
+				dstMap.DeepCloneUpdate(srcVal)
+				m[k] = dstMap
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(srcVal)
@@ -112,7 +114,9 @@ func (m M) DeepCloneUpdate(d M) {
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdate(M(srcVal))
 			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
-				M(dstRaw).DeepCloneUpdate(M(srcVal))
+				dstMap := M(dstRaw)
+				dstMap.DeepCloneUpdate(M(srcVal))
+				m[k] = dstMap
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(M(srcVal))
@@ -140,7 +144,9 @@ func (m M) DeepCloneUpdateNoOverwrite(d M) {
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdateNoOverwrite(srcVal)
 			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
-				M(dstRaw).DeepCloneUpdateNoOverwrite(srcVal)
+				dstMap := M(dstRaw)
+				dstMap.DeepCloneUpdateNoOverwrite(srcVal)
+				m[k] = dstMap
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(srcVal)
@@ -150,7 +156,9 @@ func (m M) DeepCloneUpdateNoOverwrite(d M) {
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdateNoOverwrite(M(srcVal))
 			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
-				M(dstRaw).DeepCloneUpdateNoOverwrite(M(srcVal))
+				dstMap := M(dstRaw)
+				dstMap.DeepCloneUpdateNoOverwrite(M(srcVal))
+				m[k] = dstMap
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(M(srcVal))

--- a/mapstr/mapstr.go
+++ b/mapstr/mapstr.go
@@ -99,6 +99,10 @@ func (m M) DeepCloneUpdate(d M) {
 		case M:
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdate(srcVal)
+			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
+				// Destination is map[string]interface{}: recurse in-place (same
+				// semantics as deepUpdateValue) rather than overwriting the subtree.
+				M(dstRaw).DeepCloneUpdate(srcVal)
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(srcVal)
@@ -107,6 +111,8 @@ func (m M) DeepCloneUpdate(d M) {
 		case map[string]interface{}:
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdate(M(srcVal))
+			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
+				M(dstRaw).DeepCloneUpdate(M(srcVal))
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(M(srcVal))
@@ -133,6 +139,8 @@ func (m M) DeepCloneUpdateNoOverwrite(d M) {
 		case M:
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdateNoOverwrite(srcVal)
+			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
+				M(dstRaw).DeepCloneUpdateNoOverwrite(srcVal)
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(srcVal)
@@ -141,6 +149,8 @@ func (m M) DeepCloneUpdateNoOverwrite(d M) {
 		case map[string]interface{}:
 			if dstMap, ok := m[k].(M); ok {
 				dstMap.DeepCloneUpdateNoOverwrite(M(srcVal))
+			} else if dstRaw, ok := m[k].(map[string]interface{}); ok {
+				M(dstRaw).DeepCloneUpdateNoOverwrite(M(srcVal))
 			} else {
 				fresh := make(M, len(srcVal))
 				fresh.DeepCloneUpdate(M(srcVal))


### PR DESCRIPTION
## Summary

- **Bug fix**: `DeepCloneUpdate` and `DeepCloneUpdateNoOverwrite` only recursed when the destination value was `mapstr.M`. When the destination held a `map[string]interface{}` (common for events decoded from JSON/wire), they overwrote the entire subtree with a fresh map, silently dropping all existing fields.
- **Impact**: This caused broad regressions in beats (elastic/beats#49762): `event.start`, `event.end`, `process.start`, and `@timestamp` were lost or replaced with `{}` whenever a processor merged metadata into events whose field trees contained `map[string]interface{}` nodes.
- **Fix**: Added an explicit `map[string]interface{}` destination branch that casts to `M` and recurses in-place, matching the behavior of `deepUpdateValue`.
- **Tests**: Regression tests for mixed-type destinations (the failing scenario), plus the deep-nested partial-population and sub-map aliasing cases from the original review.

## Test plan

- [x] `go test ./mapstr/... -race` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)