### PR TITLE
feat(tlscommon): add CertificateReload config to ServerConfig

### DIFF
--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -28,9 +28,26 @@ import (
 )
 
 // CertificateReload is the configuration for hot-reloading TLS certificates.
+// Use DefaultCertificateReload to get a value with sensible defaults (enabled,
+// 5 s reload interval).
 type CertificateReload struct {
-	Enabled        bool          `config:"enabled" yaml:"enabled,omitempty"`
+	Enabled        *bool         `config:"enabled" yaml:"enabled,omitempty"`
 	ReloadInterval time.Duration `config:"reload_interval" yaml:"reload_interval,omitempty"`
+}
+
+// DefaultCertificateReload returns a CertificateReload with sensible defaults:
+// enabled with a 5-second reload interval.
+func DefaultCertificateReload() CertificateReload {
+	enabled := true
+	return CertificateReload{
+		Enabled:        &enabled,
+		ReloadInterval: defaultReloadInterval,
+	}
+}
+
+// IsEnabled returns true unless certificate reload has been explicitly disabled.
+func (c *CertificateReload) IsEnabled() bool {
+	return c.Enabled == nil || *c.Enabled
 }
 
 // ServerConfig defines the user configurable tls options for any TCP based service.

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -21,22 +21,30 @@ import (
 	"crypto/tls"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
+// CertificateReload is the configuration for hot-reloading TLS certificates.
+type CertificateReload struct {
+	Enabled        bool          `config:"enabled" yaml:"enabled,omitempty"`
+	ReloadInterval time.Duration `config:"reload_interval" yaml:"reload_interval,omitempty"`
+}
+
 // ServerConfig defines the user configurable tls options for any TCP based service.
 type ServerConfig struct {
-	Enabled          *bool               `config:"enabled" yaml:"enabled,omitempty"`
-	VerificationMode TLSVerificationMode `config:"verification_mode" yaml:"verification_mode,omitempty"` // one of 'none', 'full', 'strict', 'certificate'
-	Versions         []TLSVersion        `config:"supported_protocols" yaml:"supported_protocols,omitempty"`
-	CipherSuites     []CipherSuite       `config:"cipher_suites" yaml:"cipher_suites,omitempty"`
-	CAs              []string            `config:"certificate_authorities" yaml:"certificate_authorities,omitempty"`
-	Certificate      CertificateConfig   `config:",inline" yaml:",inline"`
-	CurveTypes       []TLSCurveType      `config:"curve_types" yaml:"curve_types,omitempty"`
-	ClientAuth       *TLSClientAuth      `config:"client_authentication" yaml:"client_authentication,omitempty"` //`none`, `optional` or `required`
-	CASha256         []string            `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
+	Enabled           *bool               `config:"enabled" yaml:"enabled,omitempty"`
+	VerificationMode  TLSVerificationMode `config:"verification_mode" yaml:"verification_mode,omitempty"` // one of 'none', 'full', 'strict', 'certificate'
+	Versions          []TLSVersion        `config:"supported_protocols" yaml:"supported_protocols,omitempty"`
+	CipherSuites      []CipherSuite       `config:"cipher_suites" yaml:"cipher_suites,omitempty"`
+	CAs               []string            `config:"certificate_authorities" yaml:"certificate_authorities,omitempty"`
+	Certificate       CertificateConfig   `config:",inline" yaml:",inline"`
+	CurveTypes        []TLSCurveType      `config:"curve_types" yaml:"curve_types,omitempty"`
+	ClientAuth        *TLSClientAuth      `config:"client_authentication" yaml:"client_authentication,omitempty"` //`none`, `optional` or `required`
+	CASha256          []string            `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
+	CertificateReload CertificateReload   `config:"certificate_reload" yaml:"certificate_reload,omitempty"`
 }
 
 // LoadTLSServerConfig tranforms a ServerConfig into a `tls.Config` to be used directly with golang


### PR DESCRIPTION
## What does this PR do?

Adds a `CertificateReload` configuration struct to `tlscommon.ServerConfig` so that any component using `tlscommon` gets certificate hot-reload configuration support out of the box — no wrapper types needed.

The `CertificateReload` struct has two fields:
- `Enabled` (`certificate_reload.enabled`) — `*bool`, enabled by default (`nil` = enabled, matching the OTel Collector pattern where reload is always on). Only explicitly setting `false` disables it.
- `ReloadInterval` (`certificate_reload.reload_interval`) — how often to re-read cert/key files from disk, used with `CertReloader` (added in a prior commit)

Also provides:
- `DefaultCertificateReload()` — constructor returning a `CertificateReload` with sensible defaults (enabled, 5s reload interval)
- `IsEnabled()` — helper that returns `true` unless explicitly disabled

## Why is it important?

The `CertReloader` type was recently added to `tlscommon` but consumers (e.g. Fleet Server) had to define their own wrapper around `ServerConfig` to hold the reload configuration. Moving the config into `ServerConfig` directly eliminates that boilerplate and makes it available to all `tlscommon` users. See https://github.com/elastic/fleet-server/pull/6838#discussion_r3104205601.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Existing tests continue to pass — no behavioral change to `ServerConfig.Unpack` or `Validate`

## Related issues

- Relates https://github.com/elastic/fleet-server/issues/6433
- Relates https://github.com/elastic/fleet-server/pull/6838