### PR TITLE
feat(tlscommon): add CAReloader for dynamic CA certificate reloading

### DIFF
--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -124,7 +124,7 @@ func TestCAPinning(t *testing.T) {
 
 				tlsC := &TLSConfig{
 					Verification: mode,
-					RootCAs:      rootCAs,
+					rootCAs:      rootCAs,
 					CASha256:     []string{pin},
 				}
 
@@ -208,7 +208,7 @@ func TestCAPinning(t *testing.T) {
 		pin := Fingerprint(ca.Leaf)
 
 		tlsC := &TLSConfig{
-			RootCAs:  rootCAs,
+			rootCAs:  rootCAs,
 			CASha256: []string{pin},
 		}
 
@@ -282,7 +282,7 @@ func TestCAPinning(t *testing.T) {
 		pin := "wrong-pin"
 
 		tlsC := &TLSConfig{
-			RootCAs:  rootCAs,
+			rootCAs:  rootCAs,
 			CASha256: []string{pin},
 		}
 

--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -56,7 +56,10 @@ func TestCAPinning(t *testing.T) {
 		require.NoError(t, err)
 
 		tls := tlsCfg.BuildModuleClientConfig(host)
-		require.Nil(t, tls.VerifyConnection)
+		// With CA reload enabled (the default), VerifyStrict uses a custom
+		// VerifyConnection callback to verify against the dynamically reloaded
+		// CA pool instead of relying on Go's built-in verification.
+		require.NotNil(t, tls.VerifyConnection)
 	})
 
 	t.Run("when the ca_sha256 field is defined we use CA cert pinning", func(t *testing.T) {

--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -100,7 +100,7 @@ func TestCAPinning(t *testing.T) {
 					_, _ = w.Write(msg)
 				})
 
-				l, err := net.Listen("tcp", addr)
+				l, err := net.Listen("tcp", addr) //nolint:noctx // testing
 
 				server := &http.Server{ //nolint:gosec // testing
 					Handler: mux,
@@ -181,7 +181,7 @@ func TestCAPinning(t *testing.T) {
 			_, _ = w.Write(msg)
 		})
 
-		l, err := net.Listen("tcp", addr)
+		l, err := net.Listen("tcp", addr) //nolint:noctx // testing
 		require.NoError(t, err)
 
 		// Server needs to provides the chain of trust, so server certificate + intermediate.
@@ -255,7 +255,7 @@ func TestCAPinning(t *testing.T) {
 			_, _ = w.Write(msg)
 		})
 
-		l, err := net.Listen("tcp", addr)
+		l, err := net.Listen("tcp", addr) //nolint:noctx // testing
 		require.NoError(t, err)
 
 		// Server needs to provides the chain of trust, so server certificate + intermediate.

--- a/transport/tlscommon/ca_pinning_test.go
+++ b/transport/tlscommon/ca_pinning_test.go
@@ -127,7 +127,7 @@ func TestCAPinning(t *testing.T) {
 
 				tlsC := &TLSConfig{
 					Verification: mode,
-					rootCAs:      rootCAs,
+					rootCAs:      newStaticCertPool(rootCAs),
 					CASha256:     []string{pin},
 				}
 
@@ -211,7 +211,7 @@ func TestCAPinning(t *testing.T) {
 		pin := Fingerprint(ca.Leaf)
 
 		tlsC := &TLSConfig{
-			rootCAs:  rootCAs,
+			rootCAs:  newStaticCertPool(rootCAs),
 			CASha256: []string{pin},
 		}
 
@@ -285,7 +285,7 @@ func TestCAPinning(t *testing.T) {
 		pin := "wrong-pin"
 
 		tlsC := &TLSConfig{
-			rootCAs:  rootCAs,
+			rootCAs:  newStaticCertPool(rootCAs),
 			CASha256: []string{pin},
 		}
 

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -1,0 +1,94 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tlscommon
+
+import (
+	"crypto/x509"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
+)
+
+// CAReloader periodically reloads CA certificate files from disk.
+// On each call to GetCertPool, it checks whether the reload interval has
+// elapsed and, if so, re-reads the CA files from disk. Invalid or unreadable
+// files are skipped, preserving the last successfully loaded pool.
+type CAReloader struct {
+	caPaths        []string
+	reloadInterval time.Duration
+	log            *logp.Logger
+
+	mu         sync.RWMutex
+	pool       *x509.CertPool
+	nextReload time.Time
+}
+
+// NewCAReloader creates a CAReloader for the given CA file paths. Inline PEM
+// strings are also accepted and will be included on every reload (they never
+// change, but are needed to build a complete pool). An initial load is
+// performed; an error is returned only if no CA could be loaded at all.
+func NewCAReloader(caPaths []string, reloadInterval time.Duration) (*CAReloader, error) {
+	if len(caPaths) == 0 {
+		return nil, fmt.Errorf("at least one CA path must be provided")
+	}
+
+	r := &CAReloader{
+		caPaths:        caPaths,
+		reloadInterval: reloadInterval,
+		log:            logp.NewLogger("tls"),
+	}
+
+	pool, errs := LoadCertificateAuthorities(r.caPaths)
+	if len(errs) == len(r.caPaths) {
+		return nil, fmt.Errorf("initial CA load failed, none of the %d CA(s) could be loaded: %v", len(r.caPaths), errs)
+	}
+	r.pool = pool
+	r.nextReload = time.Now().Add(r.reloadInterval)
+
+	return r, nil
+}
+
+// GetCertPool returns the current CA certificate pool, reloading from disk if
+// the reload interval has elapsed. It is safe for concurrent use.
+func (r *CAReloader) GetCertPool() *x509.CertPool {
+	r.mu.RLock()
+	if time.Now().Before(r.nextReload) {
+		defer r.mu.RUnlock()
+		return r.pool
+	}
+	r.mu.RUnlock()
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if time.Now().Before(r.nextReload) {
+		return r.pool
+	}
+
+	r.nextReload = time.Now().Add(r.reloadInterval)
+
+	pool, errs := LoadCertificateAuthorities(r.caPaths)
+	if pool == nil {
+		r.log.Warnf("CA reload failed, keeping previous pool: %v", errs)
+		return r.pool
+	}
+	r.pool = pool
+	return r.pool
+}

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -89,8 +89,8 @@ func (r *CAReloader) GetCertPool() *x509.CertPool {
 	r.nextReload = time.Now().Add(r.reloadInterval)
 
 	pool, errs := LoadCertificateAuthorities(r.caPaths)
-	if len(errs) == len(r.caPaths) {
-		r.log.Warnf("CA reload failed, keeping previous pool: %v", errs)
+	if len(errs) > 0 {
+		r.log.Warnf("CA reload failed for %d/%d CA(s), keeping previous pool: %v", len(errs), len(r.caPaths), errs)
 		return r.pool
 	}
 	r.pool = pool

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -18,6 +18,7 @@
 package tlscommon
 
 import (
+	"bytes"
 	"crypto/x509"
 	"fmt"
 	"sync"
@@ -38,6 +39,11 @@ type CAReloader struct {
 	mu         sync.RWMutex
 	pool       *x509.CertPool
 	nextReload time.Time
+	// trustedFingerprintCerts holds CA certificates discovered at runtime via
+	// CATrustedFingerprint. Unlike the CAs loaded from caPaths on disk, these
+	// certs come from the peer's certificate chain during a TLS handshake and
+	// must be explicitly re-added to the pool after every disk reload.
+	trustedFingerprintCerts []*x509.Certificate
 }
 
 // NewCAReloader creates a CAReloader for the given CA file paths. Inline PEM
@@ -93,6 +99,30 @@ func (r *CAReloader) GetCertPool() *x509.CertPool {
 		r.log.Warnf("CA reload failed for %d/%d CA(s), keeping previous pool: %v", len(errs), len(r.caPaths), errs)
 		return r.pool
 	}
+
+	for _, cert := range r.trustedFingerprintCerts {
+		pool.AddCert(cert)
+	}
+
 	r.pool = pool
 	return r.pool
+}
+
+// AddTrustedCert registers a certificate so it is included in every pool
+// returned by GetCertPool, surviving reloads from disk. Duplicate certs
+// (by raw bytes) are ignored.
+func (r *CAReloader) AddTrustedCert(cert *x509.Certificate) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	for _, existing := range r.trustedFingerprintCerts {
+		if bytes.Equal(existing.Raw, cert.Raw) {
+			return
+		}
+	}
+
+	r.trustedFingerprintCerts = append(r.trustedFingerprintCerts, cert)
+	if r.pool != nil {
+		r.pool.AddCert(cert)
+	}
 }

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -49,6 +49,10 @@ func NewCAReloader(caPaths []string, reloadInterval time.Duration) (*CAReloader,
 		return nil, fmt.Errorf("at least one CA path must be provided")
 	}
 
+	if reloadInterval <= 0 {
+		reloadInterval = defaultReloadInterval
+	}
+
 	r := &CAReloader{
 		caPaths:        caPaths,
 		reloadInterval: reloadInterval,

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -85,7 +85,7 @@ func (r *CAReloader) GetCertPool() *x509.CertPool {
 	r.nextReload = time.Now().Add(r.reloadInterval)
 
 	pool, errs := LoadCertificateAuthorities(r.caPaths)
-	if pool == nil {
+	if len(errs) == len(r.caPaths) {
 		r.log.Warnf("CA reload failed, keeping previous pool: %v", errs)
 		return r.pool
 	}

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -113,6 +113,9 @@ func (r *CAReloader) GetCertPool() *x509.CertPool {
 	return r.pool
 }
 
+// IsDynamic reports that CAReloader provides a dynamically reloaded pool.
+func (r *CAReloader) IsDynamic() bool { return true }
+
 // AddTrustedCert registers a certificate so it is included in every pool
 // returned by GetCertPool, surviving reloads from disk. Duplicate certs
 // (by raw bytes) are ignored.

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -95,9 +95,12 @@ func (r *CAReloader) GetCertPool() *x509.CertPool {
 	r.nextReload = time.Now().Add(r.reloadInterval)
 
 	pool, errs := LoadCertificateAuthorities(r.caPaths)
-	if len(errs) > 0 {
-		r.log.Warnf("CA reload failed for %d/%d CA(s), keeping previous pool: %v", len(errs), len(r.caPaths), errs)
+	if len(errs) == len(r.caPaths) {
+		r.log.Warnf("CA reload failed for all %d CA(s), keeping previous pool: %v", len(r.caPaths), errs)
 		return r.pool
+	}
+	if len(errs) > 0 {
+		r.log.Warnf("CA reload: %d/%d CA(s) failed to load, continuing with the ones that succeeded: %v", len(errs), len(r.caPaths), errs)
 	}
 
 	for _, cert := range r.trustedFingerprintCerts {

--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -76,7 +76,9 @@ func NewCAReloader(caPaths []string, reloadInterval time.Duration) (*CAReloader,
 }
 
 // GetCertPool returns the current CA certificate pool, reloading from disk if
-// the reload interval has elapsed. It is safe for concurrent use.
+// the reload interval has elapsed. The returned pool is a snapshot: callers
+// should not cache it across handshakes but instead call GetCertPool each time
+// to pick up reloaded CAs. It is safe for concurrent use.
 func (r *CAReloader) GetCertPool() *x509.CertPool {
 	r.mu.RLock()
 	if time.Now().Before(r.nextReload) {

--- a/transport/tlscommon/ca_reloader_test.go
+++ b/transport/tlscommon/ca_reloader_test.go
@@ -1,0 +1,151 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package tlscommon
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/testing/certutil"
+)
+
+func writeCAFile(t *testing.T, dir, name string) string {
+	t.Helper()
+	_, _, pair, err := certutil.NewRootCA()
+	require.NoError(t, err)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, pair.Cert, 0o600))
+	return path
+}
+
+func TestNewCAReloader_ValidCA(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 5*time.Second)
+	require.NoError(t, err)
+
+	pool := r.GetCertPool()
+	require.NotNil(t, pool)
+}
+
+func TestNewCAReloader_InvalidCA(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.pem")
+	require.NoError(t, os.WriteFile(path, []byte("not a cert"), 0o600))
+
+	_, err := NewCAReloader([]string{path}, 5*time.Second)
+	assert.Error(t, err)
+}
+
+func TestNewCAReloader_MissingFile(t *testing.T) {
+	_, err := NewCAReloader([]string{"/nonexistent/ca.pem"}, 5*time.Second)
+	assert.Error(t, err)
+}
+
+func TestNewCAReloader_EmptyPaths(t *testing.T) {
+	_, err := NewCAReloader([]string{}, 5*time.Second)
+	assert.Error(t, err)
+}
+
+func TestCAReloader_ReloadsAfterInterval(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	initialPool := r.GetCertPool()
+	require.NotNil(t, initialPool)
+
+	// Overwrite with a new CA.
+	writeCAFile(t, dir, "ca.pem")
+
+	// After the reload interval, GetCertPool should return a pool built
+	// from the new CA file.
+	require.Eventually(t, func() bool {
+		pool := r.GetCertPool()
+		return !pool.Equal(initialPool)
+	}, 2*time.Second, 50*time.Millisecond, "CA pool should have been reloaded")
+}
+
+func TestCAReloader_InvalidNewCA_KeepsOld(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	initialPool := r.GetCertPool()
+	require.NotNil(t, initialPool)
+
+	// Overwrite with invalid data.
+	require.NoError(t, os.WriteFile(caPath, []byte("not a cert"), 0o600))
+
+	// The old pool should be preserved.
+	require.Never(t, func() bool {
+		pool := r.GetCertPool()
+		return pool == nil
+	}, 500*time.Millisecond, 50*time.Millisecond, "pool should not become nil after invalid reload")
+}
+
+func TestCAReloader_NoReloadBeforeInterval(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 1*time.Hour)
+	require.NoError(t, err)
+
+	initialPool := r.GetCertPool()
+
+	// Replace the CA file.
+	writeCAFile(t, dir, "ca.pem")
+
+	// Should still return the original pool since interval hasn't elapsed.
+	pool := r.GetCertPool()
+	assert.True(t, pool.Equal(initialPool))
+}
+
+func TestCAReloader_InlinePEM(t *testing.T) {
+	_, _, pair, err := certutil.NewRootCA()
+	require.NoError(t, err)
+
+	// Pass the PEM directly as an inline string (starts with "-").
+	r, err := NewCAReloader([]string{string(pair.Cert)}, 5*time.Second)
+	require.NoError(t, err)
+
+	pool := r.GetCertPool()
+	require.NotNil(t, pool)
+
+	// Verify the pool contains the CA.
+	block, _ := pem.Decode(pair.Cert)
+	require.NotNil(t, block)
+	ca, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	chains, err := ca.Verify(x509.VerifyOptions{Roots: pool})
+	require.NoError(t, err)
+	assert.NotEmpty(t, chains)
+}

--- a/transport/tlscommon/ca_reloader_test.go
+++ b/transport/tlscommon/ca_reloader_test.go
@@ -111,6 +111,23 @@ func TestCAReloader_InvalidNewCA_KeepsOld(t *testing.T) {
 	}, 500*time.Millisecond, 50*time.Millisecond, "pool should not become nil after invalid reload")
 }
 
+func TestCAReloader_NoReloadBeforeInterval(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 1*time.Hour)
+	require.NoError(t, err)
+
+	initialPool := r.GetCertPool()
+
+	// Replace the CA file.
+	writeCAFile(t, dir, "ca.pem")
+
+	// Should still return the original pool since interval hasn't elapsed.
+	pool := r.GetCertPool()
+	assert.True(t, pool.Equal(initialPool))
+}
+
 func TestCAReloader_PartialReloadFailure_KeepsOldPool(t *testing.T) {
 	dir := t.TempDir()
 	caPath1 := writeCAFile(t, dir, "ca1.pem")
@@ -133,21 +150,60 @@ func TestCAReloader_PartialReloadFailure_KeepsOldPool(t *testing.T) {
 		"pool should not change when one CA fails to reload")
 }
 
-func TestCAReloader_NoReloadBeforeInterval(t *testing.T) {
+func TestCAReloader_AddTrustedCert_SurvivesReload(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	// Generate a separate CA cert and add it via AddTrustedCert.
+	_, _, pair, err := certutil.NewRootCA()
+	require.NoError(t, err)
+	block, _ := pem.Decode(pair.Cert)
+	require.NotNil(t, block)
+	extraCA, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
+
+	r.AddTrustedCert(extraCA)
+
+	// Verify it's in the pool now.
+	pool := r.GetCertPool()
+	_, err = extraCA.Verify(x509.VerifyOptions{Roots: pool})
+	require.NoError(t, err, "trusted fingerprint cert should be in the pool before reload")
+
+	// Trigger a reload by writing a new CA to the file and waiting.
+	writeCAFile(t, dir, "ca.pem")
+	require.Eventually(t, func() bool {
+		pool = r.GetCertPool()
+		_, err = extraCA.Verify(x509.VerifyOptions{Roots: pool})
+		return err == nil
+	}, 2*time.Second, 50*time.Millisecond,
+		"trusted fingerprint cert should survive CA reload")
+}
+
+func TestCAReloader_AddTrustedCert_Deduplicates(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
 	r, err := NewCAReloader([]string{caPath}, 1*time.Hour)
 	require.NoError(t, err)
 
-	initialPool := r.GetCertPool()
+	_, _, pair, err := certutil.NewRootCA()
+	require.NoError(t, err)
+	block, _ := pem.Decode(pair.Cert)
+	require.NotNil(t, block)
+	extraCA, err := x509.ParseCertificate(block.Bytes)
+	require.NoError(t, err)
 
-	// Replace the CA file.
-	writeCAFile(t, dir, "ca.pem")
+	r.AddTrustedCert(extraCA)
+	r.AddTrustedCert(extraCA)
+	r.AddTrustedCert(extraCA)
 
-	// Should still return the original pool since interval hasn't elapsed.
-	pool := r.GetCertPool()
-	assert.True(t, pool.Equal(initialPool))
+	r.mu.RLock()
+	count := len(r.trustedFingerprintCerts)
+	r.mu.RUnlock()
+	assert.Equal(t, 1, count, "duplicate certs should not be added")
 }
 
 func TestCAReloader_InlinePEM(t *testing.T) {

--- a/transport/tlscommon/ca_reloader_test.go
+++ b/transport/tlscommon/ca_reloader_test.go
@@ -111,6 +111,28 @@ func TestCAReloader_InvalidNewCA_KeepsOld(t *testing.T) {
 	}, 500*time.Millisecond, 50*time.Millisecond, "pool should not become nil after invalid reload")
 }
 
+func TestCAReloader_PartialReloadFailure_KeepsOldPool(t *testing.T) {
+	dir := t.TempDir()
+	caPath1 := writeCAFile(t, dir, "ca1.pem")
+	caPath2 := writeCAFile(t, dir, "ca2.pem")
+
+	r, err := NewCAReloader([]string{caPath1, caPath2}, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	initialPool := r.GetCertPool()
+	require.NotNil(t, initialPool)
+
+	// Corrupt one CA file; the other stays valid.
+	require.NoError(t, os.WriteFile(caPath2, []byte("not a cert"), 0o600))
+
+	// The old pool (with both CAs) should be preserved.
+	require.Never(t, func() bool {
+		pool := r.GetCertPool()
+		return !pool.Equal(initialPool)
+	}, 500*time.Millisecond, 50*time.Millisecond,
+		"pool should not change when one CA fails to reload")
+}
+
 func TestCAReloader_NoReloadBeforeInterval(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")

--- a/transport/tlscommon/ca_reloader_test.go
+++ b/transport/tlscommon/ca_reloader_test.go
@@ -128,7 +128,7 @@ func TestCAReloader_NoReloadBeforeInterval(t *testing.T) {
 	assert.True(t, pool.Equal(initialPool))
 }
 
-func TestCAReloader_PartialReloadFailure_KeepsOldPool(t *testing.T) {
+func TestCAReloader_PartialReloadFailure_UsesSuccessfulCAs(t *testing.T) {
 	dir := t.TempDir()
 	caPath1 := writeCAFile(t, dir, "ca1.pem")
 	caPath2 := writeCAFile(t, dir, "ca2.pem")
@@ -142,12 +142,33 @@ func TestCAReloader_PartialReloadFailure_KeepsOldPool(t *testing.T) {
 	// Corrupt one CA file; the other stays valid.
 	require.NoError(t, os.WriteFile(caPath2, []byte("not a cert"), 0o600))
 
-	// The old pool (with both CAs) should be preserved.
+	// The pool should update to contain only the successful CA.
+	require.Eventually(t, func() bool {
+		pool := r.GetCertPool()
+		return pool != nil && !pool.Equal(initialPool)
+	}, 2*time.Second, 50*time.Millisecond,
+		"pool should update with the CAs that loaded successfully")
+}
+
+func TestCAReloader_TotalReloadFailure_KeepsOldPool(t *testing.T) {
+	dir := t.TempDir()
+	caPath := writeCAFile(t, dir, "ca.pem")
+
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	require.NoError(t, err)
+
+	initialPool := r.GetCertPool()
+	require.NotNil(t, initialPool)
+
+	// Corrupt the only CA file so all paths fail.
+	require.NoError(t, os.WriteFile(caPath, []byte("not a cert"), 0o600))
+
+	// The old pool should be preserved since all CAs failed.
 	require.Never(t, func() bool {
 		pool := r.GetCertPool()
 		return !pool.Equal(initialPool)
 	}, 500*time.Millisecond, 50*time.Millisecond,
-		"pool should not change when one CA fails to reload")
+		"pool should not change when all CAs fail to reload")
 }
 
 func TestCAReloader_AddTrustedCert_SurvivesReload(t *testing.T) {

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -19,7 +19,6 @@ package tlscommon
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -63,17 +62,23 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		curves[idx] = tls.CurveID(id)
 	}
 
-	var cas *x509.CertPool
-	var caReloader *CAReloader
+	var rootCAs certPoolProvider
 
 	if len(config.CAs) > 0 && config.CertificateReload.IsEnabled() {
-		var err error
-		caReloader, err = NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
+		reloader, err := NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
 		logFail(err)
-	} else {
-		var errs []error
-		cas, errs = LoadCertificateAuthorities(config.CAs)
+		if reloader != nil {
+			rootCAs = reloader
+		}
+	} else if len(config.CAs) > 0 {
+		pool, errs := LoadCertificateAuthorities(config.CAs)
 		logFail(errs...)
+		rootCAs = newStaticCertPool(pool)
+	}
+	if rootCAs == nil && config.CATrustedFingerprint != "" {
+		// Pre-allocate an empty pool so trustRootCA can add fingerprint-matched
+		// certs without a nil dereference on concurrent handshakes.
+		rootCAs = newStaticCertPool(nil)
 	}
 
 	var certs []tls.Certificate
@@ -107,7 +112,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		Versions:             config.Versions,
 		Verification:         config.VerificationMode,
 		Certificates:         certs,
-		rootCAs:              cas,
+		rootCAs:              rootCAs,
 		CipherSuites:         config.CipherSuites,
 		CurvePreferences:     curves,
 		Renegotiation:        tls.RenegotiationSupport(config.Renegotiation),
@@ -115,7 +120,6 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		CATrustedFingerprint: config.CATrustedFingerprint,
 		Logger:               logger,
 		certReloader:         reloader,
-		caReloader:           caReloader,
 	}, nil
 }
 

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -70,9 +70,6 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		var err error
 		caReloader, err = NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
 		logFail(err)
-		if caReloader != nil {
-			cas = caReloader.GetCertPool()
-		}
 	} else {
 		var errs []error
 		cas, errs = LoadCertificateAuthorities(config.CAs)

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -19,6 +19,7 @@ package tlscommon
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -62,8 +63,21 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		curves[idx] = tls.CurveID(id)
 	}
 
-	cas, errs := LoadCertificateAuthorities(config.CAs)
-	logFail(errs...)
+	var cas *x509.CertPool
+	var caReloader *CAReloader
+
+	if len(config.CAs) > 0 && config.CertificateReload.IsEnabled() {
+		var err error
+		caReloader, err = NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
+		logFail(err)
+		if caReloader != nil {
+			cas = caReloader.GetCertPool()
+		}
+	} else {
+		var errs []error
+		cas, errs = LoadCertificateAuthorities(config.CAs)
+		logFail(errs...)
+	}
 
 	var certs []tls.Certificate
 	var reloader *CertReloader
@@ -96,7 +110,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		Versions:             config.Versions,
 		Verification:         config.VerificationMode,
 		Certificates:         certs,
-		RootCAs:              cas,
+		rootCAs:              cas,
 		CipherSuites:         config.CipherSuites,
 		CurvePreferences:     curves,
 		Renegotiation:        tls.RenegotiationSupport(config.Renegotiation),
@@ -104,6 +118,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		CATrustedFingerprint: config.CATrustedFingerprint,
 		Logger:               logger,
 		certReloader:         reloader,
+		caReloader:           caReloader,
 	}, nil
 }
 

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -19,6 +19,7 @@ package tlscommon
 
 import (
 	"crypto/tls"
+	"crypto/x509"
 	"errors"
 	"fmt"
 	"time"
@@ -90,8 +91,21 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		curves[idx] = tls.CurveID(id)
 	}
 
-	cas, errs := LoadCertificateAuthorities(config.CAs)
-	logFail(errs...)
+	var cas *x509.CertPool
+	var caReloader *CAReloader
+
+	if len(config.CAs) > 0 && config.CertificateReload.IsEnabled() {
+		var err error
+		caReloader, err = NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
+		logFail(err)
+		if caReloader != nil {
+			cas = caReloader.GetCertPool()
+		}
+	} else {
+		var errs []error
+		cas, errs = LoadCertificateAuthorities(config.CAs)
+		logFail(errs...)
+	}
 
 	var certs []tls.Certificate
 	var reloader *CertReloader
@@ -129,13 +143,14 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		Versions:         config.Versions,
 		Verification:     config.VerificationMode,
 		Certificates:     certs,
-		ClientCAs:        cas,
+		clientCAs:        cas,
 		CipherSuites:     config.CipherSuites,
 		CurvePreferences: curves,
 		ClientAuth:       tls.ClientAuthType(clientAuth),
 		CASha256:         config.CASha256,
 		Logger:           logger,
 		certReloader:     reloader,
+		caReloader:       caReloader,
 	}, nil
 }
 

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -98,9 +98,6 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		var err error
 		caReloader, err = NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
 		logFail(err)
-		if caReloader != nil {
-			cas = caReloader.GetCertPool()
-		}
 	} else {
 		var errs []error
 		cas, errs = LoadCertificateAuthorities(config.CAs)

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -19,7 +19,6 @@ package tlscommon
 
 import (
 	"crypto/tls"
-	"crypto/x509"
 	"errors"
 	"fmt"
 	"time"
@@ -91,17 +90,18 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		curves[idx] = tls.CurveID(id)
 	}
 
-	var cas *x509.CertPool
-	var caReloader *CAReloader
+	var clientCAs certPoolProvider
 
 	if len(config.CAs) > 0 && config.CertificateReload.IsEnabled() {
-		var err error
-		caReloader, err = NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
+		reloader, err := NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
 		logFail(err)
-	} else {
-		var errs []error
-		cas, errs = LoadCertificateAuthorities(config.CAs)
+		if reloader != nil {
+			clientCAs = reloader
+		}
+	} else if len(config.CAs) > 0 {
+		pool, errs := LoadCertificateAuthorities(config.CAs)
 		logFail(errs...)
+		clientCAs = newStaticCertPool(pool)
 	}
 
 	var certs []tls.Certificate
@@ -140,14 +140,13 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		Versions:         config.Versions,
 		Verification:     config.VerificationMode,
 		Certificates:     certs,
-		clientCAs:        cas,
+		clientCAs:        clientCAs,
 		CipherSuites:     config.CipherSuites,
 		CurvePreferences: curves,
 		ClientAuth:       tls.ClientAuthType(clientAuth),
 		CASha256:         config.CASha256,
 		Logger:           logger,
 		certReloader:     reloader,
-		caReloader:       caReloader,
 	}, nil
 }
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -32,6 +32,43 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
+// certPoolProvider abstracts over static and dynamically-reloaded CA pools.
+// CAReloader implements this interface for the dynamic case; staticCertPool
+// implements it for the static case.
+type certPoolProvider interface {
+	GetCertPool() *x509.CertPool
+	AddTrustedCert(cert *x509.Certificate)
+	IsDynamic() bool
+}
+
+// staticCertPool is a certPoolProvider backed by a fixed *x509.CertPool.
+// It is safe for concurrent use.
+type staticCertPool struct {
+	mu   sync.Mutex
+	pool *x509.CertPool
+}
+
+func newStaticCertPool(pool *x509.CertPool) *staticCertPool {
+	return &staticCertPool{pool: pool}
+}
+
+func (s *staticCertPool) GetCertPool() *x509.CertPool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.pool
+}
+
+func (s *staticCertPool) AddTrustedCert(cert *x509.Certificate) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.pool == nil {
+		s.pool = x509.NewCertPool()
+	}
+	s.pool.AddCert(cert)
+}
+
+func (s *staticCertPool) IsDynamic() bool { return false }
+
 // TLSConfig is the interface used to configure a tcp client or server from a `Config`
 type TLSConfig struct {
 
@@ -47,17 +84,13 @@ type TLSConfig struct {
 	// connection.
 	Certificates []tls.Certificate
 
-	// rootCAsMu protects rootCAs against concurrent writes from trustRootCA
-	// during parallel TLS handshakes.
-	rootCAsMu sync.Mutex
+	// rootCAs provides the CA pool for verifying server certificates.
+	// nil means use the system pool. Use currentRootCAs() to access.
+	rootCAs certPoolProvider
 
-	// rootCAs holds the root certificate authorities used to verify server
-	// certificates. Access via currentRootCAs() to support dynamic reloading.
-	rootCAs *x509.CertPool
-
-	// clientCAs holds the root certificate authorities used to verify client
-	// certificates. Access via currentClientCAs() to support dynamic reloading.
-	clientCAs *x509.CertPool
+	// clientCAs provides the CA pool for verifying client certificates.
+	// nil means use the system pool. Use currentClientCAs() to access.
+	clientCAs certPoolProvider
 
 	// List of supported cipher suites. If nil, a default list provided by the
 	// implementation will be used.
@@ -97,10 +130,6 @@ type TLSConfig struct {
 	// the resulting tls.Config instead of populating Certificates statically.
 	certReloader *CertReloader
 
-	// caReloader, when set, provides dynamic CA certificate reloading from
-	// disk. The VerifyConnection callback will call caReloader.GetCertPool()
-	// on each handshake instead of using the static RootCAs/ClientCAs pool.
-	caReloader *CAReloader
 }
 
 var (
@@ -108,19 +137,17 @@ var (
 )
 
 func (c *TLSConfig) currentRootCAs() *x509.CertPool {
-	if c.caReloader != nil {
-		return c.caReloader.GetCertPool()
+	if c.rootCAs == nil {
+		return nil
 	}
-	c.rootCAsMu.Lock()
-	defer c.rootCAsMu.Unlock()
-	return c.rootCAs
+	return c.rootCAs.GetCertPool()
 }
 
 func (c *TLSConfig) currentClientCAs() *x509.CertPool {
-	if c.caReloader != nil {
-		return c.caReloader.GetCertPool()
+	if c.clientCAs == nil {
+		return nil
 	}
-	return c.clientCAs
+	return c.clientCAs.GetCertPool()
 }
 
 type tlsOptFunc func(t *TLSSettings)
@@ -153,7 +180,8 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 
 	minVersion, maxVersion := extractMinMaxVersion(c.Versions)
 
-	insecure := c.Verification != VerifyStrict || c.caReloader != nil
+	dynamic := (c.rootCAs != nil && c.rootCAs.IsDynamic()) || (c.clientCAs != nil && c.clientCAs.IsDynamic())
+	insecure := c.Verification != VerifyStrict || dynamic
 	if c.Verification == VerifyNone {
 		c.Logger.Named("tls").Warn("SSL/TLS verifications disabled.")
 	}
@@ -162,8 +190,8 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		MinVersion:         minVersion,
 		MaxVersion:         maxVersion,
 		Certificates:       c.Certificates,
-		RootCAs:            c.rootCAs,
-		ClientCAs:          c.clientCAs,
+		RootCAs:            c.currentRootCAs(),
+		ClientCAs:          c.currentClientCAs(),
 		InsecureSkipVerify: insecure, //nolint:gosec // we are using our own verification for now
 		CipherSuites:       convCipherSuites(c.CipherSuites),
 		CurvePreferences:   c.CurvePreferences,
@@ -272,18 +300,7 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Log
 		}
 
 		logger.Debug("CA certificate matching 'ca_trusted_fingerprint' found, adding it to 'certificate_authorities'")
-		if cfg.caReloader != nil {
-			cfg.caReloader.AddTrustedCert(cert)
-		} else {
-			cfg.rootCAsMu.Lock()
-			pool := cfg.rootCAs
-			if pool == nil {
-				pool = x509.NewCertPool()
-				cfg.rootCAs = pool
-			}
-			pool.AddCert(cert)
-			cfg.rootCAsMu.Unlock()
-		}
+		cfg.rootCAs.AddTrustedCert(cert)
 		return nil
 	}
 
@@ -352,8 +369,8 @@ func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.Connecti
 		// Cert is trusted by CA
 		// Hostname or IP matches the certificate
 		// Returns error if SNA is empty
-		if cfg.caReloader != nil {
-			// When caReloader is active, InsecureSkipVerify is true so Go's
+		if cfg.rootCAs != nil && cfg.rootCAs.IsDynamic() {
+			// When rootCAs is dynamic, InsecureSkipVerify is true so Go's
 			// stdlib won't validate the chain. Do full strict verification
 			// manually using the dynamically reloaded CA pool.
 			return func(cs tls.ConnectionState) error {
@@ -416,7 +433,7 @@ func makeVerifyServerConnection(cfg *TLSConfig) func(tls.ConnectionState) error 
 			return verifyCertsWithOpts(cs.PeerCertificates, cfg.CASha256, opts)
 		}
 	case VerifyStrict:
-		if cfg.caReloader != nil {
+		if cfg.clientCAs != nil && cfg.clientCAs.IsDynamic() {
 			return func(cs tls.ConnectionState) error {
 				if len(cs.PeerCertificates) == 0 {
 					if cfg.ClientAuth == tls.RequireAndVerifyClientCert {

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -129,7 +129,6 @@ type TLSConfig struct {
 	// ToConfig will use it to set GetCertificate and GetClientCertificate on
 	// the resulting tls.Config instead of populating Certificates statically.
 	certReloader *CertReloader
-
 }
 
 var (
@@ -175,7 +174,7 @@ func WithLogger(logger *logp.Logger) TLSOption {
 // By default VerifyConnection is set to client mode.
 func (c *TLSConfig) ToConfig() *tls.Config {
 	if c == nil {
-		return &tls.Config{} //nolint:gosec // empty TLS config
+		return &tls.Config{}
 	}
 
 	minVersion, maxVersion := extractMinMaxVersion(c.Versions)

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -146,7 +146,7 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 
 	minVersion, maxVersion := extractMinMaxVersion(c.Versions)
 
-	insecure := c.Verification != VerifyStrict
+	insecure := c.Verification != VerifyStrict || c.caReloader != nil
 	if c.Verification == VerifyNone {
 		c.Logger.Named("tls").Warn("SSL/TLS verifications disabled.")
 	}
@@ -340,9 +340,29 @@ func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.Connecti
 		// Cert is trusted by CA
 		// Hostname or IP matches the certificate
 		// Returns error if SNA is empty
-		// The whole validation is done by Go's standard library default
-		// SSL/TLS verification (tls.Config.InsecureSkipVerify is set to false)
-		// so we only need to check the pin
+		if cfg.caReloader != nil {
+			// When caReloader is active, InsecureSkipVerify is true so Go's
+			// stdlib won't validate the chain. Do full strict verification
+			// manually using the dynamically reloaded CA pool.
+			return func(cs tls.ConnectionState) error {
+				if cfg.CATrustedFingerprint != "" {
+					if err := trustRootCA(cfg, cs.PeerCertificates, logger); err != nil {
+						return err
+					}
+				}
+				if len(cs.PeerCertificates) == 0 {
+					return ErrMissingPeerCertificate
+				}
+				opts := x509.VerifyOptions{
+					Roots:         cfg.currentRootCAs(),
+					DNSName:       serverName,
+					Intermediates: x509.NewCertPool(),
+				}
+				return verifyCertsWithOpts(cs.PeerCertificates, cfg.CASha256, opts)
+			}
+		}
+		// Static CAs: Go's stdlib handles chain + hostname verification
+		// (InsecureSkipVerify is false). We only need a callback for CA pin checking.
 		if len(cfg.CASha256) > 0 {
 			return func(cs tls.ConnectionState) error {
 				if cfg.CATrustedFingerprint != "" {
@@ -384,6 +404,22 @@ func makeVerifyServerConnection(cfg *TLSConfig) func(tls.ConnectionState) error 
 			return verifyCertsWithOpts(cs.PeerCertificates, cfg.CASha256, opts)
 		}
 	case VerifyStrict:
+		if cfg.caReloader != nil {
+			return func(cs tls.ConnectionState) error {
+				if len(cs.PeerCertificates) == 0 {
+					if cfg.ClientAuth == tls.RequireAndVerifyClientCert {
+						return ErrMissingPeerCertificate
+					}
+					return nil
+				}
+				opts := x509.VerifyOptions{
+					Roots:         cfg.currentClientCAs(),
+					Intermediates: x509.NewCertPool(),
+					KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+				}
+				return verifyCertsWithOpts(cs.PeerCertificates, cfg.CASha256, opts)
+			}
+		}
 		if len(cfg.CASha256) > 0 {
 			return func(cs tls.ConnectionState) error {
 				return verifyCAPin(cfg.CASha256, cs.VerifiedChains)

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -26,6 +26,7 @@ import (
 	"errors"
 	"fmt"
 	"net"
+	"sync"
 	"time"
 
 	"github.com/elastic/elastic-agent-libs/logp"
@@ -45,6 +46,10 @@ type TLSConfig struct {
 	// List of certificate chains to present to the other side of the
 	// connection.
 	Certificates []tls.Certificate
+
+	// rootCAsMu protects rootCAs against concurrent writes from trustRootCA
+	// during parallel TLS handshakes.
+	rootCAsMu sync.Mutex
 
 	// rootCAs holds the root certificate authorities used to verify server
 	// certificates. Access via currentRootCAs() to support dynamic reloading.
@@ -106,6 +111,8 @@ func (c *TLSConfig) currentRootCAs() *x509.CertPool {
 	if c.caReloader != nil {
 		return c.caReloader.GetCertPool()
 	}
+	c.rootCAsMu.Lock()
+	defer c.rootCAsMu.Unlock()
 	return c.rootCAs
 }
 
@@ -268,12 +275,14 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Log
 		if cfg.caReloader != nil {
 			cfg.caReloader.AddTrustedCert(cert)
 		} else {
-			pool := cfg.currentRootCAs()
+			cfg.rootCAsMu.Lock()
+			pool := cfg.rootCAs
 			if pool == nil {
 				pool = x509.NewCertPool()
 				cfg.rootCAs = pool
 			}
 			pool.AddCert(cert)
+			cfg.rootCAsMu.Unlock()
 		}
 		return nil
 	}

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -265,13 +265,16 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Log
 		}
 
 		logger.Debug("CA certificate matching 'ca_trusted_fingerprint' found, adding it to 'certificate_authorities'")
-		pool := cfg.currentRootCAs()
-		if pool == nil {
-			pool = x509.NewCertPool()
-			cfg.rootCAs = pool
+		if cfg.caReloader != nil {
+			cfg.caReloader.AddTrustedCert(cert)
+		} else {
+			pool := cfg.currentRootCAs()
+			if pool == nil {
+				pool = x509.NewCertPool()
+				cfg.rootCAs = pool
+			}
+			pool.AddCert(cert)
 		}
-
-		pool.AddCert(cert)
 		return nil
 	}
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -265,11 +265,13 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Log
 		}
 
 		logger.Debug("CA certificate matching 'ca_trusted_fingerprint' found, adding it to 'certificate_authorities'")
-		if cfg.rootCAs == nil {
-			cfg.rootCAs = x509.NewCertPool()
+		pool := cfg.currentRootCAs()
+		if pool == nil {
+			pool = x509.NewCertPool()
+			cfg.rootCAs = pool
 		}
 
-		cfg.rootCAs.AddCert(cert)
+		pool.AddCert(cert)
 		return nil
 	}
 

--- a/transport/tlscommon/tls_config.go
+++ b/transport/tlscommon/tls_config.go
@@ -46,15 +46,13 @@ type TLSConfig struct {
 	// connection.
 	Certificates []tls.Certificate
 
-	// Set of root certificate authorities use to verify server certificates.
-	// If RootCAs is nil, TLS might use the system its root CA set (not supported
-	// on MS Windows).
-	RootCAs *x509.CertPool
+	// rootCAs holds the root certificate authorities used to verify server
+	// certificates. Access via currentRootCAs() to support dynamic reloading.
+	rootCAs *x509.CertPool
 
-	// Set of root certificate authorities use to verify client certificates.
-	// If ClientCAs is nil, TLS might use the system its root CA set (not supported
-	// on MS Windows).
-	ClientCAs *x509.CertPool
+	// clientCAs holds the root certificate authorities used to verify client
+	// certificates. Access via currentClientCAs() to support dynamic reloading.
+	clientCAs *x509.CertPool
 
 	// List of supported cipher suites. If nil, a default list provided by the
 	// implementation will be used.
@@ -93,11 +91,30 @@ type TLSConfig struct {
 	// ToConfig will use it to set GetCertificate and GetClientCertificate on
 	// the resulting tls.Config instead of populating Certificates statically.
 	certReloader *CertReloader
+
+	// caReloader, when set, provides dynamic CA certificate reloading from
+	// disk. The VerifyConnection callback will call caReloader.GetCertPool()
+	// on each handshake instead of using the static RootCAs/ClientCAs pool.
+	caReloader *CAReloader
 }
 
 var (
 	ErrMissingPeerCertificate = errors.New("missing peer certificates")
 )
+
+func (c *TLSConfig) currentRootCAs() *x509.CertPool {
+	if c.caReloader != nil {
+		return c.caReloader.GetCertPool()
+	}
+	return c.rootCAs
+}
+
+func (c *TLSConfig) currentClientCAs() *x509.CertPool {
+	if c.caReloader != nil {
+		return c.caReloader.GetCertPool()
+	}
+	return c.clientCAs
+}
 
 type tlsOptFunc func(t *TLSSettings)
 
@@ -138,8 +155,8 @@ func (c *TLSConfig) ToConfig() *tls.Config {
 		MinVersion:         minVersion,
 		MaxVersion:         maxVersion,
 		Certificates:       c.Certificates,
-		RootCAs:            c.RootCAs,
-		ClientCAs:          c.ClientCAs,
+		RootCAs:            c.rootCAs,
+		ClientCAs:          c.clientCAs,
 		InsecureSkipVerify: insecure, //nolint:gosec // we are using our own verification for now
 		CipherSuites:       convCipherSuites(c.CipherSuites),
 		CurvePreferences:   c.CurvePreferences,
@@ -248,11 +265,11 @@ func trustRootCA(cfg *TLSConfig, peerCerts []*x509.Certificate, logger *logp.Log
 		}
 
 		logger.Debug("CA certificate matching 'ca_trusted_fingerprint' found, adding it to 'certificate_authorities'")
-		if cfg.RootCAs == nil {
-			cfg.RootCAs = x509.NewCertPool()
+		if cfg.rootCAs == nil {
+			cfg.rootCAs = x509.NewCertPool()
 		}
 
-		cfg.RootCAs.AddCert(cert)
+		cfg.rootCAs.AddCert(cert)
 		return nil
 	}
 
@@ -286,7 +303,7 @@ func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.Connecti
 			}
 
 			opts := x509.VerifyOptions{
-				Roots:         cfg.RootCAs,
+				Roots:         cfg.currentRootCAs(),
 				Intermediates: x509.NewCertPool(),
 			}
 			err := verifyCertsWithOpts(cs.PeerCertificates, cfg.CASha256, opts)
@@ -312,7 +329,7 @@ func makeVerifyConnection(cfg *TLSConfig, logger *logp.Logger) func(tls.Connecti
 			}
 
 			opts := x509.VerifyOptions{
-				Roots:         cfg.RootCAs,
+				Roots:         cfg.currentRootCAs(),
 				Intermediates: x509.NewCertPool(),
 			}
 			return verifyCertsWithOpts(cs.PeerCertificates, cfg.CASha256, opts)
@@ -358,7 +375,7 @@ func makeVerifyServerConnection(cfg *TLSConfig) func(tls.ConnectionState) error 
 			}
 
 			opts := x509.VerifyOptions{
-				Roots:         cfg.ClientCAs,
+				Roots:         cfg.currentClientCAs(),
 				Intermediates: x509.NewCertPool(),
 				KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
 			}

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -22,11 +22,15 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/hex"
+	"encoding/pem"
 	"errors"
 	"net"
 	"net/http"
 	"net/url"
+	"os"
+	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -314,6 +318,38 @@ func TestTrustRootCA(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestTrustRootCA_WithCAReloader(t *testing.T) {
+	certs := tlscommontest.GenTestCerts(t)
+	cafingerprint := tlscommontest.GetCertFingerprint(certs["ca"])
+
+	dir := t.TempDir()
+	caPath := filepath.Join(dir, "ca.pem")
+	require.NoError(t, os.WriteFile(caPath, pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: certs["ca"].Raw,
+	}), 0o600))
+
+	reloader, err := NewCAReloader([]string{caPath}, 1*time.Hour)
+	require.NoError(t, err)
+
+	cfg := TLSConfig{
+		CATrustedFingerprint: cafingerprint,
+		caReloader:           reloader,
+	}
+
+	logger := logptest.NewTestingLogger(t, "")
+	err = trustRootCA(&cfg, []*x509.Certificate{certs["correct"], certs["ca"]}, logger)
+	require.NoError(t, err)
+
+	// The CA should be in the reloader's pool.
+	pool := reloader.GetCertPool()
+	_, err = certs["ca"].Verify(x509.VerifyOptions{Roots: pool})
+	assert.NoError(t, err, "trusted CA should be verifiable through the reloader pool")
+
+	// rootCAs on the config should remain nil since the reloader handles it.
+	assert.Nil(t, cfg.rootCAs, "rootCAs should remain nil when caReloader is set")
 }
 
 func TestMakeVerifyConnectionUsesCATrustedFingerprint(t *testing.T) {

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -165,7 +165,7 @@ func TestMakeVerifyServerConnection(t *testing.T) {
 			cfg := &TLSConfig{
 				Verification: test.verificationMode,
 				ClientAuth:   test.clientAuth,
-				ClientCAs:    test.certAuthorities,
+				clientCAs:    test.certAuthorities,
 			}
 
 			verifier := makeVerifyServerConnection(cfg)
@@ -261,7 +261,7 @@ func TestTrustRootCA(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := TLSConfig{
-				RootCAs:              tc.rootCAs,
+				rootCAs:              tc.rootCAs,
 				CATrustedFingerprint: tc.caTrustedFingerprint,
 			}
 
@@ -297,18 +297,18 @@ func TestTrustRootCA(t *testing.T) {
 			}
 
 			if tc.expectedRootCAsLen == 0 {
-				if cfg.RootCAs != nil {
+				if cfg.rootCAs != nil {
 					t.Fatal("cfg.RootCAs should be nil")
 				}
 			} else {
-				if cfg.RootCAs == nil {
+				if cfg.rootCAs == nil {
 					t.Fatal("cfg.RootCAs should not be nil")
 				}
 
 				// we want to know the number of certificates in the CertPool (RootCAs), as it is not
 				// directly available, we use this workaround of reading the number of subjects in the pool.
 				//nolint:staticcheck // we do not expect the system root CAs.
-				if got, expected := len(cfg.RootCAs.Subjects()), tc.expectedRootCAsLen; got != expected {
+				if got, expected := len(cfg.rootCAs.Subjects()), tc.expectedRootCAsLen; got != expected {
 					t.Fatalf("expecting cfg.RootCAs to have %d element, got %d instead", expected, got)
 				}
 			}
@@ -472,7 +472,7 @@ func TestMakeVerifyServerConnectionForIPs(t *testing.T) {
 			}
 
 			cfg := &TLSConfig{
-				RootCAs:      rootCAs,
+				rootCAs:      rootCAs,
 				Verification: test.verificationMode,
 				ServerName:   test.serverName,
 			}
@@ -649,13 +649,13 @@ func TestVerificationMode(t *testing.T) {
 
 			tlsC := TLSConfig{
 				Verification: test.verificationMode,
-				RootCAs:      certPool,
+				rootCAs:      certPool,
 				ServerName:   test.hostname,
 				Logger:       logptest.NewTestingLogger(t, ""),
 			}
 
 			if test.ignoreCerts {
-				tlsC.RootCAs = nil
+				tlsC.rootCAs = nil
 				tlsC.ServerName = ""
 			}
 

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -745,7 +745,7 @@ func TestVerificationMode(t *testing.T) {
 // The HTTP server will shutdown at the end of the test.
 func startTestServer(t *testing.T, serverAddr string, serverCerts []tls.Certificate) url.URL {
 	// Creates a listener on a random port selected by the OS
-	l, err := net.Listen("tcp", "localhost:0")
+	l, err := net.Listen("tcp", "localhost:0") //nolint:noctx // testing
 	if err != nil {
 		t.Fatalf("could call net.Listen: %s", err)
 	}

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -166,10 +166,14 @@ func TestMakeVerifyServerConnection(t *testing.T) {
 
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
+			var clientCAs certPoolProvider
+			if test.certAuthorities != nil {
+				clientCAs = newStaticCertPool(test.certAuthorities)
+			}
 			cfg := &TLSConfig{
 				Verification: test.verificationMode,
 				ClientAuth:   test.clientAuth,
-				clientCAs:    test.certAuthorities,
+				clientCAs:    clientCAs,
 			}
 
 			verifier := makeVerifyServerConnection(cfg)
@@ -265,7 +269,7 @@ func TestTrustRootCA(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			cfg := TLSConfig{
-				rootCAs:              tc.rootCAs,
+				rootCAs:              newStaticCertPool(tc.rootCAs),
 				CATrustedFingerprint: tc.caTrustedFingerprint,
 			}
 
@@ -300,19 +304,18 @@ func TestTrustRootCA(t *testing.T) {
 				}
 			}
 
+			pool := cfg.rootCAs.GetCertPool()
 			if tc.expectedRootCAsLen == 0 {
-				if cfg.rootCAs != nil {
-					t.Fatal("cfg.RootCAs should be nil")
+				//nolint:staticcheck // we do not expect the system root CAs.
+				if pool != nil && len(pool.Subjects()) > 0 {
+					t.Fatal("cfg.RootCAs pool should be empty")
 				}
 			} else {
-				if cfg.rootCAs == nil {
-					t.Fatal("cfg.RootCAs should not be nil")
+				if pool == nil {
+					t.Fatal("cfg.RootCAs pool should not be nil")
 				}
-
-				// we want to know the number of certificates in the CertPool (RootCAs), as it is not
-				// directly available, we use this workaround of reading the number of subjects in the pool.
 				//nolint:staticcheck // we do not expect the system root CAs.
-				if got, expected := len(cfg.rootCAs.Subjects()), tc.expectedRootCAsLen; got != expected {
+				if got, expected := len(pool.Subjects()), tc.expectedRootCAsLen; got != expected {
 					t.Fatalf("expecting cfg.RootCAs to have %d element, got %d instead", expected, got)
 				}
 			}
@@ -336,7 +339,7 @@ func TestTrustRootCA_WithCAReloader(t *testing.T) {
 
 	cfg := TLSConfig{
 		CATrustedFingerprint: cafingerprint,
-		caReloader:           reloader,
+		rootCAs:              reloader,
 	}
 
 	logger := logptest.NewTestingLogger(t, "")
@@ -347,9 +350,6 @@ func TestTrustRootCA_WithCAReloader(t *testing.T) {
 	pool := reloader.GetCertPool()
 	_, err = certs["ca"].Verify(x509.VerifyOptions{Roots: pool})
 	assert.NoError(t, err, "trusted CA should be verifiable through the reloader pool")
-
-	// rootCAs on the config should remain nil since the reloader handles it.
-	assert.Nil(t, cfg.rootCAs, "rootCAs should remain nil when caReloader is set")
 }
 
 func TestMakeVerifyConnectionUsesCATrustedFingerprint(t *testing.T) {
@@ -422,10 +422,17 @@ func TestMakeVerifyConnectionUsesCATrustedFingerprint(t *testing.T) {
 
 	for name, test := range testcases {
 		t.Run(name, func(t *testing.T) {
+			var rootCAs certPoolProvider
+			if test.CATrustedFingerprint != "" {
+				// Pre-allocate an empty pool so trustRootCA can add fingerprint-matched
+				// certs without a nil dereference.
+				rootCAs = newStaticCertPool(nil)
+			}
 			cfg := &TLSConfig{
 				Verification:         test.verificationMode,
 				CATrustedFingerprint: test.CATrustedFingerprint,
 				CASha256:             test.CASHA256,
+				rootCAs:              rootCAs,
 			}
 
 			verifier := makeVerifyConnection(cfg, logptest.NewTestingLogger(t, ""))
@@ -508,7 +515,7 @@ func TestMakeVerifyServerConnectionForIPs(t *testing.T) {
 			}
 
 			cfg := &TLSConfig{
-				rootCAs:      rootCAs,
+				rootCAs:      newStaticCertPool(rootCAs),
 				Verification: test.verificationMode,
 				ServerName:   test.serverName,
 			}
@@ -685,7 +692,7 @@ func TestVerificationMode(t *testing.T) {
 
 			tlsC := TLSConfig{
 				Verification: test.verificationMode,
-				rootCAs:      certPool,
+				rootCAs:      newStaticCertPool(certPool),
 				ServerName:   test.hostname,
 				Logger:       logptest.NewTestingLogger(t, ""),
 			}

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -139,10 +139,10 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
 	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
 	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
-	// When a dynamic CA provider is active, RootCAs is nil: Go ignores it (InsecureSkipVerify=true)
-	// and CA verification is done via VerifyConnection. With verification_mode=none,
-	// VerifyConnection is nil (no verification performed).
-	assert.Nil(t, cfg.RootCAs)
+	// RootCAs is populated from the provider's initial pool. Go ignores it when
+	// InsecureSkipVerify=true; CA verification is done via VerifyConnection instead.
+	// With verification_mode=none, VerifyConnection is nil (no verification performed).
+	assert.NotNil(t, cfg.RootCAs)
 	assert.Nil(t, cfg.VerifyConnection)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
@@ -201,9 +201,9 @@ key: mykey.pem
 		assert.NotNil(t, cfg)
 		// values not set by default
 		assert.Len(t, cfg.Certificates, 0)
-		// When a dynamic CA provider is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
-		// and CA verification is done via VerifyConnection.
-		assert.Nil(t, cfg.ClientCAs)
+		// ClientCAs is populated from the provider's initial pool. Go ignores it when
+		// InsecureSkipVerify=true; CA verification is done via VerifyConnection instead.
+		assert.NotNil(t, cfg.ClientCAs)
 		assert.NotNil(t, cfg.VerifyConnection, "expected VerifyConnection to enforce CA validation with dynamic CA provider")
 		assert.Len(t, cfg.CipherSuites, 0)
 		assert.Len(t, cfg.CurvePreferences, 0)
@@ -252,10 +252,10 @@ func TestApplyWithServerConfig(t *testing.T) {
 	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
 	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
 	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
-	// When a dynamic CA provider is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
-	// and CA verification is done via VerifyConnection. With verification_mode=none,
-	// VerifyConnection is nil (no verification performed).
-	assert.Nil(t, cfg.ClientCAs)
+	// ClientCAs is populated from the provider's initial pool. Go ignores it when
+	// InsecureSkipVerify=true; CA verification is done via VerifyConnection instead.
+	// With verification_mode=none, VerifyConnection is nil (no verification performed).
+	assert.NotNil(t, cfg.ClientCAs)
 	assert.Nil(t, cfg.VerifyConnection)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -139,7 +139,7 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
 	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
 	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
-	// When caReloader is active, RootCAs is nil: Go ignores it (InsecureSkipVerify=true)
+	// When a dynamic CA provider is active, RootCAs is nil: Go ignores it (InsecureSkipVerify=true)
 	// and CA verification is done via VerifyConnection. With verification_mode=none,
 	// VerifyConnection is nil (no verification performed).
 	assert.Nil(t, cfg.RootCAs)
@@ -201,10 +201,10 @@ key: mykey.pem
 		assert.NotNil(t, cfg)
 		// values not set by default
 		assert.Len(t, cfg.Certificates, 0)
-		// When caReloader is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
+		// When a dynamic CA provider is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
 		// and CA verification is done via VerifyConnection.
 		assert.Nil(t, cfg.ClientCAs)
-		assert.NotNil(t, cfg.VerifyConnection, "expected VerifyConnection to enforce CA validation with caReloader")
+		assert.NotNil(t, cfg.VerifyConnection, "expected VerifyConnection to enforce CA validation with dynamic CA provider")
 		assert.Len(t, cfg.CipherSuites, 0)
 		assert.Len(t, cfg.CurvePreferences, 0)
 		// values set by default
@@ -252,7 +252,7 @@ func TestApplyWithServerConfig(t *testing.T) {
 	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
 	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
 	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
-	// When caReloader is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
+	// When a dynamic CA provider is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
 	// and CA verification is done via VerifyConnection. With verification_mode=none,
 	// VerifyConnection is nil (no verification performed).
 	assert.Nil(t, cfg.ClientCAs)

--- a/transport/tlscommon/tls_test.go
+++ b/transport/tlscommon/tls_test.go
@@ -139,7 +139,11 @@ func TestApplyWithConfig(t *testing.T) {
 	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
 	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
 	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
-	assert.NotNil(t, cfg.RootCAs)
+	// When caReloader is active, RootCAs is nil: Go ignores it (InsecureSkipVerify=true)
+	// and CA verification is done via VerifyConnection. With verification_mode=none,
+	// VerifyConnection is nil (no verification performed).
+	assert.Nil(t, cfg.RootCAs)
+	assert.Nil(t, cfg.VerifyConnection)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
 	assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))
@@ -197,7 +201,10 @@ key: mykey.pem
 		assert.NotNil(t, cfg)
 		// values not set by default
 		assert.Len(t, cfg.Certificates, 0)
-		assert.NotNil(t, cfg.ClientCAs)
+		// When caReloader is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
+		// and CA verification is done via VerifyConnection.
+		assert.Nil(t, cfg.ClientCAs)
+		assert.NotNil(t, cfg.VerifyConnection, "expected VerifyConnection to enforce CA validation with caReloader")
 		assert.Len(t, cfg.CipherSuites, 0)
 		assert.Len(t, cfg.CurvePreferences, 0)
 		// values set by default
@@ -245,7 +252,11 @@ func TestApplyWithServerConfig(t *testing.T) {
 	assert.NotNil(t, cfg.GetCertificate, "expected GetCertificate callback from cert reloader")
 	assert.NotNil(t, cfg.GetClientCertificate, "expected GetClientCertificate callback from cert reloader")
 	assert.Empty(t, cfg.Certificates, "expected Certificates to be empty when cert reloader is active")
-	assert.NotNil(t, cfg.ClientCAs)
+	// When caReloader is active, ClientCAs is nil: Go ignores it (InsecureSkipVerify=true)
+	// and CA verification is done via VerifyConnection. With verification_mode=none,
+	// VerifyConnection is nil (no verification performed).
+	assert.Nil(t, cfg.ClientCAs)
+	assert.Nil(t, cfg.VerifyConnection)
 	assert.Equal(t, true, cfg.InsecureSkipVerify)
 	assert.Len(t, cfg.CipherSuites, 2)
 	assert.Equal(t, int(TLSVersionDefaultMin), int(cfg.MinVersion))


### PR DESCRIPTION
## What does this PR do?

Adds a \`CAReloader\` that periodically re-reads CA certificate files from disk, following the same time-based pattern as the \`CertReloader\` introduced in #417. Wires it into \`LoadTLSConfig\` and \`LoadTLSServerConfig\` so that when \`certificate_reload\` is enabled and CAs are configured, the CA pool is refreshed on each TLS handshake (if the reload interval has elapsed).

Specifically:
- New \`CAReloader\` struct in \`ca_reloader.go\` with the same double-checked locking pattern as \`CertReloader\`
- New \`certPoolProvider\` interface (with \`GetCertPool\`, \`AddTrustedCert\`, and \`IsDynamic\` methods) with two implementations: \`CAReloader\` (dynamic) and \`staticCertPool\` (wraps a static \`*x509.CertPool\`). The \`rootCAs\`/\`clientCAs\` fields on \`TLSConfig\` are typed as this interface, and all access goes through the interface
- \`IsDynamic()\` drives the \`InsecureSkipVerify=true\` + manual chain verification path: when any CA provider is dynamic, Go's stdlib is prevented from doing chain validation with a stale pool; full chain + hostname verification is done manually in the \`VerifyConnection\` callback using the dynamically-reloaded pool
- \`VerifyConnection\` callbacks in \`makeVerifyConnection\` and \`makeVerifyServerConnection\` call \`GetCertPool()\` on the provider, which returns the latest pool (reloaded if the interval has elapsed)
- \`CATrustedFingerprint\` certs discovered at runtime are preserved across CA reloads via \`CAReloader.AddTrustedCert\`

### Behavior

- **Enabled by default**: CA reload is on when \`certificate_reload\` is enabled (the default) and CAs are configured
- **No extra goroutines**: on each TLS handshake, checks if the reload interval (default 5s) has elapsed; if so, re-reads CA files from disk
- **Partial failure resilience**: if some CA files fail to reload, the pool is updated with the ones that succeeded and a warning is logged; only a total failure (all CAs unreadable) preserves the previous pool

## Why is it important?

The \`CertReloader\` from #417 hot-reloads cert/key files but CA files were still loaded once at startup. In environments with frequent CA rotation (e.g. Kubernetes with cert-manager), this gap prevents fully deprecating \`ssl.restart_on_cert_change\` in Beats (https://github.com/elastic/beats/pull/50444#issuecomment-4361127104).

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Builds on #417
- Relates to https://github.com/elastic/beats/pull/50444

🤖 Generated with [Claude Code](https://claude.com/claude-code)