### PR TITLE
fix(tlscommon): restore empty Certificates slice for backward compatibility

### DIFF
--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -65,7 +65,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 	cas, errs := LoadCertificateAuthorities(config.CAs)
 	logFail(errs...)
 
-	var certs []tls.Certificate
+	certs := make([]tls.Certificate, 0)
 	var reloader *CertReloader
 
 	// Skip cert reloading when inline PEMs are used; reloading only makes sense with file paths.

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -93,7 +93,7 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 	cas, errs := LoadCertificateAuthorities(config.CAs)
 	logFail(errs...)
 
-	var certs []tls.Certificate
+	certs := make([]tls.Certificate, 0)
 	var reloader *CertReloader
 
 	// Skip cert reloading when inline PEMs are used; reloading only makes sense with file paths.


### PR DESCRIPTION
## What does this PR do?

Restores the pre-v0.43.0 behavior where `LoadTLSConfig` and `LoadTLSServerConfig` return `Certificates: []tls.Certificate{}` (an empty non-nil slice) rather than `Certificates: nil` when no certificate is configured.

## Root cause

The refactoring in #417 changed the initialization from:
```go
certs := make([]tls.Certificate, 0)
```
to:
```go
var certs []tls.Certificate
```

When no certificate file is configured, `certs` is never assigned, leaving it `nil`. While `nil` and `[]tls.Certificate{}` are functionally identical for `tls.Config` (Go's TLS stack treats them the same), callers using `reflect.DeepEqual` — including test assertions — observe them as different values.

## Impact

This is a regression discovered in a downstream consumer:
- [elastic/fleet-server#7054](https://github.com/elastic/fleet-server/pull/7054) — `TestToESConfig` fails: `Certificates: []tls.Certificate{}` expected, got `Certificates: nil`

## Fix

Restore `certs := make([]tls.Certificate, 0)` in both `LoadTLSConfig` (`config.go`) and `LoadTLSServerConfig` (`server_config.go`). This is a two-line change with no behavioral impact on TLS operation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)