### PR TITLE
feat(tlscommon): wire CertReloader into LoadTLSConfig and LoadTLSServerConfig

### DIFF
--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -156,4 +156,3 @@ func (r *CertReloader) getCertificate() (*tls.Certificate, error) {
 	r.cert = &cert
 	return r.cert, nil
 }
-

--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -156,15 +156,9 @@ func (r *CertReloader) getCertificate() (*tls.Certificate, error) {
 	return r.cert, nil
 }
 
-// newCertReloaderFromConfig creates a CertReloader from a CertificateConfig
-// and CertificateReload configuration. It resolves the passphrase from the
-// config and applies the reload interval.
-func newCertReloaderFromConfig(certCfg CertificateConfig, reloadCfg CertificateReload) (*CertReloader, error) {
-	var opts []CertReloaderOption
-	if reloadCfg.ReloadInterval > 0 {
-		opts = append(opts, WithReloadInterval(reloadCfg.ReloadInterval))
-	}
-
+// newCertReloaderFromConfig creates a CertReloader from a CertificateConfig.
+// Additional options (e.g. WithReloadInterval) can be passed by the caller.
+func newCertReloaderFromConfig(certCfg CertificateConfig, opts ...CertReloaderOption) (*CertReloader, error) {
 	passphrase, err := certCfg.resolvePassphrase()
 	if err != nil {
 		return nil, fmt.Errorf("failed to resolve TLS key passphrase: %w", err)

--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -37,11 +37,12 @@ const defaultReloadInterval = 5 * time.Second
 // This design follows the OpenTelemetry Collector's configtls approach: no file
 // watchers or extra goroutines — just a time check on the handshake hot path.
 type CertReloader struct {
-	certPath       string
-	keyPath        string
-	passphrase     string
-	reloadInterval time.Duration
-	log            *logp.Logger
+	certPath         string
+	keyPath          string
+	passphrase       string
+	disableLegacyPEM bool
+	reloadInterval   time.Duration
+	log              *logp.Logger
 
 	mu         sync.RWMutex
 	cert       *tls.Certificate
@@ -63,6 +64,14 @@ func WithReloadInterval(d time.Duration) CertReloaderOption {
 func WithPassphrase(passphrase string) CertReloaderOption {
 	return func(r *CertReloader) {
 		r.passphrase = passphrase
+	}
+}
+
+// WithDisableLegacyPEMSupport configures whether encrypted PKCS#1 PEM keys
+// should be treated as an error instead of a deprecation warning.
+func WithDisableLegacyPEMSupport(disable bool) CertReloaderOption {
+	return func(r *CertReloader) {
+		r.disableLegacyPEM = disable
 	}
 }
 
@@ -94,12 +103,13 @@ func NewCertReloader(certPath, keyPath string, opts ...CertReloaderOption) (*Cer
 	return r, nil
 }
 
+// loadKeyPair mirrors the static cert-loading path in LoadCertificate (tls.go).
 func (r *CertReloader) loadKeyPair() (tls.Certificate, error) {
-	certPEM, err := ReadPEMFile(r.log, r.certPath, r.passphrase)
+	certPEM, err := readPEMFile(r.log, r.certPath, r.passphrase, r.disableLegacyPEM)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("reading certificate file: %w", err)
 	}
-	keyPEM, err := ReadPEMFile(r.log, r.keyPath, r.passphrase)
+	keyPEM, err := readPEMFile(r.log, r.keyPath, r.passphrase, r.disableLegacyPEM)
 	if err != nil {
 		return tls.Certificate{}, fmt.Errorf("reading key file: %w", err)
 	}
@@ -110,6 +120,17 @@ func (r *CertReloader) loadKeyPair() (tls.Certificate, error) {
 // reload interval has elapsed. It is safe for concurrent use and is intended
 // to be used with tls.Config.GetCertificate.
 func (r *CertReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate, error) {
+	return r.getCertificate()
+}
+
+// GetClientCertificate returns the current certificate, reloading from disk if
+// the reload interval has elapsed. It is safe for concurrent use and is
+// intended to be used with tls.Config.GetClientCertificate.
+func (r *CertReloader) GetClientCertificate(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+	return r.getCertificate()
+}
+
+func (r *CertReloader) getCertificate() (*tls.Certificate, error) {
 	r.mu.RLock()
 	if time.Now().Before(r.nextReload) {
 		defer r.mu.RUnlock()
@@ -133,4 +154,27 @@ func (r *CertReloader) GetCertificate(_ *tls.ClientHelloInfo) (*tls.Certificate,
 	}
 	r.cert = &cert
 	return r.cert, nil
+}
+
+// newCertReloaderFromConfig creates a CertReloader from a CertificateConfig
+// and CertificateReload configuration. It resolves the passphrase from the
+// config and applies the reload interval.
+func newCertReloaderFromConfig(certCfg CertificateConfig, reloadCfg CertificateReload) (*CertReloader, error) {
+	var opts []CertReloaderOption
+	if reloadCfg.ReloadInterval > 0 {
+		opts = append(opts, WithReloadInterval(reloadCfg.ReloadInterval))
+	}
+
+	passphrase, err := certCfg.resolvePassphrase()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve TLS key passphrase: %w", err)
+	}
+	if passphrase != "" {
+		opts = append(opts, WithPassphrase(passphrase))
+	}
+	if certCfg.DisableLegacyPEMSupport {
+		opts = append(opts, WithDisableLegacyPEMSupport(true))
+	}
+
+	return NewCertReloader(certCfg.Certificate, certCfg.Key, opts...)
 }

--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -31,7 +31,7 @@ const defaultReloadInterval = 5 * time.Second
 // CertReloader periodically reloads TLS certificate and key files from disk.
 // On each call to GetCertificate (i.e., on each TLS handshake), it checks
 // whether the reload interval has elapsed and, if so, re-reads the files from
-// disk. Invalid cert/key pairs are silently skipped, preserving the last
+// disk. Invalid cert/key pairs are logged and skipped, preserving the last
 // successfully loaded certificate.
 //
 // This design follows the OpenTelemetry Collector's configtls approach: no file
@@ -150,6 +150,7 @@ func (r *CertReloader) getCertificate() (*tls.Certificate, error) {
 
 	cert, err := r.loadKeyPair()
 	if err != nil {
+		r.log.Errorf("Failed to reload TLS certificate from %s and %s, continuing with current certificate: %v", r.certPath, r.keyPath, err)
 		return r.cert, nil
 	}
 	r.cert = &cert

--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -156,19 +156,3 @@ func (r *CertReloader) getCertificate() (*tls.Certificate, error) {
 	return r.cert, nil
 }
 
-// newCertReloaderFromConfig creates a CertReloader from a CertificateConfig.
-// Additional options (e.g. WithReloadInterval) can be passed by the caller.
-func newCertReloaderFromConfig(certCfg CertificateConfig, opts ...CertReloaderOption) (*CertReloader, error) {
-	passphrase, err := certCfg.resolvePassphrase()
-	if err != nil {
-		return nil, fmt.Errorf("failed to resolve TLS key passphrase: %w", err)
-	}
-	if passphrase != "" {
-		opts = append(opts, WithPassphrase(passphrase))
-	}
-	if certCfg.DisableLegacyPEMSupport {
-		opts = append(opts, WithDisableLegacyPEMSupport(true))
-	}
-
-	return NewCertReloader(certCfg.Certificate, certCfg.Key, opts...)
-}

--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -82,6 +82,12 @@ func NewCertReloader(certPath, keyPath string, opts ...CertReloaderOption) (*Cer
 	if certPath == "" || keyPath == "" {
 		return nil, fmt.Errorf("certificate and key paths must be non-empty")
 	}
+	if IsPEMString(certPath) {
+		return nil, fmt.Errorf("certificate must be a file path, not an inline PEM")
+	}
+	if IsPEMString(keyPath) {
+		return nil, fmt.Errorf("key must be a file path, not an inline PEM")
+	}
 
 	r := &CertReloader{
 		certPath:       certPath,

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	Renegotiation        TLSRenegotiationSupport `config:"renegotiation" yaml:"renegotiation"`
 	CASha256             []string                `config:"ca_sha256" yaml:"ca_sha256,omitempty"`
 	CATrustedFingerprint string                  `config:"ca_trusted_fingerprint" yaml:"ca_trusted_fingerprint,omitempty"`
+	CertificateReload    CertificateReload       `config:"certificate_reload" yaml:"certificate_reload,omitempty"`
 }
 
 // LoadTLSConfig will load a certificate from config with all TLS based keys
@@ -61,20 +62,27 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		curves[idx] = tls.CurveID(id)
 	}
 
-	cert, err := LoadCertificate(&config.Certificate)
-	logFail(err)
-
 	cas, errs := LoadCertificateAuthorities(config.CAs)
 	logFail(errs...)
+
+	var certs []tls.Certificate
+	var reloader *CertReloader
+	var err error
+
+	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
+		reloader, err = newCertReloaderFromConfig(config.Certificate, config.CertificateReload)
+		logFail(err)
+	} else {
+		cert, err := LoadCertificate(&config.Certificate)
+		logFail(err)
+		if cert != nil {
+			certs = []tls.Certificate{*cert}
+		}
+	}
 
 	// fail, if any error occurred when loading certificate files
 	if len(fail) != 0 {
 		return nil, errors.Join(fail...)
-	}
-
-	certs := make([]tls.Certificate, 0)
-	if cert != nil {
-		certs = []tls.Certificate{*cert}
 	}
 
 	// return config if no error occurred
@@ -89,6 +97,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		CASha256:             config.CASha256,
 		CATrustedFingerprint: config.CATrustedFingerprint,
 		Logger:               logger,
+		certReloader:         reloader,
 	}, nil
 }
 

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -70,7 +70,11 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 	var err error
 
 	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
-		reloader, err = newCertReloaderFromConfig(config.Certificate, config.CertificateReload)
+		var reloadOpts []CertReloaderOption
+		if config.CertificateReload.ReloadInterval > 0 {
+			reloadOpts = append(reloadOpts, WithReloadInterval(config.CertificateReload.ReloadInterval))
+		}
+		reloader, err = newCertReloaderFromConfig(config.Certificate, reloadOpts...)
 		logFail(err)
 	} else {
 		cert, err := LoadCertificate(&config.Certificate)

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -67,14 +67,14 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 
 	var certs []tls.Certificate
 	var reloader *CertReloader
-	var err error
 
 	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
-		var reloadOpts []CertReloaderOption
+		reloadOpts, err := config.Certificate.reloaderOptions()
+		logFail(err)
 		if config.CertificateReload.ReloadInterval > 0 {
 			reloadOpts = append(reloadOpts, WithReloadInterval(config.CertificateReload.ReloadInterval))
 		}
-		reloader, err = newCertReloaderFromConfig(config.Certificate, reloadOpts...)
+		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, reloadOpts...)
 		logFail(err)
 	} else {
 		cert, err := LoadCertificate(&config.Certificate)

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -68,7 +68,9 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 	var certs []tls.Certificate
 	var reloader *CertReloader
 
-	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
+	// Skip cert reloading when inline PEMs are used; reloading only makes sense with file paths.
+	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() &&
+		!IsPEMString(config.Certificate.Certificate) && !IsPEMString(config.Certificate.Key) {
 		reloadOpts, err := config.Certificate.reloaderOptions()
 		logFail(err)
 		if config.CertificateReload.ReloadInterval > 0 {

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -98,7 +98,11 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 	var err error
 
 	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
-		reloader, err = newCertReloaderFromConfig(config.Certificate, config.CertificateReload)
+		var reloadOpts []CertReloaderOption
+		if config.CertificateReload.ReloadInterval > 0 {
+			reloadOpts = append(reloadOpts, WithReloadInterval(config.CertificateReload.ReloadInterval))
+		}
+		reloader, err = newCertReloaderFromConfig(config.Certificate, reloadOpts...)
 		logFail(err)
 	} else {
 		cert, err := LoadCertificate(&config.Certificate)

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -95,14 +95,14 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 
 	var certs []tls.Certificate
 	var reloader *CertReloader
-	var err error
 
 	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
-		var reloadOpts []CertReloaderOption
+		reloadOpts, err := config.Certificate.reloaderOptions()
+		logFail(err)
 		if config.CertificateReload.ReloadInterval > 0 {
 			reloadOpts = append(reloadOpts, WithReloadInterval(config.CertificateReload.ReloadInterval))
 		}
-		reloader, err = newCertReloaderFromConfig(config.Certificate, reloadOpts...)
+		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, reloadOpts...)
 		logFail(err)
 	} else {
 		cert, err := LoadCertificate(&config.Certificate)

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -90,20 +90,27 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		curves[idx] = tls.CurveID(id)
 	}
 
-	cert, err := LoadCertificate(&config.Certificate)
-	logFail(err)
-
 	cas, errs := LoadCertificateAuthorities(config.CAs)
 	logFail(errs...)
+
+	var certs []tls.Certificate
+	var reloader *CertReloader
+	var err error
+
+	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
+		reloader, err = newCertReloaderFromConfig(config.Certificate, config.CertificateReload)
+		logFail(err)
+	} else {
+		cert, err := LoadCertificate(&config.Certificate)
+		logFail(err)
+		if cert != nil {
+			certs = []tls.Certificate{*cert}
+		}
+	}
 
 	// fail, if any error occurred when loading certificate files
 	if len(fail) != 0 {
 		return nil, errors.Join(fail...)
-	}
-
-	certs := make([]tls.Certificate, 0)
-	if cert != nil {
-		certs = []tls.Certificate{*cert}
 	}
 
 	clientAuth := TLSClientAuthNone
@@ -122,6 +129,7 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		ClientAuth:       tls.ClientAuthType(clientAuth),
 		CASha256:         config.CASha256,
 		Logger:           logger,
+		certReloader:     reloader,
 	}, nil
 }
 

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -96,7 +96,9 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 	var certs []tls.Certificate
 	var reloader *CertReloader
 
-	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() {
+	// Skip cert reloading when inline PEMs are used; reloading only makes sense with file paths.
+	if config.Certificate.Certificate != "" && config.CertificateReload.IsEnabled() &&
+		!IsPEMString(config.Certificate.Certificate) && !IsPEMString(config.Certificate.Key) {
 		reloadOpts, err := config.Certificate.reloaderOptions()
 		logFail(err)
 		if config.CertificateReload.ReloadInterval > 0 {

--- a/transport/tlscommon/tls.go
+++ b/transport/tlscommon/tls.go
@@ -46,13 +46,9 @@ func LoadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
 	}
 
 	log := logp.NewLogger(logSelector)
-	passphrase := config.Passphrase
-	if passphrase == "" && config.PassphrasePath != "" {
-		p, err := os.ReadFile(config.PassphrasePath)
-		if err != nil {
-			return nil, fmt.Errorf("unable to read passphrase_file: %w", err)
-		}
-		passphrase = string(p)
+	passphrase, err := config.resolvePassphrase()
+	if err != nil {
+		return nil, err
 	}
 
 	certPEM, err := readPEMFile(log, certificate, passphrase, config.DisableLegacyPEMSupport)

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -152,7 +152,6 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 	if c.certReloader != nil {
 		cfg.GetCertificate = c.certReloader.GetCertificate
 		cfg.GetClientCertificate = c.certReloader.GetClientCertificate
-		cfg.Certificates = nil
 	}
 
 	return cfg

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -88,6 +88,11 @@ type TLSConfig struct {
 	time func() time.Time
 
 	Logger *logp.Logger
+
+	// certReloader, when set, provides dynamic certificate reloading from disk.
+	// ToConfig will use it to set GetCertificate and GetClientCertificate on
+	// the resulting tls.Config instead of populating Certificates statically.
+	certReloader *CertReloader
 }
 
 var (
@@ -129,7 +134,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		c.Logger.Named("tls").Warn("SSL/TLS verifications disabled.")
 	}
 
-	return &tls.Config{
+	cfg := &tls.Config{
 		MinVersion:         minVersion,
 		MaxVersion:         maxVersion,
 		Certificates:       c.Certificates,
@@ -143,6 +148,14 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		Time:               c.time,
 		VerifyConnection:   makeVerifyConnection(c, c.Logger),
 	}
+
+	if c.certReloader != nil {
+		cfg.GetCertificate = c.certReloader.GetCertificate
+		cfg.GetClientCertificate = c.certReloader.GetClientCertificate
+		cfg.Certificates = nil
+	}
+
+	return cfg
 }
 
 // BuildModuleClientConfig takes the TLSConfig and transform it into a `tls.Config`.

--- a/transport/tlscommon/tls_nofips_test.go
+++ b/transport/tlscommon/tls_nofips_test.go
@@ -142,8 +142,7 @@ func TestEncryptedKeyPassphrase(t *testing.T) {
         key_passphrase: Abcd1234!
         `), logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
-		require.NotNil(t, cfg)
-		assert.Len(t, cfg.Certificates, 1)
+		assert.NotNil(t, cfg.certReloader, "expected cert reloader to be active")
 	})
 
 	t.Run("passphrase value with legacy support disabled", func(t *testing.T) {
@@ -169,7 +168,7 @@ func TestEncryptedKeyPassphrase(t *testing.T) {
         key_passphrase_path: %s
         `, fileName)), logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
-		assert.NotNil(t, cfg)
+		assert.NotNil(t, cfg.certReloader, "expected cert reloader to be active")
 	})
 
 	t.Run("logs deprecation warning", func(t *testing.T) {

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -136,7 +136,9 @@ func TestApplyWithConfig(t *testing.T) {
 
 	cfg := tmp.BuildModuleClientConfig("")
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
+	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
+	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
 	assert.NotNil(t, cfg.RootCAs)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
@@ -240,7 +242,9 @@ func TestApplyWithServerConfig(t *testing.T) {
 
 	cfg := tmp.BuildModuleClientConfig("")
 	assert.NotNil(t, cfg)
-	assert.Len(t, cfg.Certificates, 1)
+	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
+	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
+	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
 	assert.NotNil(t, cfg.ClientCAs)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
@@ -423,6 +427,99 @@ func TestKeyPassphrase(t *testing.T) {
     key_passphrase: Abcd1234!
     `), logptest.NewTestingLogger(t, ""))
 		require.NoError(t, err)
-		assert.Equal(t, 1, len(cfg.Certificates), "expected 1 certificate to be loaded")
+		assert.NotNil(t, cfg.certReloader, "expected cert reloader to be active")
+	})
+}
+
+func TestCertReloadWiring(t *testing.T) {
+	logger := logptest.NewTestingLogger(t, "")
+
+	t.Run("client config enables cert reload by default", func(t *testing.T) {
+		cfg, err := LoadTLSConfig(mustLoad(t, `
+    certificate: testdata/ca_test.pem
+    key: testdata/ca_test.key
+    `), logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.certReloader)
+
+		tlsCfg := cfg.BuildModuleClientConfig("")
+		assert.NotNil(t, tlsCfg.GetCertificate)
+		assert.NotNil(t, tlsCfg.GetClientCertificate)
+		assert.Empty(t, tlsCfg.Certificates)
+
+		cert, err := tlsCfg.GetClientCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEmpty(t, cert.Certificate)
+	})
+
+	t.Run("client config disables cert reload explicitly", func(t *testing.T) {
+		cfg, err := LoadTLSConfig(mustLoad(t, `
+    certificate: testdata/ca_test.pem
+    key: testdata/ca_test.key
+    certificate_reload:
+      enabled: false
+    `), logger)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.certReloader)
+		assert.Len(t, cfg.Certificates, 1)
+
+		tlsCfg := cfg.BuildModuleClientConfig("")
+		assert.Nil(t, tlsCfg.GetCertificate)
+		assert.Nil(t, tlsCfg.GetClientCertificate)
+		assert.Len(t, tlsCfg.Certificates, 1)
+	})
+
+	t.Run("client config without certificate skips reloader", func(t *testing.T) {
+		cfg, err := LoadTLSConfig(mustLoad(t, `
+    certificate_authorities: [testdata/ca_test.pem]
+    `), logger)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.certReloader)
+		assert.Empty(t, cfg.Certificates)
+	})
+
+	t.Run("server config enables cert reload by default", func(t *testing.T) {
+		var c ServerConfig
+		ucfg, err := config.NewConfigWithYAML([]byte(`
+    certificate: testdata/ca_test.pem
+    key: testdata/ca_test.key
+    `), "")
+		require.NoError(t, err)
+		require.NoError(t, ucfg.Unpack(&c))
+
+		cfg, err := LoadTLSServerConfig(&c, logger)
+		require.NoError(t, err)
+		require.NotNil(t, cfg.certReloader)
+
+		tlsCfg := cfg.BuildServerConfig("localhost")
+		assert.NotNil(t, tlsCfg.GetCertificate)
+		assert.NotNil(t, tlsCfg.GetClientCertificate)
+		assert.Empty(t, tlsCfg.Certificates)
+
+		cert, err := tlsCfg.GetCertificate(nil)
+		require.NoError(t, err)
+		assert.NotEmpty(t, cert.Certificate)
+	})
+
+	t.Run("server config disables cert reload explicitly", func(t *testing.T) {
+		var c ServerConfig
+		ucfg, err := config.NewConfigWithYAML([]byte(`
+    certificate: testdata/ca_test.pem
+    key: testdata/ca_test.key
+    certificate_reload:
+      enabled: false
+    `), "")
+		require.NoError(t, err)
+		require.NoError(t, ucfg.Unpack(&c))
+
+		cfg, err := LoadTLSServerConfig(&c, logger)
+		require.NoError(t, err)
+		assert.Nil(t, cfg.certReloader)
+		assert.Len(t, cfg.Certificates, 1)
+
+		tlsCfg := cfg.BuildServerConfig("localhost")
+		assert.Nil(t, tlsCfg.GetCertificate)
+		assert.Nil(t, tlsCfg.GetClientCertificate)
+		assert.Len(t, tlsCfg.Certificates, 1)
 	})
 }

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -407,6 +407,23 @@ func (c *CertificateConfig) resolvePassphrase() (string, error) {
 	return "", nil
 }
 
+// reloaderOptions returns the CertReloaderOption values derived from this config.
+func (c *CertificateConfig) reloaderOptions() ([]CertReloaderOption, error) {
+	passphrase, err := c.resolvePassphrase()
+	if err != nil {
+		return nil, fmt.Errorf("failed to resolve TLS key passphrase: %w", err)
+	}
+
+	var opts []CertReloaderOption
+	if passphrase != "" {
+		opts = append(opts, WithPassphrase(passphrase))
+	}
+	if c.DisableLegacyPEMSupport {
+		opts = append(opts, WithDisableLegacyPEMSupport(true))
+	}
+	return opts, nil
+}
+
 // Validate validates the CertificateConfig
 func (c *CertificateConfig) Validate() error {
 	hasCertificate := c.Certificate != ""

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -22,6 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"os"
 )
 
 var (
@@ -387,6 +388,22 @@ type CertificateConfig struct {
 	Passphrase              string `config:"key_passphrase" yaml:"key_passphrase,omitempty"`
 	PassphrasePath          string `config:"key_passphrase_path" yaml:"key_passphrase_path,omitempty"`
 	DisableLegacyPEMSupport bool   `config:"disable_legacy_pem_support" yaml:"disable_legacy_pem_support,omitempty"`
+}
+
+// resolvePassphrase returns the passphrase for decrypting private keys,
+// reading it from a file if PassphrasePath is set.
+func (c *CertificateConfig) resolvePassphrase() (string, error) {
+	if c.Passphrase != "" {
+		return c.Passphrase, nil
+	}
+	if c.PassphrasePath != "" {
+		p, err := os.ReadFile(c.PassphrasePath)
+		if err != nil {
+			return "", fmt.Errorf("unable to read key passphrase file: %w", err)
+		}
+		return string(p), nil
+	}
+	return "", nil
 }
 
 // Validate validates the CertificateConfig

--- a/transport/tlscommon/types.go
+++ b/transport/tlscommon/types.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"strings"
 )
 
 var (
@@ -401,7 +402,7 @@ func (c *CertificateConfig) resolvePassphrase() (string, error) {
 		if err != nil {
 			return "", fmt.Errorf("unable to read key passphrase file: %w", err)
 		}
-		return string(p), nil
+		return strings.TrimSpace(string(p)), nil
 	}
 	return "", nil
 }


### PR DESCRIPTION
## What does this PR do?

Wires `CertReloader` into the core TLS configuration loading functions so that **all consumers** of `tlscommon` get automatic TLS certificate hot-reload without manual wiring.

This is a follow-up to the server-side reloading changes made in #404 and #405. Those PRs added `CertReloader` and the `CertificateReload` config to `ServerConfig`. This PR completes the picture by:

1. **Adding `CertificateReload` to the client-side `Config` struct** — enables cert reload for TLS clients (e.g., Elastic Agent connecting to Fleet Server or Elasticsearch)
2. **Wiring `CertReloader` into `LoadTLSConfig` and `LoadTLSServerConfig`** — when certificate reload is enabled (the default), these functions create a `CertReloader` instead of loading certificates statically
3. **Wiring callbacks in `ToConfig()`** — sets `GetCertificate` and `GetClientCertificate` on the resulting `tls.Config`, clearing `Certificates` so Go's TLS stack uses the callbacks
4. **Adding `GetClientCertificate` method to `CertReloader`** — same reload logic as `GetCertificate`, with the signature expected by `tls.Config.GetClientCertificate`
5. **Adding `resolvePassphrase` helper on `CertificateConfig`** — consolidates passphrase resolution (inline value or file path) used when constructing a `CertReloader`

### Behavior

- **Enabled by default**: certificate reload is on unless explicitly disabled via `certificate_reload.enabled: false`, matching the OTel Collector pattern
- **No extra goroutines**: on each TLS handshake, checks if the reload interval (default 5s) has elapsed; if so, re-reads cert/key files from disk
- **Safe rollover**: invalid cert/key pairs during reload are silently skipped; the last successfully loaded certificate continues to be served
- **Passphrase support**: encrypted private keys work with both `key_passphrase` and `key_passphrase_path`

### Impact on consumers

Consumers that call `LoadTLSConfig` or `LoadTLSServerConfig` (Fleet Server, Elastic Agent, Beats inputs like `http_endpoint`, etc.) automatically get cert reload. Consumers that previously wired `CertReloader` manually (e.g., Fleet Server in elastic/fleet-server#6838) can remove that manual wiring.

## Why is it important?

In environments with frequent certificate rotation — Kubernetes (where Secrets are remounted into pods), serverless (where cert-manager manages per-project certificates), and general ops — processes currently require a restart to pick up rotated TLS certificates. With this change, any component using `tlscommon` reloads certificates automatically, both as a TLS server and as a TLS client.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Follow-up to #404 and #405
- Enables simplification of elastic/fleet-server#6838


🤖 Generated with [Claude Code](https://claude.com/claude-code)