### PR TITLE
feat(logp): add Logger.WithLazy for deferred field encoding

### DIFF
--- a/logp/logger.go
+++ b/logp/logger.go
@@ -167,6 +167,16 @@ func (l *Logger) With(args ...interface{}) *Logger {
 	return &Logger{sugar.Desugar(), sugar, l.selectors}
 }
 
+// WithLazy creates a child logger and adds structured context to it lazily.
+// Semantics match [zap.Logger.WithLazy]: the fields are encoded into the
+// underlying core only when the child is first written to (or further
+// chained with [Logger.With]). Useful on hot paths where a logger is always
+// built but only rarely emits.
+func (l *Logger) WithLazy(fields ...zapcore.Field) *Logger {
+	zapLog := l.logger.WithLazy(fields...)
+	return &Logger{zapLog, zapLog.Sugar(), l.selectors}
+}
+
 // Name returns the Logger's underlying name, or an empty string if the
 // logger is unnamed.
 func (l *Logger) Name() string {

--- a/logp/logger_test.go
+++ b/logp/logger_test.go
@@ -80,6 +80,46 @@ func TestNewInMemory(t *testing.T) {
 	assert.Contains(t, logs[3], "error_val")
 }
 
+func TestLoggerWithLazy(t *testing.T) {
+	core, observed := observer.New(zapcore.DebugLevel)
+	root, err := NewZapLogger(zap.New(core))
+	require.NoError(t, err, "constructing zap logger")
+
+	child := root.WithLazy(
+		zap.String("operation", "create"),
+		zap.String("source_file", "src-1"),
+	)
+	child.Infof("hello %s", "world")
+
+	entries := observed.All()
+	require.Len(t, entries, 1, "expected one emitted entry")
+	fields := map[string]string{}
+	for _, f := range entries[0].Context {
+		if f.Type == zapcore.StringType {
+			fields[f.Key] = f.String
+		}
+	}
+	assert.Equal(t, "create", fields["operation"], "operation field")
+	assert.Equal(t, "src-1", fields["source_file"], "source_file field")
+	assert.Equal(t, "hello world", entries[0].Message, "formatted message")
+}
+
+func TestLoggerWithLazyBelowLevelEmitsNothing(t *testing.T) {
+	// A Debugf call against an Info-level logger should produce no observer
+	// entries, even when the logger was built via WithLazy.
+	core, observed := observer.New(zapcore.InfoLevel)
+	root, err := NewZapLogger(zap.New(core))
+	require.NoError(t, err, "constructing zap logger")
+
+	child := root.WithLazy(
+		zap.String("operation", "create"),
+		zap.String("source_file", "src-1"),
+	)
+	child.Debugf("debugf below configured level")
+
+	assert.Empty(t, observed.All(), "no entries should be emitted below the configured level")
+}
+
 func TestLoggerHasSelector(t *testing.T) {
 	logger := newLogger(zap.NewNop(), map[string]struct{}{
 		"config": {},


### PR DESCRIPTION
## What does this PR do?

Adds `Logger.WithLazy(fields ...zapcore.Field) *Logger`, a thin wrapper around [`zap.Logger.WithLazy`](https://pkg.go.dev/go.uber.org/zap#Logger.WithLazy). The returned child logger holds the fields without encoding them into the underlying core; the encoding happens on the first emit (or when the child is further chained with `With`).

The signature takes typed `zapcore.Field` values, mirroring `zap.Logger.WithLazy`. This avoids the reflection cost of `sweetenFields` that the sugared variants pay, which matters on hot paths.

## Why is it important?

Hot paths in beats build a contextual logger per event but only emit through it on rare branches (error handling, or when debug logging is enabled). Today they either:

- pay `With(...)` per event, which clones the underlying zap logger eagerly even when no message is emitted, or
- maintain a bespoke "lazy" wrapper to defer the clone, which has its own thread-safety and ergonomics trade-offs.

`WithLazy` solves both: zap's `lazyWithCore` uses `sync.Once` internally, so the returned logger is thread-safe by construction, and the wrapper allocation is small enough to be cheap on the per-event hot path.

Concrete use case: the filestream input's prospector event loop in [elastic/beats#50118](https://github.com/elastic/beats/pull/50118). Benchmarks on `BenchmarkFilestream/10000_files/fingerprint`:

| | sec/op | B/op | allocs/op |
|---|---|---|---|
| `main` (eager `With`) | 602.4m | 557.4 MiB | 4.114M |
| bespoke `lazyLog` (current PR) | 532.4m (-11.6%) | 527.2 MiB (-5.4%) | 3.684M (-10.5%) |
| `logp.WithLazy` | 531.8m (-11.7%) | 535.0 MiB (-4.0%) | 3.775M (-8.3%) |

`WithLazy` keeps essentially all of the time savings and most of the allocation savings, while being a built-in, thread-safe primitive that any hot path can reuse.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates elastic/beats#50118