### PR TITLE
feat: remove deprecated LoggingWithTypedOutputs

### DIFF
--- a/logp/configure/logging.go
+++ b/logp/configure/logging.go
@@ -79,42 +79,7 @@ func LoggingWithOutputs(beatName string, cfg *config.C, outputs ...zapcore.Core)
 	return logp.ConfigureWithOutputs(config, outputs...)
 }
 
-// LoggingWithTypedOutputs applies some defaults then calls ConfigureWithTypedOutputs
-//
-// Deprecated: Prefer using localized loggers. Use logp.LoggingWithTypedOutputsLocal.
-func LoggingWithTypedOutputs(beatName string, cfg, typedCfg *config.C, logKey, kind string, outputs ...zapcore.Core) error {
-	config := logp.DefaultConfig(environment)
-	config.Beat = beatName
-	if cfg != nil {
-		if err := cfg.Unpack(&config); err != nil {
-			return err
-		}
-	}
-
-	applyFlags(&config)
-
-	typedLogpConfig := logp.DefaultEventConfig(environment)
-	defaultName := typedLogpConfig.Files.Name
-	typedLogpConfig.Beat = beatName
-	if typedCfg != nil {
-		if err := typedCfg.Unpack(&typedLogpConfig); err != nil {
-			return fmt.Errorf("cannot unpack typed output config: %w", err)
-		}
-	}
-
-	// Make sure we're always running on the same log level
-	typedLogpConfig.Level = config.Level
-	typedLogpConfig.Selectors = config.Selectors
-
-	// If the name has not been configured, make it {beatName}-events-data
-	if typedLogpConfig.Files.Name == defaultName {
-		typedLogpConfig.Files.Name = beatName + "-events-data"
-	}
-
-	return logp.ConfigureWithTypedOutput(config, typedLogpConfig, logKey, kind, outputs...)
-}
-
-// LoggingWithTypedOutputs applies some defaults and returns a logger instance
+// LoggingWithTypedOutputsLocal applies some defaults and returns a logger instance
 func LoggingWithTypedOutputsLocal(beatName string, cfg, typedCfg *config.C, logKey, kind string, outputs ...zapcore.Core) (*logp.Logger, error) {
 	config := logp.DefaultConfig(environment)
 	config.Beat = beatName


### PR DESCRIPTION
## What does this PR do?

Removes the deprecated `configure.LoggingWithTypedOutputs` function from `logp/configure/logging.go`. Callers should use `configure.LoggingWithTypedOutputsLocal` instead, which returns a localized logger instance rather than relying on global state.

Also fixes the godoc comment on `LoggingWithTypedOutputsLocal`, which previously started with the wrong function name due to a stale copy-paste.

## Why is it important?

The function was deprecated in favor of the `Local` variant. The last in-org caller in `elastic/elastic-agent` was migrated in elastic/elastic-agent#13436, and a search of the elastic org confirms no remaining uses, so the deprecated wrapper can be deleted.

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- ~~I have added tests that prove my fix is effective or that my feature works~~

## Related issues

- Relates https://github.com/elastic/elastic-agent-libs/issues/397
- Relates elastic/elastic-agent#13436 (last in-org caller removed)
- org-wide code search confirming no remaining uses: https://github.com/search?q=org%3Aelastic+LoggingWithTypedOutputs&type=code