### PR TITLE
feat(tlscommon): add CertReloader for TLS certificate hot-reload

### DIFF
--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -1,0 +1,112 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tlscommon
+
+import (
+	"crypto/tls"
+	"fmt"
+	"sync"
+	"time"
+)
+
+const defaultReloadInterval = 5 * time.Second
+
+// CertReloader periodically reloads TLS certificate and key files from disk.
+// On each call to GetCertificate (i.e., on each TLS handshake), it checks
+// whether the reload interval has elapsed and, if so, re-reads the files from
+// disk. Invalid cert/key pairs are silently skipped, preserving the last
+// successfully loaded certificate.
+//
+// This design follows the OpenTelemetry Collector's configtls approach: no file
+// watchers or extra goroutines — just a time check on the handshake hot path.
+type CertReloader struct {
+	certPath       string
+	keyPath        string
+	reloadInterval time.Duration
+
+	mu         sync.RWMutex
+	cert       *tls.Certificate
+	nextReload time.Time
+}
+
+// CertReloaderOption is a functional option for configuring a CertReloader.
+type CertReloaderOption func(*CertReloader)
+
+// WithReloadInterval sets how often the certificate files are re-read from disk.
+// If not specified, a default of 5 seconds is used.
+func WithReloadInterval(d time.Duration) CertReloaderOption {
+	return func(r *CertReloader) {
+		r.reloadInterval = d
+	}
+}
+
+// NewCertReloader creates a CertReloader for the given cert and key file paths.
+// It performs an initial load of the certificate pair, returning an error if the
+// initial load fails.
+func NewCertReloader(certPath, keyPath string, opts ...CertReloaderOption) (*CertReloader, error) {
+	if certPath == "" || keyPath == "" {
+		return nil, fmt.Errorf("certificate and key paths must be non-empty")
+	}
+
+	r := &CertReloader{
+		certPath:       certPath,
+		keyPath:        keyPath,
+		reloadInterval: defaultReloadInterval,
+	}
+	for _, opt := range opts {
+		opt(r)
+	}
+
+	cert, err := tls.LoadX509KeyPair(certPath, keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("initial certificate load failed: %w", err)
+	}
+	r.cert = &cert
+	r.nextReload = time.Now().Add(r.reloadInterval)
+
+	return r, nil
+}
+
+// GetCertificate returns the current certificate, reloading from disk if the
+// reload interval has elapsed. It is safe for concurrent use and is intended
+// to be used with tls.Config.GetCertificate.
+func (r *CertReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	r.mu.RLock()
+	if time.Now().Before(r.nextReload) {
+		defer r.mu.RUnlock()
+		return r.cert, nil
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	// Another goroutine may have reloaded while we waited for the write lock.
+	if time.Now().Before(r.nextReload) {
+		return r.cert, nil
+	}
+
+	r.nextReload = time.Now().Add(r.reloadInterval)
+
+	cert, err := tls.LoadX509KeyPair(r.certPath, r.keyPath)
+	if err != nil {
+		return r.cert, nil
+	}
+	r.cert = &cert
+	return r.cert, nil
+}

--- a/transport/tlscommon/cert_reloader_test.go
+++ b/transport/tlscommon/cert_reloader_test.go
@@ -1,0 +1,152 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tlscommon
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeKeyAndCertFiles generates a cert/key pair and writes them to dir,
+// returning the file paths. Each call generates a distinct pair.
+func writeKeyAndCertFiles(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+
+	keyPEM, certPEM := makeKeyCertPair(t, blockTypePKCS8, "")
+
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, []byte(certPEM), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, []byte(keyPEM), 0o600))
+
+	return certPath, keyPath
+}
+
+func TestNewCertReloader_ValidCertPair(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeKeyAndCertFiles(t, dir)
+
+	r, err := NewCertReloader(certPath, keyPath)
+	require.NoError(t, err)
+
+	got, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	assert.NotNil(t, got)
+	assert.NotEmpty(t, got.Certificate)
+}
+
+func TestNewCertReloader_InvalidCertPair(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write a cert from one pair and a key from another — they won't match.
+	_, certPEM1 := makeKeyCertPair(t, blockTypePKCS8, "")
+	keyPEM2, _ := makeKeyCertPair(t, blockTypePKCS8, "")
+
+	certPath := filepath.Join(dir, "cert.pem")
+	keyPath := filepath.Join(dir, "key.pem")
+	require.NoError(t, os.WriteFile(certPath, []byte(certPEM1), 0o600))
+	require.NoError(t, os.WriteFile(keyPath, []byte(keyPEM2), 0o600))
+
+	_, err := NewCertReloader(certPath, keyPath)
+	assert.Error(t, err)
+}
+
+func TestNewCertReloader_MissingFiles(t *testing.T) {
+	_, err := NewCertReloader("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	assert.Error(t, err)
+}
+
+func TestNewCertReloader_EmptyPaths(t *testing.T) {
+	_, err := NewCertReloader("", "")
+	assert.Error(t, err)
+}
+
+func TestCertReloader_ReloadsAfterInterval(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeKeyAndCertFiles(t, dir)
+
+	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(100*time.Millisecond))
+	require.NoError(t, err)
+
+	// Capture the initial certificate bytes.
+	initial, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	initialRaw := initial.Certificate[0]
+
+	// Overwrite with a new cert/key pair (distinct from the original).
+	writeKeyAndCertFiles(t, dir)
+
+	// After the reload interval, GetCertificate should return the new cert.
+	require.Eventually(t, func() bool {
+		got, err := r.GetCertificate(nil)
+		return err == nil && !bytes.Equal(got.Certificate[0], initialRaw)
+	}, 2*time.Second, 50*time.Millisecond, "cert should have been reloaded")
+}
+
+func TestCertReloader_InvalidNewCert_KeepsOld(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeKeyAndCertFiles(t, dir)
+
+	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(100*time.Millisecond))
+	require.NoError(t, err)
+
+	initial, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	initialRaw := initial.Certificate[0]
+
+	// Overwrite the cert file with invalid data.
+	require.NoError(t, os.WriteFile(certPath, []byte("not a cert"), 0o600))
+
+	// The original cert should remain served even after the reload interval,
+	// because the new cert is invalid and the reload is silently skipped.
+	require.Never(t, func() bool {
+		got, err := r.GetCertificate(nil)
+		if err != nil {
+			return true
+		}
+		return !bytes.Equal(got.Certificate[0], initialRaw)
+	}, 500*time.Millisecond, 50*time.Millisecond, "cert should not have changed after invalid reload")
+}
+
+func TestCertReloader_NoReloadBeforeInterval(t *testing.T) {
+	dir := t.TempDir()
+	certPath, keyPath := writeKeyAndCertFiles(t, dir)
+
+	// Use a long reload interval so it won't elapse during the test.
+	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(1*time.Hour))
+	require.NoError(t, err)
+
+	initial, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	initialRaw := initial.Certificate[0]
+
+	// Replace the cert files on disk.
+	writeKeyAndCertFiles(t, dir)
+
+	// GetCertificate should still return the original cert because the
+	// reload interval hasn't elapsed.
+	got, err := r.GetCertificate(nil)
+	require.NoError(t, err)
+	assert.Equal(t, initialRaw, got.Certificate[0])
+}


### PR DESCRIPTION
## What does this PR do?

Adds a `CertReloader` type to the `tlscommon` package that periodically reloads TLS certificate and key files from disk, enabling TLS certificate hot-reload without requiring a process restart.

The design follows the [OpenTelemetry Collector's `configtls` approach](https://github.com/open-telemetry/opentelemetry-collector/blob/7201768d04fb628e65cb4e3d5ead69d17c43d59d/config/configtls/configtls.go#L152): on each `GetCertificate` call (i.e., each TLS handshake), it checks whether the reload interval has elapsed and, if so, re-reads the files from disk. No file watchers or extra goroutines needed.

**API:**
- `NewCertReloader(certPath, keyPath string, opts ...CertReloaderOption) (*CertReloader, error)` — validates and loads the initial cert/key pair
- `WithReloadInterval(d time.Duration) CertReloaderOption` — configures how often to re-read files (default: 5s)
- `(*CertReloader).GetCertificate(*tls.ClientHelloInfo) (*tls.Certificate, error)` — for use with `tls.Config.GetCertificate`

**Behavior:**
- Invalid cert/key pairs during reload are silently skipped; the last successfully loaded certificate continues to be served
- Concurrent access is safe via `sync.RWMutex` with double-checked locking to avoid redundant reloads

## Why is it important?

Fleet Server needs TLS certificate hot-reload ([elastic/fleet-server#6433](https://github.com/elastic/fleet-server/issues/6433)) for environments with frequent certificate rotation — Kubernetes (where Secrets are remounted into pods), serverless (where cert-manager rotates certs), and general ops. The team discussed implementing this in `elastic-agent-libs` so it can be reused by other projects that need the same capability.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Tests cover: valid/invalid/missing cert pairs, reload after interval, invalid cert keeps old, no reload before interval

## Related issues

- Relates https://github.com/elastic/fleet-server/issues/6433
- Relates https://github.com/elastic/fleet-server/pull/6838