### PR TITLE
feat: add fleetapi contract package for shared Fleet Server types

### DIFF
--- a/fleetapi/ack.go
+++ b/fleetapi/ack.go
@@ -1,0 +1,56 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+import "encoding/json"
+
+// AckEvent is an event sent in an ACK request to Fleet Server.
+type AckEvent struct {
+	EventType       string                 `json:"type"`
+	SubType         string                 `json:"subtype"`
+	Timestamp       string                 `json:"timestamp"`
+	ActionID        string                 `json:"action_id"`
+	AgentID         string                 `json:"agent_id"`
+	Message         string                 `json:"message,omitempty"`
+	Payload         json.RawMessage        `json:"payload,omitempty"`
+	Data            json.RawMessage        `json:"data,omitempty"`
+	ActionInputType string                 `json:"action_input_type,omitempty"`
+	ActionData      json.RawMessage        `json:"action_data,omitempty"`
+	ActionResponse  map[string]interface{} `json:"action_response,omitempty"`
+	StartedAt       string                 `json:"started_at,omitempty"`
+	CompletedAt     string                 `json:"completed_at,omitempty"`
+	Error           string                 `json:"error,omitempty"`
+}
+
+// AckRequest is the payload sent to Fleet Server's ack endpoint.
+type AckRequest struct {
+	Events []AckEvent `json:"events"`
+}
+
+// AckResponseItem is the status of an individual ack event.
+type AckResponseItem struct {
+	Status  int    `json:"status"`
+	Message string `json:"message,omitempty"`
+}
+
+// AckResponse is the response from Fleet Server's ack endpoint.
+type AckResponse struct {
+	Action string            `json:"action"`
+	Errors bool              `json:"errors,omitempty"`
+	Items  []AckResponseItem `json:"items,omitempty"`
+}

--- a/fleetapi/actions.go
+++ b/fleetapi/actions.go
@@ -1,0 +1,58 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+const (
+	ActionTypeUnknown              = "UNKNOWN"
+	ActionTypeUpgrade              = "UPGRADE"
+	ActionTypeUnenroll             = "UNENROLL"
+	ActionTypePolicyChange         = "POLICY_CHANGE"
+	ActionTypePolicyReassign       = "POLICY_REASSIGN"
+	ActionTypeSettings             = "SETTINGS"
+	ActionTypeInputAction          = "INPUT_ACTION"
+	ActionTypeCancel               = "CANCEL"
+	ActionTypeDiagnostics          = "REQUEST_DIAGNOSTICS"
+	ActionTypeMigrate              = "MIGRATE"
+	ActionTypePrivilegeLevelChange = "PRIVILEGE_LEVEL_CHANGE"
+)
+
+// Action represents the base fields of a Fleet action returned in a checkin
+// response. Both the full Elastic Agent and lightweight emulators (e.g. Horde
+// drones) receive actions in this shape; each consumer interprets the Data
+// payload according to its own needs.
+type Action struct {
+	ID          string          `json:"id"`
+	Type        string          `json:"type"`
+	InputType   string          `json:"input_type,omitempty"`
+	Data        json.RawMessage `json:"data,omitempty"`
+	CreatedAt   time.Time       `json:"created_at,omitempty"`
+	StartTime   *time.Time      `json:"start_time,omitempty"`
+	Expiration  *time.Time      `json:"expiration,omitempty"`
+	Traceparent string          `json:"traceparent,omitempty"`
+}
+
+// Signed contains the signed data and signature for action verification.
+type Signed struct {
+	Data      string `json:"data"`
+	Signature string `json:"signature"`
+}

--- a/fleetapi/checkin.go
+++ b/fleetapi/checkin.go
@@ -1,0 +1,77 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// CheckinRequest is the payload sent to Fleet Server's checkin endpoint.
+//
+// Fields that carry consumer-specific types (e.g. local metadata, upgrade
+// details, component status) use json.RawMessage so that both the full
+// Elastic Agent and lightweight emulators can populate them without
+// sharing internal type definitions.
+type CheckinRequest struct {
+	Status            string            `json:"status"`
+	AckToken          string            `json:"ack_token,omitempty"`
+	Metadata          json.RawMessage   `json:"local_metadata,omitempty"`
+	Message           string            `json:"message"`
+	Components        []CheckinComponent `json:"components"`
+	UpgradeDetails    json.RawMessage   `json:"upgrade_details,omitempty"`
+	AgentPolicyID     string            `json:"agent_policy_id,omitempty"`
+	PolicyRevisionIDX int64             `json:"policy_revision_idx,omitempty"`
+	Upgrade           CheckinUpgrade    `json:"upgrade,omitempty"`
+}
+
+// CheckinComponent provides information about a component during checkin.
+type CheckinComponent struct {
+	ID      string        `json:"id"`
+	Type    string        `json:"type"`
+	Status  string        `json:"status"`
+	Message string        `json:"message"`
+	Units   []CheckinUnit `json:"units,omitempty"`
+}
+
+// CheckinUnit provides information about a unit within a component during checkin.
+type CheckinUnit struct {
+	ID      string                 `json:"id"`
+	Type    string                 `json:"type"`
+	Status  string                 `json:"status"`
+	Message string                 `json:"message"`
+	Payload map[string]interface{} `json:"payload,omitempty"`
+}
+
+// CheckinRollback describes an available rollback version.
+type CheckinRollback struct {
+	Version    string    `json:"version"`
+	ValidUntil time.Time `json:"valid_until"`
+}
+
+// CheckinUpgrade carries rollback information in the checkin request.
+type CheckinUpgrade struct {
+	Rollbacks []CheckinRollback `json:"rollbacks,omitempty"`
+}
+
+// CheckinResponse is the response from Fleet Server's checkin endpoint.
+type CheckinResponse struct {
+	AckToken     string          `json:"ack_token"`
+	Actions      json.RawMessage `json:"actions"`
+	FleetWarning string          `json:"-"`
+}

--- a/fleetapi/enroll.go
+++ b/fleetapi/enroll.go
@@ -1,0 +1,67 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// EnrollType is the type of enrollment to do with the elastic-agent.
+type EnrollType string
+
+const (
+	// PermanentEnroll is default enrollment type.
+	PermanentEnroll EnrollType = "PERMANENT"
+)
+
+// EnrollRequest is the payload sent to Fleet Server's enroll endpoint.
+type EnrollRequest struct {
+	EnrollAPIKey string     `json:"-"`
+	Type         EnrollType `json:"type"`
+	ID           string     `json:"id,omitempty"`
+	ReplaceToken string     `json:"replace_token,omitempty"`
+	Metadata     EnrollMeta `json:"metadata"`
+}
+
+// EnrollMeta carries metadata sent during enrollment.
+type EnrollMeta struct {
+	Local        json.RawMessage        `json:"local"`
+	UserProvided map[string]interface{} `json:"user_provided"`
+	Tags         []string               `json:"tags,omitempty"`
+}
+
+// EnrollResponse is the response from Fleet Server's enroll endpoint.
+type EnrollResponse struct {
+	Action string             `json:"action"`
+	Item   EnrollItemResponse `json:"item"`
+}
+
+// EnrollItemResponse contains the enrolled agent details.
+type EnrollItemResponse struct {
+	ID                   string                 `json:"id"`
+	Active               bool                   `json:"active"`
+	PolicyID             string                 `json:"policy_id"`
+	Type                 EnrollType             `json:"type"`
+	EnrolledAt           time.Time              `json:"enrolled_at"`
+	UserProvidedMetadata map[string]interface{} `json:"user_provided_metadata"`
+	LocalMetadata        map[string]interface{} `json:"local_metadata"`
+	Actions              []interface{}          `json:"actions"`
+	AccessAPIKey         string                 `json:"access_api_key"`
+	Tags                 []string               `json:"tags"`
+}

--- a/fleetapi/errors.go
+++ b/fleetapi/errors.go
@@ -1,0 +1,39 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+import (
+	"errors"
+	"net/http"
+)
+
+var (
+	ErrTooManyRequests    = errors.New("too many requests received (429)")
+	ErrConnRefused        = errors.New("connection refused")
+	ErrTemporaryServerErr = errors.New("temporary server error, please retry later")
+	ErrInvalidToken       = errors.New("invalid enrollment token")
+	ErrInvalidAPIKey      = errors.New("invalid api key to authenticate with fleet")
+)
+
+// TemporaryServerErrorCodes maps HTTP status codes that indicate a transient
+// Fleet Server failure. Clients should retry the request with backoff.
+var TemporaryServerErrorCodes = map[int]string{
+	http.StatusBadGateway:         "BadGateway",
+	http.StatusServiceUnavailable: "ServiceUnavailable",
+	http.StatusGatewayTimeout:     "GatewayTimeout",
+}

--- a/fleetapi/fleetapi_test.go
+++ b/fleetapi/fleetapi_test.go
@@ -1,0 +1,124 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestActionRoundTrip(t *testing.T) {
+	now := time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)
+	a := Action{
+		ID:        "action-1",
+		Type:      ActionTypeUpgrade,
+		Data:      json.RawMessage(`{"version":"9.0.0"}`),
+		CreatedAt: now,
+	}
+
+	b, err := json.Marshal(a)
+	require.NoError(t, err)
+
+	var decoded Action
+	require.NoError(t, json.Unmarshal(b, &decoded))
+	assert.Equal(t, a.ID, decoded.ID)
+	assert.Equal(t, a.Type, decoded.Type)
+	assert.JSONEq(t, `{"version":"9.0.0"}`, string(decoded.Data))
+}
+
+func TestCheckinRequestJSON(t *testing.T) {
+	req := CheckinRequest{
+		Status:        "online",
+		AckToken:      "tok-1",
+		Message:       "Running",
+		AgentPolicyID: "policy-1",
+	}
+
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+
+	assert.Equal(t, "online", m["status"])
+	assert.Equal(t, "tok-1", m["ack_token"])
+	assert.Equal(t, "Running", m["message"])
+	assert.Equal(t, "policy-1", m["agent_policy_id"])
+}
+
+func TestCheckinResponseJSON(t *testing.T) {
+	raw := `{
+		"ack_token": "tok-2",
+		"actions": [{"id":"a1","type":"POLICY_CHANGE"}]
+	}`
+	var resp CheckinResponse
+	require.NoError(t, json.Unmarshal([]byte(raw), &resp))
+	assert.Equal(t, "tok-2", resp.AckToken)
+	assert.NotEmpty(t, resp.Actions)
+	assert.Empty(t, resp.FleetWarning, "FleetWarning should not be populated from JSON")
+}
+
+func TestAckEventJSON(t *testing.T) {
+	evt := AckEvent{
+		EventType: "ACTION_RESULT",
+		SubType:   "ACKNOWLEDGED",
+		Timestamp: "2025-01-01T00:00:00Z",
+		ActionID:  "action-1",
+		AgentID:   "agent-1",
+	}
+
+	b, err := json.Marshal(evt)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, "ACTION_RESULT", m["type"])
+	assert.Equal(t, "ACKNOWLEDGED", m["subtype"])
+}
+
+func TestEnrollRequestJSON(t *testing.T) {
+	req := EnrollRequest{
+		EnrollAPIKey: "secret-key",
+		Type:         PermanentEnroll,
+		Metadata: EnrollMeta{
+			Local: json.RawMessage(`{"os":"linux"}`),
+		},
+	}
+
+	b, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var m map[string]interface{}
+	require.NoError(t, json.Unmarshal(b, &m))
+	assert.Equal(t, "PERMANENT", m["type"])
+	assert.Nil(t, m["enroll_api_key"], "EnrollAPIKey must not appear in JSON")
+}
+
+func TestSentinelErrors(t *testing.T) {
+	assert.True(t, errors.Is(ErrTooManyRequests, ErrTooManyRequests))
+	assert.True(t, errors.Is(ErrConnRefused, ErrConnRefused))
+	assert.True(t, errors.Is(ErrTemporaryServerErr, ErrTemporaryServerErr))
+	assert.True(t, errors.Is(ErrInvalidToken, ErrInvalidToken))
+	assert.True(t, errors.Is(ErrInvalidAPIKey, ErrInvalidAPIKey))
+	assert.False(t, errors.Is(ErrInvalidToken, ErrInvalidAPIKey))
+}

--- a/fleetapi/version.go
+++ b/fleetapi/version.go
@@ -1,0 +1,26 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package fleetapi
+
+// DefaultFleetAPIVersion is the value for the Elastic-Api-Version header
+// sent on every Fleet Server request.
+const DefaultFleetAPIVersion = "2023-06-01"
+
+// ElasticAPIVersionHeaderKey is the HTTP header key used to communicate the
+// API version to Fleet Server.
+const ElasticAPIVersionHeaderKey = "Elastic-Api-Version"


### PR DESCRIPTION
## What does this PR do?

Add a new `fleetapi` package containing shared data contract types for communicating with Fleet Server. The package provides the canonical type definitions for the Fleet Server API surface used by both Elastic Agent and lightweight emulators (e.g. Horde drones).

The package includes:
- **Action types** (`actions.go`): Action type constants (`UPGRADE`, `POLICY_CHANGE`, `MIGRATE`, etc.) and a base `Action` struct with `json.RawMessage` data for consumer-specific interpretation
- **Checkin types** (`checkin.go`): `CheckinRequest`, `CheckinResponse`, `CheckinComponent`, `CheckinUnit`, `CheckinRollback`, `CheckinUpgrade`
- **Ack types** (`ack.go`): `AckEvent`, `AckRequest`, `AckResponse`, `AckResponseItem`
- **Enrollment types** (`enroll.go`): `EnrollRequest`, `EnrollResponse`, `EnrollMeta`, `EnrollItemResponse`
- **Sentinel errors** (`errors.go`): `ErrTooManyRequests`, `ErrConnRefused`, `ErrTemporaryServerErr`, `ErrInvalidToken`, `ErrInvalidAPIKey`, plus `TemporaryServerErrorCodes` map
- **API version** (`version.go`): `DefaultFleetAPIVersion` and `ElasticAPIVersionHeaderKey` constants

Types that carry consumer-specific data (e.g. local metadata, upgrade details) use `json.RawMessage` so both the full Agent and lightweight emulators can populate them without sharing internal type definitions.

## Why is it important?

Today both Elastic Agent (`internal/pkg/fleetapi/`) and Horde (`internal/pkg/drone/common/`) independently define their own Fleet Server contract types. Over time these definitions have drifted:

- Horde is missing 5 of 11 action type constants (`UNENROLL`, `POLICY_REASSIGN`, `SETTINGS`, `PRIVILEGE_LEVEL_CHANGE`, `UNKNOWN`)
- Horde doesn't send the `Elastic-Api-Version` header
- Sentinel errors for enrollment failures exist only in Agent; Horde treats all errors identically
- Ack event field sets differ between the two codebases
- Checkin request/response structs have diverged (missing `components`, `upgrade` rollback info, `Warning` header in Horde)

By placing the canonical types in `elastic-agent-libs`, both repositories can import them and stay aligned as the Fleet Server API evolves.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

- [x] Types use only stdlib imports (encoding/json, errors, net/http, time) — no Agent-internal dependencies
- [x] All tests pass
- [x] JSON serialization matches existing Fleet Server API contract

## Related issues

- Follow-up consumer PRs for elastic-agent and horde will reference this PR