### PR TITLE
feat: add MLKEM curve types

### DIFF
--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -72,11 +72,13 @@ var tlsCipherSuites = map[string]CipherSuite{
 	"TLS-CHACHA20-POLY1305-SHA256": CipherSuite(tls.TLS_CHACHA20_POLY1305_SHA256),
 }
 
-var supportedCipherSuites = make(map[CipherSuite]string, len(tlsCipherSuites))
-var tlsCipherSuitesInverse = make(map[CipherSuite]string, len(tlsCipherSuites))
-var tlsRenegotiationSupportTypesInverse = make(map[TLSRenegotiationSupport]string, len(tlsRenegotiationSupportTypes))
-var tlsVerificationModesInverse = make(map[TLSVerificationMode]string, len(tlsVerificationModes))
-var tlsClientAuthTypesInverse = make(map[TLSClientAuth]string, len(tlsClientAuthTypes))
+var (
+	supportedCipherSuites               = make(map[CipherSuite]string, len(tlsCipherSuites))
+	tlsCipherSuitesInverse              = make(map[CipherSuite]string, len(tlsCipherSuites))
+	tlsRenegotiationSupportTypesInverse = make(map[TLSRenegotiationSupport]string, len(tlsRenegotiationSupportTypes))
+	tlsVerificationModesInverse         = make(map[TLSVerificationMode]string, len(tlsVerificationModes))
+	tlsClientAuthTypesInverse           = make(map[TLSClientAuth]string, len(tlsClientAuthTypes))
+)
 
 // Init creates a inverse representation of the values mapping.
 func init() {
@@ -97,13 +99,16 @@ func init() {
 	}
 }
 
-var supportedCurveTypes = make(map[TLSCurveType]string, len(tlsCurveTypes))
-var tlsCurveTypes = map[string]TLSCurveType{
-	"P-256":  TLSCurveType(tls.CurveP256),
-	"P-384":  TLSCurveType(tls.CurveP384),
-	"P-521":  TLSCurveType(tls.CurveP521),
-	"X25519": TLSCurveType(tls.X25519),
-}
+var (
+	supportedCurveTypes = make(map[TLSCurveType]string, len(tlsCurveTypes))
+	tlsCurveTypes       = map[string]TLSCurveType{
+		"P-256":              TLSCurveType(tls.CurveP256),
+		"P-384":              TLSCurveType(tls.CurveP384),
+		"P-521":              TLSCurveType(tls.CurveP521),
+		"X25519":             TLSCurveType(tls.X25519),
+		"X25519MLKEM768":     TLSCurveType(tls.X25519MLKEM768),
+	}
+)
 
 var tlsRenegotiationSupportTypes = map[string]TLSRenegotiationSupport{
 	"never":  TLSRenegotiationSupport(tls.RenegotiateNever),

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -102,11 +102,11 @@ func init() {
 var (
 	supportedCurveTypes = make(map[TLSCurveType]string, len(tlsCurveTypes))
 	tlsCurveTypes       = map[string]TLSCurveType{
-		"P-256":              TLSCurveType(tls.CurveP256),
-		"P-384":              TLSCurveType(tls.CurveP384),
-		"P-521":              TLSCurveType(tls.CurveP521),
-		"X25519":             TLSCurveType(tls.X25519),
-		"X25519MLKEM768":     TLSCurveType(tls.X25519MLKEM768),
+		"P-256":          TLSCurveType(tls.CurveP256),
+		"P-384":          TLSCurveType(tls.CurveP384),
+		"P-521":          TLSCurveType(tls.CurveP521),
+		"X25519":         TLSCurveType(tls.X25519),
+		"X25519MLKEM768": TLSCurveType(tls.X25519MLKEM768),
 	}
 )
 

--- a/transport/tlscommon/types_126.go
+++ b/transport/tlscommon/types_126.go
@@ -1,0 +1,27 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build go1.26
+
+package tlscommon
+
+import "crypto/tls"
+
+func init() {
+	tlsCurveTypes["SecP256r1MLKEM768"] = TLSCurveType(tls.SecP256r1MLKEM768)
+	tlsCurveTypes["SecP384r1MLKEM1024"] = TLSCurveType(tls.SecP384r1MLKEM1024)
+}


### PR DESCRIPTION
## What does this PR do?

add support for setting hybrid post-quantum KEMs

## Why is it important?

there's no reason to restrict tls settings already supported by go and it's nice to have a post quantum curve.

formatting caused by go fmt, not sure why CI was not failing

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [ ] My code follows the style guidelines of this project
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

