### PR TITLE
Add redact.Redact method

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -20,7 +20,6 @@ package redact
 import (
 	"fmt"
 	"io"
-	"maps"
 	"net/url"
 	"reflect"
 	"slices"
@@ -90,7 +89,7 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 		if keyString, ok := any(key).(string); ok && strings.ToLower(keyString) == "name" {
 			keyVal, ok := val.(string)
 			if ok && redactKey(keyVal, ro) {
-				for vk := range maps.Keys(obj) {
+				for vk := range obj {
 					if vs, ok := any(vk).(string); ok && strings.ToLower(vs) == "value" {
 						obj[vk] = REDACTED
 						break
@@ -136,6 +135,7 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 					if ro.markerPrefix != "" && strings.HasPrefix(keyString, ro.markerPrefix) {
 						markers = append(markers, keyString)
 						delete(obj, key)
+						continue
 					}
 				}
 			default:

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package redact
 
 import (

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -38,7 +38,7 @@ type redactOptions struct {
 	ignoreKeys   []string
 }
 
-// WithErrorOutput determines where any error messagess that are encountered are written to.
+// WithErrorOutput determines where any error messages that are encountered are written to.
 //
 // Defaults to io.Discard.
 func WithErrorOutput(w io.Writer) RedactOption {

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -1,0 +1,176 @@
+package redact
+
+import (
+	"fmt"
+	"io"
+	"maps"
+	"net/url"
+	"reflect"
+	"slices"
+	"strings"
+)
+
+// REDACTED is the value that replaces sensitive values.
+const REDACTED = "REDACTED"
+
+// RedactOption is an optional arg to control how the Redact method works.
+type RedactOption func(ro *redactOptions)
+
+type redactOptions struct {
+	errOut       io.Writer
+	markerPrefix string
+	ignoreKeys   []string
+}
+
+// WithErrorOutput determines where any error messagess that are encounterd are written to.
+//
+// Defaults to io.Discard.
+func WithErrorOutput(w io.Writer) RedactOption {
+	return func(ro *redactOptions) {
+		ro.errOut = w
+	}
+}
+
+// WithMarkerPrefix sets the redaction marker prefix string.
+func WithMarkerPrefix(s string) RedactOption {
+	return func(ro *redactOptions) {
+		ro.markerPrefix = s
+	}
+}
+
+// WithIgnoreKeys sets case-sensitive key values where redaction will be skipped.
+func WithIgnoreKeys(keys ...string) RedactOption {
+	return func(ro *redactOptions) {
+		ro.ignoreKeys = append(ro.ignoreKeys, keys...)
+	}
+}
+
+// Redact walks obj and replaces values of sensitive keys with a redacted
+// placeholder. It mutates obj in place; nested maps and slice elements are
+// modified directly and no copy is returned.
+func Redact(obj map[any]any, opts ...RedactOption) {
+	ro := &redactOptions{
+		errOut:       io.Discard,
+		markerPrefix: "",
+		ignoreKeys:   []string{},
+	}
+	for _, opt := range opts {
+		opt(ro)
+	}
+	redactMap(obj, ro)
+}
+
+func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
+	if obj == nil {
+		return
+	}
+
+	markers := make([]string, 0)
+	for key, val := range obj {
+		// detect if the obj has entries of the form:
+		// - name: Authorization
+		//   value: Bearer SecretValue
+		if keyString, ok := any(key).(string); ok && strings.ToLower(keyString) == "name" {
+			keyVal, ok := any(val).(string)
+			if ok && redactKey(keyVal, ro) {
+				for vk := range maps.Keys(obj) {
+					if vs, ok := any(vk).(string); ok && strings.ToLower(vs) == "value" {
+						obj[vk] = REDACTED
+						break
+					}
+				}
+			}
+		}
+		if val != nil {
+			switch cast := val.(type) {
+			case map[string]any:
+				redactMap(cast, ro)
+			case map[any]any:
+				redactMap(cast, ro)
+			case map[int]any:
+				redactMap(cast, ro)
+			case []any:
+				// Recursively process each element in the slice so that we also walk
+				// through lists (e.g. inputs[4].streams[0]). This is required to
+				// reach redaction markers that are inside slice items.
+				for i, value := range cast {
+					switch m := value.(type) {
+					case map[string]any:
+						redactMap(m, ro)
+					case map[any]any:
+						redactMap(m, ro)
+					case map[int]any:
+						redactMap(m, ro)
+					case string:
+						if redactedValue, redact := redactURL(m); redact {
+							cast[i] = redactedValue
+						}
+					}
+				}
+			case string:
+				if keyString, ok := any(key).(string); ok && redactKey(keyString, ro) {
+					val = REDACTED
+				} else if redactedValue, redact := redactURL(cast); redact {
+					val = redactedValue
+				}
+			case bool: // redaction marker values are always going to be bool, process redaction markers in this case
+				if keyString, ok := any(key).(string); ok {
+					// Find siblings that have the redaction marker.
+					if ro.markerPrefix != "" && strings.HasPrefix(keyString, ro.markerPrefix) {
+						markers = append(markers, keyString)
+						delete(obj, key)
+					}
+				}
+			default:
+				// in cases where we got some weird kind of map we couldn't parse, print a warning
+				if reflect.TypeOf(val).Kind() == reflect.Map {
+					fmt.Fprintf(ro.errOut, "[WARNING]: file may be partly redacted, could not cast value %v of type %T", key, val)
+				}
+
+			}
+		}
+		obj[key] = val
+	}
+
+	for _, redactionMarker := range markers {
+		keyToRedact := strings.TrimPrefix(redactionMarker, ro.markerPrefix)
+		for rootKey := range obj {
+			if keyString, ok := any(rootKey).(string); ok {
+				if keyString == keyToRedact {
+					obj[rootKey] = REDACTED
+				}
+
+				if keyString == redactionMarker {
+					delete(obj, rootKey)
+				}
+			}
+		}
+	}
+}
+
+func redactKey(k string, ro *redactOptions) bool {
+	if slices.Contains(ro.ignoreKeys, k) {
+		return false
+	}
+
+	k = strings.ToLower(k)
+	return strings.Contains(k, "auth") ||
+		strings.Contains(k, "certificate") ||
+		strings.Contains(k, "passphrase") ||
+		strings.Contains(k, "password") ||
+		strings.Contains(k, "token") ||
+		strings.Contains(k, "key") ||
+		strings.Contains(k, "secret")
+}
+
+func redactURL(v string) (string, bool) {
+	u, err := url.Parse(v)
+
+	if err != nil || u.User == nil {
+		return v, false
+	}
+
+	u.User = url.UserPassword(REDACTED, REDACTED)
+
+	return u.String(), true
+}

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -39,7 +39,7 @@ type redactOptions struct {
 	ignoreKeys   []string
 }
 
-// WithErrorOutput determines where any error messagess that are encounterd are written to.
+// WithErrorOutput determines where any error messagess that are encountered are written to.
 //
 // Defaults to io.Discard.
 func WithErrorOutput(w io.Writer) RedactOption {
@@ -88,7 +88,7 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 		// - name: Authorization
 		//   value: Bearer SecretValue
 		if keyString, ok := any(key).(string); ok && strings.ToLower(keyString) == "name" {
-			keyVal, ok := any(val).(string)
+			keyVal, ok := val.(string)
 			if ok && redactKey(keyVal, ro) {
 				for vk := range maps.Keys(obj) {
 					if vs, ok := any(vk).(string); ok && strings.ToLower(vs) == "value" {

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -93,6 +93,7 @@ func TestRedact(t *testing.T) {
 			},
 		},
 		"URL credentials are redacted": {
+			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[any]any{
 				"url":       "https://user:pass@example.com/path",
 				"other_url": "https://example.com/path",
@@ -121,6 +122,7 @@ func TestRedact(t *testing.T) {
 			},
 		},
 		"sensitive key wins over URL redaction": {
+			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[any]any{
 				"secret_url": "https://user:pass@example.com",
 			},
@@ -274,16 +276,16 @@ func TestRedact(t *testing.T) {
 			input: map[any]any{
 				"inputs": []any{
 					map[string]any{
-						"type":                        "test_input",
-						"redactKey":                   "secretValue",
-						markerPrefix + "redactKey":    true,
+						"type":                     "test_input",
+						"redactKey":                "secretValue",
+						markerPrefix + "redactKey": true,
 					},
 				},
 				"outputs": map[string]any{
 					"default": map[string]any{
-						"type":                       "elasticsearch",
-						"api_key":                    "alreadyMatched",
-						"redactOtherKey":             "secretOutputValue",
+						"type":                          "elasticsearch",
+						"api_key":                       "alreadyMatched",
+						"redactOtherKey":                "secretOutputValue",
 						markerPrefix + "redactOtherKey": true,
 					},
 				},
@@ -317,9 +319,9 @@ func TestRedact(t *testing.T) {
 									"transforms": []any{
 										map[string]any{
 											"set": map[string]any{
-												"target":                  "header.Authorization",
-												"value":                   "SSWS this-should-be-redacted",
-												markerPrefix + "value":    true,
+												"target":               "header.Authorization",
+												"value":                "SSWS this-should-be-redacted",
+												markerPrefix + "value": true,
 											},
 										},
 										map[string]any{
@@ -401,10 +403,10 @@ func TestRedact(t *testing.T) {
 		},
 		"ignored keys and markers coexist": {
 			input: map[any]any{
-				"routekey":                 "should-not-redact",
-				"keepme":                   "value",
-				markerPrefix + "keepme":    true,
-				"api_key":                  "secret",
+				"routekey":              "should-not-redact",
+				"keepme":                "value",
+				markerPrefix + "keepme": true,
+				"api_key":               "secret",
 			},
 			opts: []RedactOption{
 				WithIgnoreKeys("routekey"),
@@ -447,6 +449,7 @@ func TestRedactURL(t *testing.T) {
 			expect:   "https://example.com/path",
 			redacted: false,
 		},
+		//nolint:gosec // this test is meant to redact sensitive values
 		"url with credentials": {
 			input:    "https://user:pass@example.com/path",
 			expect:   "https://" + redactedURL + "@example.com/path",

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1,3 +1,20 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
 package redact
 
 import (

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -499,9 +499,9 @@ func TestRedactURL(t *testing.T) {
 			expect:   "https://example.com/path",
 			redacted: false,
 		},
+		//nolint:gosec // this test is meant to redact sensitive values
 		{
-			name: "url with credentials",
-			//nolint:gosec // this test is meant to redact sensitive values
+			name:     "url with credentials",
 			input:    "https://user:pass@example.com/path",
 			expect:   "https://" + redactedURL + "@example.com/path",
 			redacted: true,

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -1,0 +1,485 @@
+package redact
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+const redactedURL = REDACTED + ":" + REDACTED
+
+func TestRedact(t *testing.T) {
+	const markerPrefix = "__mark_redact_"
+
+	tests := map[string]struct {
+		input  map[any]any
+		opts   []RedactOption
+		expect map[any]any
+	}{
+		"nil map": {
+			input:  nil,
+			expect: nil,
+		},
+		"empty map": {
+			input:  map[any]any{},
+			expect: map[any]any{},
+		},
+		"no redactions": {
+			input: map[any]any{
+				"type":      "elasticsearch",
+				"namespace": "default",
+				"count":     int64(5),
+			},
+			expect: map[any]any{
+				"type":      "elasticsearch",
+				"namespace": "default",
+				"count":     int64(5),
+			},
+		},
+		"sensitive keys are redacted": {
+			input: map[any]any{
+				"api_key":     "secret",
+				"password":    "secret",
+				"passphrase":  "secret",
+				"token":       "secret",
+				"certificate": "secret",
+				"secret":      "secret",
+				"X-App-Auth":  "secret",
+				"safe":        "value",
+			},
+			expect: map[any]any{
+				"api_key":     REDACTED,
+				"password":    REDACTED,
+				"passphrase":  REDACTED,
+				"token":       REDACTED,
+				"certificate": REDACTED,
+				"secret":      REDACTED,
+				"X-App-Auth":  REDACTED,
+				"safe":        "value",
+			},
+		},
+		"keys are matched case insensitively": {
+			input: map[any]any{
+				"API_KEY":     "secret",
+				"PassWord":    "secret",
+				"PASSPHRASE":  "secret",
+				"tOkEn":       "secret",
+				"Certificate": "secret",
+			},
+			expect: map[any]any{
+				"API_KEY":     REDACTED,
+				"PassWord":    REDACTED,
+				"PASSPHRASE":  REDACTED,
+				"tOkEn":       REDACTED,
+				"Certificate": REDACTED,
+			},
+		},
+		"URL credentials are redacted": {
+			input: map[any]any{
+				"url":       "https://user:pass@example.com/path",
+				"other_url": "https://example.com/path",
+				"plain":     "not a url",
+			},
+			expect: map[any]any{
+				"url":       "https://" + redactedURL + "@example.com/path",
+				"other_url": "https://example.com/path",
+				"plain":     "not a url",
+			},
+		},
+		"URL credentials in slice elements are redacted": {
+			input: map[any]any{
+				"urls": []any{
+					"https://user:pass@my-url1",
+					"https://user:pass@my-url2",
+					"https://my-url3",
+				},
+			},
+			expect: map[any]any{
+				"urls": []any{
+					"https://" + redactedURL + "@my-url1",
+					"https://" + redactedURL + "@my-url2",
+					"https://my-url3",
+				},
+			},
+		},
+		"sensitive key wins over URL redaction": {
+			input: map[any]any{
+				"secret_url": "https://user:pass@example.com",
+			},
+			expect: map[any]any{
+				"secret_url": REDACTED,
+			},
+		},
+		"nested map[string]any is redacted recursively": {
+			input: map[any]any{
+				"outputs": map[string]any{
+					"default": map[string]any{
+						"type":     "elasticsearch",
+						"api_key":  "secret",
+						"hosts":    []any{"https://user:pass@es:9200"},
+						"username": "user",
+					},
+				},
+			},
+			expect: map[any]any{
+				"outputs": map[string]any{
+					"default": map[string]any{
+						"type":     "elasticsearch",
+						"api_key":  REDACTED,
+						"hosts":    []any{"https://" + redactedURL + "@es:9200"},
+						"username": "user",
+					},
+				},
+			},
+		},
+		"nested map[any]any is redacted recursively": {
+			input: map[any]any{
+				"outputs": map[any]any{
+					"default": map[any]any{
+						"type":    "elasticsearch",
+						"api_key": "secret",
+					},
+				},
+			},
+			expect: map[any]any{
+				"outputs": map[any]any{
+					"default": map[any]any{
+						"type":    "elasticsearch",
+						"api_key": REDACTED,
+					},
+				},
+			},
+		},
+		"slice items that are maps are redacted recursively": {
+			input: map[any]any{
+				"inputs": []any{
+					map[string]any{
+						"type":    "test",
+						"api_key": "secret",
+					},
+					map[string]any{
+						"type":     "test",
+						"password": "secret",
+					},
+				},
+			},
+			expect: map[any]any{
+				"inputs": []any{
+					map[string]any{
+						"type":    "test",
+						"api_key": REDACTED,
+					},
+					map[string]any{
+						"type":     "test",
+						"password": REDACTED,
+					},
+				},
+			},
+		},
+		"deeply nested ssl key in inputs is redacted": {
+			input: map[any]any{
+				"inputs": []any{
+					map[string]any{
+						"ssl": map[string]any{
+							"certificate": "cert1",
+							"key":         "key1",
+						},
+						"nested": map[string]any{
+							"ssl": map[string]any{
+								"certificate": "cert2",
+								"key":         "key2",
+							},
+						},
+						"slice": []any{
+							map[string]any{
+								"ssl": map[string]any{
+									"certificate": "cert3",
+									"key":         "key3",
+								},
+							},
+						},
+					},
+				},
+			},
+			expect: map[any]any{
+				"inputs": []any{
+					map[string]any{
+						"ssl": map[string]any{
+							"certificate": REDACTED,
+							"key":         REDACTED,
+						},
+						"nested": map[string]any{
+							"ssl": map[string]any{
+								"certificate": REDACTED,
+								"key":         REDACTED,
+							},
+						},
+						"slice": []any{
+							map[string]any{
+								"ssl": map[string]any{
+									"certificate": REDACTED,
+									"key":         REDACTED,
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		"name/value entries are redacted when name indicates a secret": {
+			input: map[any]any{
+				"headers": []any{
+					map[string]any{
+						"name":  "Authorization",
+						"value": "Bearer secret-token",
+					},
+					map[string]any{
+						"name":  "X-Custom",
+						"value": "harmless",
+					},
+				},
+			},
+			expect: map[any]any{
+				"headers": []any{
+					map[string]any{
+						"name":  "Authorization",
+						"value": REDACTED,
+					},
+					map[string]any{
+						"name":  "X-Custom",
+						"value": "harmless",
+					},
+				},
+			},
+		},
+		"redaction markers are processed when prefix is configured": {
+			input: map[any]any{
+				"inputs": []any{
+					map[string]any{
+						"type":                        "test_input",
+						"redactKey":                   "secretValue",
+						markerPrefix + "redactKey":    true,
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{
+						"type":                       "elasticsearch",
+						"api_key":                    "alreadyMatched",
+						"redactOtherKey":             "secretOutputValue",
+						markerPrefix + "redactOtherKey": true,
+					},
+				},
+			},
+			opts: []RedactOption{WithMarkerPrefix(markerPrefix)},
+			expect: map[any]any{
+				"inputs": []any{
+					map[string]any{
+						"type":      "test_input",
+						"redactKey": REDACTED,
+					},
+				},
+				"outputs": map[string]any{
+					"default": map[string]any{
+						"type":           "elasticsearch",
+						"api_key":        REDACTED,
+						"redactOtherKey": REDACTED,
+					},
+				},
+			},
+		},
+		"redaction markers in nested slice items are processed": {
+			input: map[any]any{
+				"id": "test-policy",
+				"inputs": []any{
+					map[string]any{
+						"type": "httpjson",
+						"streams": []any{
+							map[string]any{
+								"request": map[string]any{
+									"transforms": []any{
+										map[string]any{
+											"set": map[string]any{
+												"target":                  "header.Authorization",
+												"value":                   "SSWS this-should-be-redacted",
+												markerPrefix + "value":    true,
+											},
+										},
+										map[string]any{
+											"set": map[string]any{
+												"target": "url.params.limit",
+												"value":  "1000",
+											},
+										},
+									},
+								},
+							},
+							map[string]any{
+								"mock_stream_config": map[string]any{
+									"kind": map[string]any{
+										"string_value": "mock_stream_config_name",
+									},
+								},
+								markerPrefix + "mock_stream_config": true,
+							},
+						},
+					},
+				},
+			},
+			opts: []RedactOption{WithMarkerPrefix(markerPrefix)},
+			expect: map[any]any{
+				"id": "test-policy",
+				"inputs": []any{
+					map[string]any{
+						"type": "httpjson",
+						"streams": []any{
+							map[string]any{
+								"request": map[string]any{
+									"transforms": []any{
+										map[string]any{
+											"set": map[string]any{
+												"target": "header.Authorization",
+												"value":  REDACTED,
+											},
+										},
+										map[string]any{
+											"set": map[string]any{
+												"target": "url.params.limit",
+												"value":  "1000",
+											},
+										},
+									},
+								},
+							},
+							map[string]any{
+								"mock_stream_config": REDACTED,
+							},
+						},
+					},
+				},
+			},
+		},
+		"redaction markers are ignored when no prefix is configured": {
+			input: map[any]any{
+				"benign":                "value",
+				markerPrefix + "benign": true,
+			},
+			expect: map[any]any{
+				"benign":                "value",
+				markerPrefix + "benign": true,
+			},
+		},
+		"ignored keys are not redacted": {
+			input: map[any]any{
+				"routekey":      "should-not-redact",
+				"my_secret_key": "redact-me",
+				"safe":          "value",
+			},
+			opts: []RedactOption{WithIgnoreKeys("routekey")},
+			expect: map[any]any{
+				"routekey":      "should-not-redact",
+				"my_secret_key": REDACTED,
+				"safe":          "value",
+			},
+		},
+		"ignored keys and markers coexist": {
+			input: map[any]any{
+				"routekey":                 "should-not-redact",
+				"keepme":                   "value",
+				markerPrefix + "keepme":    true,
+				"api_key":                  "secret",
+			},
+			opts: []RedactOption{
+				WithIgnoreKeys("routekey"),
+				WithMarkerPrefix(markerPrefix),
+			},
+			expect: map[any]any{
+				"routekey": "should-not-redact",
+				"keepme":   REDACTED,
+				"api_key":  REDACTED,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			var errOut bytes.Buffer
+			opts := append([]RedactOption{WithErrorOutput(&errOut)}, tc.opts...)
+
+			Redact(tc.input, opts...)
+
+			assert.Equal(t, tc.expect, tc.input)
+			assert.Empty(t, errOut.String(), "no warnings expected")
+		})
+	}
+}
+
+func TestRedactURL(t *testing.T) {
+	tests := map[string]struct {
+		input    string
+		expect   string
+		redacted bool
+	}{
+		"plain string": {
+			input:    "not a url",
+			expect:   "not a url",
+			redacted: false,
+		},
+		"url without credentials": {
+			input:    "https://example.com/path",
+			expect:   "https://example.com/path",
+			redacted: false,
+		},
+		"url with credentials": {
+			input:    "https://user:pass@example.com/path",
+			expect:   "https://" + redactedURL + "@example.com/path",
+			redacted: true,
+		},
+		"url with username only": {
+			input:    "https://user@example.com",
+			expect:   "https://" + redactedURL + "@example.com",
+			redacted: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			got, redacted := redactURL(tc.input)
+			assert.Equal(t, tc.expect, got)
+			assert.Equal(t, tc.redacted, redacted)
+		})
+	}
+}
+
+func TestRedactKey(t *testing.T) {
+	tests := map[string]struct {
+		key        string
+		ignoreKeys []string
+		expect     bool
+	}{
+		"empty":              {key: "", expect: false},
+		"safe":               {key: "type", expect: false},
+		"auth substring":     {key: "X-Authentication", expect: true},
+		"certificate":        {key: "certificate", expect: true},
+		"passphrase":         {key: "passphrase", expect: true},
+		"password":           {key: "password", expect: true},
+		"token":              {key: "token", expect: true},
+		"key substring":      {key: "api_key", expect: true},
+		"secret substring":   {key: "client_secret", expect: true},
+		"uppercase matches":  {key: "PASSWORD", expect: true},
+		"mixed case matches": {key: "ApiKey", expect: true},
+		"ignored exact":      {key: "routekey", ignoreKeys: []string{"routekey"}, expect: false},
+		"ignored is case sensitive": {
+			// "RouteKey" still matches the redaction rule via "key";
+			// ignoreKeys check is exact-match before lowercasing.
+			key: "RouteKey", ignoreKeys: []string{"routekey"}, expect: true,
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			ro := &redactOptions{ignoreKeys: tc.ignoreKeys}
+			assert.Equal(t, tc.expect, redactKey(tc.key, ro))
+		})
+	}
+}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -29,20 +29,24 @@ const redactedURL = REDACTED + ":" + REDACTED
 func TestRedact(t *testing.T) {
 	const markerPrefix = "__mark_redact_"
 
-	tests := map[string]struct {
+	tests := []struct {
+		name   string
 		input  map[any]any
 		opts   []RedactOption
 		expect map[any]any
 	}{
-		"nil map": {
+		{
+			name:   "nil map",
 			input:  nil,
 			expect: nil,
 		},
-		"empty map": {
+		{
+			name:   "empty map",
 			input:  map[any]any{},
 			expect: map[any]any{},
 		},
-		"no redactions": {
+		{
+			name: "no redactions",
 			input: map[any]any{
 				"type":      "elasticsearch",
 				"namespace": "default",
@@ -54,7 +58,8 @@ func TestRedact(t *testing.T) {
 				"count":     int64(5),
 			},
 		},
-		"sensitive keys are redacted": {
+		{
+			name: "sensitive keys are redacted",
 			input: map[any]any{
 				"api_key":     "secret",
 				"password":    "secret",
@@ -76,7 +81,8 @@ func TestRedact(t *testing.T) {
 				"safe":        "value",
 			},
 		},
-		"keys are matched case insensitively": {
+		{
+			name: "keys are matched case insensitively",
 			input: map[any]any{
 				"API_KEY":     "secret",
 				"PassWord":    "secret",
@@ -92,7 +98,8 @@ func TestRedact(t *testing.T) {
 				"Certificate": REDACTED,
 			},
 		},
-		"URL credentials are redacted": {
+		{
+			name: "URL credentials are redacted",
 			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[any]any{
 				"url":       "https://user:pass@example.com/path",
@@ -105,7 +112,8 @@ func TestRedact(t *testing.T) {
 				"plain":     "not a url",
 			},
 		},
-		"URL credentials in slice elements are redacted": {
+		{
+			name: "URL credentials in slice elements are redacted",
 			input: map[any]any{
 				"urls": []any{
 					"https://user:pass@my-url1",
@@ -121,7 +129,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"sensitive key wins over URL redaction": {
+		{
+			name: "sensitive key wins over URL redaction",
 			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[any]any{
 				"secret_url": "https://user:pass@example.com",
@@ -130,7 +139,8 @@ func TestRedact(t *testing.T) {
 				"secret_url": REDACTED,
 			},
 		},
-		"nested map[string]any is redacted recursively": {
+		{
+			name: "nested map[string]any is redacted recursively",
 			input: map[any]any{
 				"outputs": map[string]any{
 					"default": map[string]any{
@@ -152,7 +162,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"nested map[any]any is redacted recursively": {
+		{
+			name: "nested map[any]any is redacted recursively",
 			input: map[any]any{
 				"outputs": map[any]any{
 					"default": map[any]any{
@@ -170,7 +181,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"slice items that are maps are redacted recursively": {
+		{
+			name: "slice items that are maps are redacted recursively",
 			input: map[any]any{
 				"inputs": []any{
 					map[string]any{
@@ -196,7 +208,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"deeply nested ssl key in inputs is redacted": {
+		{
+			name: "deeply nested ssl key in inputs is redacted",
 			input: map[any]any{
 				"inputs": []any{
 					map[string]any{
@@ -246,7 +259,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"name/value entries are redacted when name indicates a secret": {
+		{
+			name: "name/value entries are redacted when name indicates a secret",
 			input: map[any]any{
 				"headers": []any{
 					map[string]any{
@@ -272,7 +286,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"redaction markers are processed when prefix is configured": {
+		{
+			name: "redaction markers are processed when prefix is configured",
 			input: map[any]any{
 				"inputs": []any{
 					map[string]any{
@@ -307,7 +322,8 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"redaction markers in nested slice items are processed": {
+		{
+			name: "redaction markers in nested slice items are processed",
 			input: map[any]any{
 				"id": "test-policy",
 				"inputs": []any{
@@ -378,7 +394,36 @@ func TestRedact(t *testing.T) {
 				},
 			},
 		},
-		"redaction markers are ignored when no prefix is configured": {
+		{
+			name: "redaction marker key is deleted from the map",
+			// Explicitly verifies that the bool branch's delete (followed by
+			// continue) removes the marker key so it does not survive in the
+			// output. Without the continue, the trailing obj[key] = val would
+			// re-add the marker before the post-loop cleanup.
+			input: map[any]any{
+				"redactKey":                "secretValue",
+				markerPrefix + "redactKey": true,
+			},
+			opts: []RedactOption{WithMarkerPrefix(markerPrefix)},
+			expect: map[any]any{
+				"redactKey": REDACTED,
+			},
+		},
+		{
+			name: "redaction marker without matching target is still deleted",
+			// The marker points to a key that does not exist in the map; the
+			// marker itself must still be removed from the output.
+			input: map[any]any{
+				"safe":                   "value",
+				markerPrefix + "missing": true,
+			},
+			opts: []RedactOption{WithMarkerPrefix(markerPrefix)},
+			expect: map[any]any{
+				"safe": "value",
+			},
+		},
+		{
+			name: "redaction markers are ignored when no prefix is configured",
 			input: map[any]any{
 				"benign":                "value",
 				markerPrefix + "benign": true,
@@ -388,7 +433,8 @@ func TestRedact(t *testing.T) {
 				markerPrefix + "benign": true,
 			},
 		},
-		"ignored keys are not redacted": {
+		{
+			name: "ignored keys are not redacted",
 			input: map[any]any{
 				"routekey":      "should-not-redact",
 				"my_secret_key": "redact-me",
@@ -401,7 +447,8 @@ func TestRedact(t *testing.T) {
 				"safe":          "value",
 			},
 		},
-		"ignored keys and markers coexist": {
+		{
+			name: "ignored keys and markers coexist",
 			input: map[any]any{
 				"routekey":              "should-not-redact",
 				"keepme":                "value",
@@ -420,8 +467,8 @@ func TestRedact(t *testing.T) {
 		},
 	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			var errOut bytes.Buffer
 			opts := append([]RedactOption{WithErrorOutput(&errOut)}, tc.opts...)
 
@@ -434,36 +481,41 @@ func TestRedact(t *testing.T) {
 }
 
 func TestRedactURL(t *testing.T) {
-	tests := map[string]struct {
+	tests := []struct {
+		name     string
 		input    string
 		expect   string
 		redacted bool
 	}{
-		"plain string": {
+		{
+			name:     "plain string",
 			input:    "not a url",
 			expect:   "not a url",
 			redacted: false,
 		},
-		"url without credentials": {
+		{
+			name:     "url without credentials",
 			input:    "https://example.com/path",
 			expect:   "https://example.com/path",
 			redacted: false,
 		},
-		//nolint:gosec // this test is meant to redact sensitive values
-		"url with credentials": {
+		{
+			name: "url with credentials",
+			//nolint:gosec // this test is meant to redact sensitive values
 			input:    "https://user:pass@example.com/path",
 			expect:   "https://" + redactedURL + "@example.com/path",
 			redacted: true,
 		},
-		"url with username only": {
+		{
+			name:     "url with username only",
 			input:    "https://user@example.com",
 			expect:   "https://" + redactedURL + "@example.com",
 			redacted: true,
 		},
 	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			got, redacted := redactURL(tc.input)
 			assert.Equal(t, tc.expect, got)
 			assert.Equal(t, tc.redacted, redacted)
@@ -472,32 +524,33 @@ func TestRedactURL(t *testing.T) {
 }
 
 func TestRedactKey(t *testing.T) {
-	tests := map[string]struct {
+	tests := []struct {
+		name       string
 		key        string
 		ignoreKeys []string
 		expect     bool
 	}{
-		"empty":              {key: "", expect: false},
-		"safe":               {key: "type", expect: false},
-		"auth substring":     {key: "X-Authentication", expect: true},
-		"certificate":        {key: "certificate", expect: true},
-		"passphrase":         {key: "passphrase", expect: true},
-		"password":           {key: "password", expect: true},
-		"token":              {key: "token", expect: true},
-		"key substring":      {key: "api_key", expect: true},
-		"secret substring":   {key: "client_secret", expect: true},
-		"uppercase matches":  {key: "PASSWORD", expect: true},
-		"mixed case matches": {key: "ApiKey", expect: true},
-		"ignored exact":      {key: "routekey", ignoreKeys: []string{"routekey"}, expect: false},
-		"ignored is case sensitive": {
+		{name: "empty", key: "", expect: false},
+		{name: "safe", key: "type", expect: false},
+		{name: "auth substring", key: "X-Authentication", expect: true},
+		{name: "certificate", key: "certificate", expect: true},
+		{name: "passphrase", key: "passphrase", expect: true},
+		{name: "password", key: "password", expect: true},
+		{name: "token", key: "token", expect: true},
+		{name: "key substring", key: "api_key", expect: true},
+		{name: "secret substring", key: "client_secret", expect: true},
+		{name: "uppercase matches", key: "PASSWORD", expect: true},
+		{name: "mixed case matches", key: "ApiKey", expect: true},
+		{name: "ignored exact", key: "routekey", ignoreKeys: []string{"routekey"}, expect: false},
+		{
 			// "RouteKey" still matches the redaction rule via "key";
 			// ignoreKeys check is exact-match before lowercasing.
-			key: "RouteKey", ignoreKeys: []string{"routekey"}, expect: true,
+			name: "ignored is case sensitive", key: "RouteKey", ignoreKeys: []string{"routekey"}, expect: true,
 		},
 	}
 
-	for name, tc := range tests {
-		t.Run(name, func(t *testing.T) {
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
 			ro := &redactOptions{ignoreKeys: tc.ignoreKeys}
 			assert.Equal(t, tc.expect, redactKey(tc.key, ro))
 		})


### PR DESCRIPTION
## What does this PR do?

Add a `redact` package with a public `Redact` method to scan through a passed map and redact any sensitive values in place.

Redaction logic can be changed with optional args (i.e., ignore_keys, redaction prefix marker support).

## Why is it important?

Redaction logic occurs in the elastic-agent as a part of diagnostics collection, and in fleet-server when otel clients send effective config. We need a single way to ensure that sensitive values that can appear do not get leaked.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Follow up work

- Change uses of `diagnostics.Redact` in elastic-agent
- Change redaction in OpAPM handler of fleet-server.

## Related issues

- Relates #415