### PR TITLE
Accept additional comment in UserAgentWithBeatTelemetry

### DIFF
--- a/useragent/useragent.go
+++ b/useragent/useragent.go
@@ -83,8 +83,8 @@ func UserAgent(binaryNameCapitalized string, version, commit, buildTime string, 
 		buildTime,
 	}
 	for _, val := range additionalComments {
-		if val != "" {
-			uaValues = append(uaValues, val)
+		if trimmed := strings.TrimSpace(val); len(trimmed) > 0 {
+			uaValues = append(uaValues, trimmed)
 		}
 	}
 	builder.WriteByte('(')
@@ -99,6 +99,7 @@ func UserAgentWithBeatTelemetry(
 	mode AgentManagementMode,
 	unprivileged AgentUnprivilegedMode,
 	isFIPSDistribution bool,
+	additionalComments ...string,
 ) string {
 	var builder strings.Builder
 	builder.WriteString("Elastic-" + binaryNameCapitalized + "/" + version + " ")
@@ -114,6 +115,11 @@ func UserAgentWithBeatTelemetry(
 	}
 	if isFIPSDistribution {
 		uaValues = append(uaValues, "FIPS")
+	}
+	for _, val := range additionalComments {
+		if trimmed := strings.TrimSpace(val); len(trimmed) > 0 {
+			uaValues = append(uaValues, trimmed)
+		}
 	}
 
 	builder.WriteByte('(')

--- a/useragent/useragent_test.go
+++ b/useragent/useragent_test.go
@@ -48,4 +48,10 @@ func TestUserAgentWithBeatTelemetry(t *testing.T) {
 
 	// Require deliberate update in case we want to extend the User Agent later
 	assert.LessOrEqual(t, len(ua2), 100, "User agent string should be less than 100 characters")
+
+	ua3 := UserAgentWithBeatTelemetry("FakeBeat", v, mode, unprivileged, isFIPSDistribution, "agentless")
+	assert.Regexp(t, regexp.MustCompile(`; Managed; Unprivileged; FIPS; agentless\)$`), ua3)
+
+	ua4 := UserAgentWithBeatTelemetry("FakeBeat", v, mode, unprivileged, isFIPSDistribution, "agentless", " test ", "   ", "\r\n\t")
+	assert.Regexp(t, regexp.MustCompile(`; Managed; Unprivileged; FIPS; agentless; test\)$`), ua4)
 }


### PR DESCRIPTION
This pull request enhances the flexibility and robustness of the `UserAgentWithBeatTelemetry` function in the `useragent` package by allowing additional comments to be appended to the user agent string, while ensuring input is sanitized. It also updates test coverage to validate the new behavior.

This is important for distinguishing traffic coming from agentless. 

**User agent string construction improvements:**

* Modified `UserAgentWithBeatTelemetry` in `useragent/useragent.go` to accept a variadic `additionalComments` parameter, enabling callers to append custom comments to the user agent string. Only non-empty, trimmed comments are included. 
* Improved input handling in both `UserAgent` and `UserAgentWithBeatTelemetry` by trimming whitespace from additional comments and excluding empty entries from the user agent string. 

**Test enhancements:**

* Added new test cases in `useragent/useragent_test.go` to verify that additional comments are correctly appended and that whitespace-only or empty comments are ignored when constructing the user agent string.

