### PR TITLE
Add retries to the Kibana client

### DIFF
--- a/kibana/client.go
+++ b/kibana/client.go
@@ -380,7 +380,7 @@ func addHeaders(out, in http.Header) {
 
 // Implements RoundTrip interface
 func (conn *Connection) RoundTrip(r *http.Request) (*http.Response, error) {
-	return conn.HTTP.Do(r)
+	return conn.HTTP.Do(r) //nolint:gosec // G704: SSRF is intentional; this is an HTTP client round-tripper that forwards caller-supplied requests
 }
 
 func (client *Client) readVersion() error {
@@ -392,14 +392,14 @@ func (client *Client) readVersion() error {
 		} `json:"version"`
 	}
 
-	code, result, err := client.Connection.Request("GET", statusAPI, nil, nil, nil)
+	code, result, err := client.Request("GET", statusAPI, nil, nil, nil)
 	if err != nil {
 		return fmt.Errorf("HTTP GET request to %s/api/status fails: %w (status=%d). Response: %s",
-			client.Connection.URL, err, code, truncateString(result))
+			client.URL, err, code, truncateString(result))
 	}
 	if code >= 400 {
 		return fmt.Errorf("HTTP GET request to %s/api/status fails: status=%d. Response: %s",
-			client.Connection.URL, code, truncateString(result))
+			client.URL, code, truncateString(result))
 	}
 
 	var versionString string
@@ -408,7 +408,7 @@ func (client *Client) readVersion() error {
 	err = json.Unmarshal(result, &kibanaVersion)
 	if err != nil {
 		return fmt.Errorf("fail to unmarshal the response from GET %s/api/status. Response: %s. Kibana status api returns: %w",
-			client.Connection.URL, truncateString(result), err)
+			client.URL, truncateString(result), err)
 	}
 
 	versionString = kibanaVersion.Version.Number
@@ -447,7 +447,7 @@ func (client *Client) KibanaIsServerless() (bool, error) {
 		params.Add("Authorization", v)
 	}
 
-	ret, resp, err := client.Connection.Request("GET", "/api/status", nil, params, nil)
+	ret, resp, err := client.Request("GET", "/api/status", nil, params, nil)
 	if err != nil {
 		return false, fmt.Errorf("error in HTTP request: %w", err)
 	}
@@ -495,7 +495,7 @@ func (client *Client) ImportMultiPartFormFile(url string, params url.Values, fil
 	if serverless, _ := client.KibanaIsServerless(); serverless {
 		sendHeaders.Add("x-elastic-internal-origin", "elastic-agent-libs")
 	}
-	statusCode, response, err := client.Connection.Request("POST", url, params, sendHeaders, buf)
+	statusCode, response, err := client.Request("POST", url, params, sendHeaders, buf)
 	if err != nil {
 		return fmt.Errorf("returned %d to import file: %w. Response: %s", statusCode, err, response)
 	}
@@ -522,5 +522,5 @@ func truncateString(b []byte) string {
 		runes = append(runes[:maxLength], []rune("... (truncated)")...)
 	}
 
-	return strings.Replace(string(runes), "\n", " ", -1)
+	return strings.ReplaceAll(string(runes), "\n", " ")
 }

--- a/kibana/client.go
+++ b/kibana/client.go
@@ -32,6 +32,7 @@ import (
 	"net/url"
 	"path"
 	"strings"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/config"
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -52,6 +53,7 @@ type Connection struct {
 
 	HTTP    *http.Client
 	Version version.V
+	Retry   RetryConfig
 }
 
 type Client struct {
@@ -203,6 +205,7 @@ func NewClientWithConfigDefault(config *ClientConfig, defaultPort int, binaryNam
 			ServiceToken: config.ServiceToken,
 			Headers:      headers,
 			HTTP:         rt,
+			Retry:        config.Retry,
 		},
 		log: log,
 	}
@@ -252,35 +255,119 @@ func (conn *Connection) SendWithContext(ctx context.Context, method, extraPath s
 
 	reqURL := addToURL(conn.URL, extraPath, params)
 
-	req, err := http.NewRequestWithContext(ctx, method, reqURL, body)
-	if err != nil {
-		return nil, fmt.Errorf("fail to create the HTTP %s request: %w", method, err)
+	maxRetries := conn.Retry.MaxRetries
+
+	// Buffer the body into a bytes.Buffer and expose it via a getBody closure so
+	// each retry attempt gets an independent reader at offset 0, mirroring the
+	// approach used in elastic-transport-go.
+	var getBody func() io.ReadCloser
+	if body != nil && maxRetries > 0 {
+		var buf bytes.Buffer
+		if _, err := buf.ReadFrom(body); err != nil {
+			return nil, fmt.Errorf("fail to read request body: %w", err)
+		}
+		getBody = func() io.ReadCloser {
+			r := buf // value copy gives an independent reader at offset 0
+			return io.NopCloser(&r)
+		}
 	}
 
-	if conn.Username != "" || conn.Password != "" {
-		req.SetBasicAuth(conn.Username, conn.Password)
-	}
-	if conn.APIKey != "" {
-		v := "ApiKey " + base64.StdEncoding.EncodeToString([]byte(conn.APIKey))
-		req.Header.Set("Authorization", v)
-	}
-	if conn.ServiceToken != "" {
-		v := "Bearer " + conn.ServiceToken
-		req.Header.Set("Authorization", v)
+	var (
+		res *http.Response
+		err error
+	)
+
+	for attempt := range maxRetries + 1 {
+		var (
+			shouldRetry     bool
+			shouldCloseBody bool
+		)
+
+		var reqBody io.Reader
+		if getBody != nil {
+			reqBody = getBody()
+		} else {
+			reqBody = body
+		}
+
+		var req *http.Request
+		req, err = http.NewRequestWithContext(ctx, method, reqURL, reqBody)
+		if err != nil {
+			return nil, fmt.Errorf("fail to create the HTTP %s request: %w", method, err)
+		}
+
+		if conn.Username != "" || conn.Password != "" {
+			req.SetBasicAuth(conn.Username, conn.Password)
+		}
+		if conn.APIKey != "" {
+			v := "ApiKey " + base64.StdEncoding.EncodeToString([]byte(conn.APIKey))
+			req.Header.Set("Authorization", v)
+		}
+		if conn.ServiceToken != "" {
+			v := "Bearer " + conn.ServiceToken
+			req.Header.Set("Authorization", v)
+		}
+
+		addHeaders(req.Header, conn.Headers)
+		addHeaders(req.Header, headers)
+
+		contentType := req.Header.Get("Content-Type")
+		contentType, _, _ = mime.ParseMediaType(contentType)
+		if contentType != "multipart/form-data" && contentType != "application/ndjson" {
+			req.Header.Set("Content-Type", "application/json")
+		}
+		req.Header.Set("Accept", "application/json")
+		req.Header.Set("kbn-xsrf", "1")
+
+		res, err = conn.RoundTrip(req)
+
+		if err != nil {
+			if conn.Retry.RetryOnError == nil || conn.Retry.RetryOnError(req, err) {
+				shouldRetry = true
+			}
+		}
+
+		// Retry on configured response statuses.
+		if res != nil {
+			for _, code := range conn.Retry.RetryOnStatus {
+				if res.StatusCode == code {
+					shouldRetry = true
+					shouldCloseBody = true
+				}
+			}
+		}
+
+		if !shouldRetry {
+			break
+		}
+
+		// Drain and close the body only when there are more attempts remaining,
+		// so the final response is still readable by the caller.
+		if shouldCloseBody && attempt < maxRetries {
+			if res.Body != nil {
+				_, _ = io.Copy(io.Discard, res.Body)
+				_ = res.Body.Close()
+			}
+		}
+
+		// Delay the retry if a backoff function is configured.
+		if conn.Retry.RetryBackoff != nil {
+			var cancelled bool
+			timer := time.NewTimer(conn.Retry.RetryBackoff(attempt + 1))
+			select {
+			case <-ctx.Done():
+				err = ctx.Err()
+				cancelled = true
+				timer.Stop()
+			case <-timer.C:
+			}
+			if cancelled {
+				break
+			}
+		}
 	}
 
-	addHeaders(req.Header, conn.Headers)
-	addHeaders(req.Header, headers)
-
-	contentType := req.Header.Get("Content-Type")
-	contentType, _, _ = mime.ParseMediaType(contentType)
-	if contentType != "multipart/form-data" && contentType != "application/ndjson" {
-		req.Header.Set("Content-Type", "application/json")
-	}
-	req.Header.Set("Accept", "application/json")
-	req.Header.Set("kbn-xsrf", "1")
-
-	return conn.RoundTrip(req)
+	return res, err
 }
 
 func addHeaders(out, in http.Header) {

--- a/kibana/client_config.go
+++ b/kibana/client_config.go
@@ -19,12 +19,33 @@ package kibana
 
 import (
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/elastic/elastic-agent-libs/transport/httpcommon"
 )
 
 const elasticAPIVersionHeaderKey = "Elastic-Api-Version"
 const elasticAPIDefaultVersion = "2023-10-31"
+
+// RetryConfig configures retry behaviour for requests made by the Kibana client.
+// The API mirrors the Elasticsearch Go client retry configuration.
+type RetryConfig struct {
+	// MaxRetries is the maximum number of retry attempts per request. Defaults to 3.
+	MaxRetries int `config:"max_retries" yaml:"max_retries,omitempty"`
+
+	// RetryOnStatus is the list of HTTP status codes that trigger a retry.
+	// Defaults to [502, 503, 504].
+	RetryOnStatus []int `config:"retry_on_status" yaml:"retry_on_status,omitempty"`
+
+	// RetryOnError is called for transport errors to decide whether to retry.
+	// When nil, all transport errors are retried. Return true to retry.
+	RetryOnError func(*http.Request, error) bool `config:"-" yaml:"-"`
+
+	// RetryBackoff returns the duration to wait before the given retry attempt (1-based).
+	// When nil, requests are retried immediately with no delay.
+	RetryBackoff func(attempt int) time.Duration `config:"-" yaml:"-"`
+}
 
 // ClientConfig to connect to Kibana
 type ClientConfig struct {
@@ -42,6 +63,7 @@ type ClientConfig struct {
 
 	IgnoreVersion bool
 
+	Retry     RetryConfig                      `config:"retry" yaml:"retry,omitempty"`
 	Transport httpcommon.HTTPTransportSettings `config:",inline" yaml:",inline"`
 }
 
@@ -58,6 +80,10 @@ func DefaultClientConfig() ClientConfig {
 		ServiceToken: "",
 		Transport:    httpcommon.DefaultHTTPTransportSettings(),
 		Headers:      map[string]string{elasticAPIVersionHeaderKey: elasticAPIDefaultVersion},
+		Retry: RetryConfig{
+			MaxRetries:    3,
+			RetryOnStatus: []int{502, 503, 504},
+		},
 	}
 }
 

--- a/kibana/client_test.go
+++ b/kibana/client_test.go
@@ -288,7 +288,10 @@ func TestRetryCustomRetryOnError(t *testing.T) {
 			},
 		},
 	}
-	_, err := conn.Send(http.MethodGet, "", nil, nil, nil)
+	resp, err := conn.Send(http.MethodGet, "", nil, nil, nil)
+	if resp != nil {
+		resp.Body.Close()
+	}
 	require.Error(t, err)
 	assert.True(t, retryOnErrorCalled)
 }

--- a/kibana/client_test.go
+++ b/kibana/client_test.go
@@ -19,10 +19,14 @@ package kibana
 
 import (
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strings"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -185,6 +189,171 @@ headers:
 	assert.Equal(t, []string{"application/json"}, requests[1].Header.Values("Accept"))
 	assert.Equal(t, []string{"1"}, requests[1].Header.Values("kbn-xsrf"))
 
+}
+
+func TestRetryOnStatus(t *testing.T) {
+	var requestCount atomic.Int32
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if n < 3 {
+			w.WriteHeader(http.StatusBadGateway) // 502 — triggers retry
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer kibanaTS.Close()
+
+	conn := Connection{
+		URL:  kibanaTS.URL,
+		HTTP: http.DefaultClient,
+		Retry: RetryConfig{
+			MaxRetries:    3,
+			RetryOnStatus: []int{502, 503, 504},
+		},
+	}
+	code, _, err := conn.Request(http.MethodGet, "", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, int32(3), requestCount.Load())
+}
+
+func TestRetryExhausted(t *testing.T) {
+	var requestCount atomic.Int32
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable) // 503 — always retried
+		_, _ = w.Write([]byte(`{"message":"unavailable"}`))
+	}))
+	defer kibanaTS.Close()
+
+	conn := Connection{
+		URL:  kibanaTS.URL,
+		HTTP: http.DefaultClient,
+		Retry: RetryConfig{
+			MaxRetries:    2,
+			RetryOnStatus: []int{503},
+		},
+	}
+	// After MaxRetries exhausted, the last response is returned rather than an error.
+	code, _, _ := conn.Request(http.MethodGet, "", nil, nil, nil)
+	assert.Equal(t, http.StatusServiceUnavailable, code)
+	assert.Equal(t, int32(3), requestCount.Load()) // 1 initial + 2 retries
+}
+
+func TestRetryDisabled(t *testing.T) {
+	var requestCount atomic.Int32
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestCount.Add(1)
+		w.WriteHeader(http.StatusBadGateway)
+		_, _ = w.Write([]byte(`{"message":"bad gateway"}`))
+	}))
+	defer kibanaTS.Close()
+
+	conn := Connection{
+		URL:  kibanaTS.URL,
+		HTTP: http.DefaultClient,
+		Retry: RetryConfig{
+			MaxRetries:    0,
+			RetryOnStatus: []int{502},
+		},
+	}
+	_, _, _ = conn.Request(http.MethodGet, "", nil, nil, nil)
+	assert.Equal(t, int32(1), requestCount.Load())
+}
+
+func TestRetryCustomRetryOnError(t *testing.T) {
+	retryOnErrorCalled := false
+	// A server that immediately closes connections forces a transport error.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Hijack and close to simulate a connection reset.
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			w.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		conn, _, _ := hj.Hijack()
+		conn.Close()
+	}))
+	defer ts.Close()
+
+	conn := Connection{
+		URL:  ts.URL,
+		HTTP: http.DefaultClient,
+		Retry: RetryConfig{
+			MaxRetries: 1,
+			RetryOnError: func(req *http.Request, err error) bool {
+				retryOnErrorCalled = true
+				return false // don't retry
+			},
+		},
+	}
+	_, err := conn.Send(http.MethodGet, "", nil, nil, nil)
+	require.Error(t, err)
+	assert.True(t, retryOnErrorCalled)
+}
+
+func TestRetryBackoff(t *testing.T) {
+	var requestCount atomic.Int32
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		if n < 2 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer kibanaTS.Close()
+
+	backoffCalled := false
+	conn := Connection{
+		URL:  kibanaTS.URL,
+		HTTP: http.DefaultClient,
+		Retry: RetryConfig{
+			MaxRetries:    2,
+			RetryOnStatus: []int{502},
+			RetryBackoff: func(attempt int) time.Duration {
+				backoffCalled = true
+				assert.Equal(t, 1, attempt)
+				return 0 // no actual sleep so the test stays fast
+			},
+		},
+	}
+	code, _, err := conn.Request(http.MethodGet, "", nil, nil, nil)
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.True(t, backoffCalled)
+}
+
+func TestRetryWithBody(t *testing.T) {
+	const payload = `{"hello":"world"}`
+	var requestCount atomic.Int32
+	kibanaTS := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := requestCount.Add(1)
+		body, _ := io.ReadAll(r.Body)
+		assert.Equal(t, payload, string(body), "body must be identical on every attempt")
+		if n < 2 {
+			w.WriteHeader(http.StatusBadGateway)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{}`))
+	}))
+	defer kibanaTS.Close()
+
+	conn := Connection{
+		URL:  kibanaTS.URL,
+		HTTP: http.DefaultClient,
+		Retry: RetryConfig{
+			MaxRetries:    2,
+			RetryOnStatus: []int{502},
+		},
+	}
+	code, _, err := conn.Request(http.MethodPost, "", nil, nil, strings.NewReader(payload))
+	require.NoError(t, err)
+	assert.Equal(t, http.StatusOK, code)
+	assert.Equal(t, int32(2), requestCount.Load())
 }
 
 func TestNewKibanaClientWithMultipartData(t *testing.T) {


### PR DESCRIPTION
## What does this PR do?

Adds retries to the Kibana client. 

The configuration is identical to what elasticsearch-go does: https://www.elastic.co/docs/reference/elasticsearch/clients/go/configuration#_config_retry, with the exception that disabling retries can be done by just setting `max_retries` to 0. 

The implementation is very similar to https://github.com/elastic/elastic-transport-go/blob/63cfa05e956c82203e86043bbf06eeab8f0a647f/elastictransport/elastictransport.go#L354.

## Why is it important?

Retries are useful to have. In particular, we use this client in elastic-agent integration tests, and have recently been having trouble with ESS Kibana returning 503s.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works


