### PR TITLE
[redact] - Handle two more cases for redacting OTeL config

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -100,7 +100,7 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 		if val != nil {
 			switch cast := val.(type) {
 			case map[string][]string:
-				var newMap map[string]any = make(map[string]any, len(cast))
+				newMap := make(map[string]any, len(cast))
 				for k, v := range cast {
 					if redactKey(k, ro) {
 						newMap[k] = REDACTED

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -99,12 +99,33 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 		}
 		if val != nil {
 			switch cast := val.(type) {
+			case map[string][]string:
+				var newMap map[string]any = make(map[string]any, len(cast))
+				for k, v := range cast {
+					if redactKey(k, ro) {
+						newMap[k] = REDACTED
+						continue
+					}
+					newSlice := make([]interface{}, len(v))
+					for i, s := range v {
+						newSlice[i] = s
+					}
+					newMap[k] = newSlice
+				}
+				redactMap(newMap, ro)
+				val = newMap
 			case map[string]any:
 				redactMap(cast, ro)
 			case map[any]any:
 				redactMap(cast, ro)
 			case map[int]any:
 				redactMap(cast, ro)
+			case []map[string]interface{}:
+				updatedRootValue := make([]map[string]interface{}, len(cast))
+				for _, item := range cast {
+					redactMap(item, ro)
+				}
+				val = updatedRootValue
 			case []any:
 				// Recursively process each element in the slice so that we also walk
 				// through lists (e.g. inputs[4].streams[0]). This is required to

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -100,7 +100,6 @@ func TestRedact(t *testing.T) {
 		},
 		{
 			name: "URL credentials are redacted",
-			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[string]any{
 				"url":       "https://user:pass@example.com/path",
 				"other_url": "https://example.com/path",
@@ -131,7 +130,6 @@ func TestRedact(t *testing.T) {
 		},
 		{
 			name: "sensitive key wins over URL redaction",
-			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[string]any{
 				"secret_url": "https://user:pass@example.com",
 			},
@@ -445,6 +443,58 @@ func TestRedact(t *testing.T) {
 				"routekey":      "should-not-redact",
 				"my_secret_key": REDACTED,
 				"safe":          "value",
+			},
+		},
+		{
+			name: "map[string][]string sensitive key is redacted",
+			input: map[string]any{
+				"headers": map[string][]string{
+					"Authorization": {"Bearer secret-token"},
+					"Content-Type":  {"application/json"},
+				},
+			},
+			expect: map[string]any{
+				"headers": map[string]any{
+					"Authorization": REDACTED,
+					"Content-Type":  []any{"application/json"},
+				},
+			},
+		},
+		{
+			name: "map[string][]string URL credentials in values are redacted",
+			//nolint:gosec // this test is meant to redact sensitive values
+			input: map[string]any{
+				"endpoints": map[string][]string{
+					"hosts": {
+						"https://user:pass@es1:9200",
+						"https://user:pass@es2:9200",
+						"https://es3:9200",
+					},
+				},
+			},
+			expect: map[string]any{
+				"endpoints": map[string]any{
+					"hosts": []any{
+						"https://" + redactedURL + "@es1:9200",
+						"https://" + redactedURL + "@es2:9200",
+						"https://es3:9200",
+					},
+				},
+			},
+		},
+		{
+			name: "map[string][]string with no sensitive data is unchanged",
+			input: map[string]any{
+				"labels": map[string][]string{
+					"env":  {"production"},
+					"team": {"platform", "infra"},
+				},
+			},
+			expect: map[string]any{
+				"labels": map[string]any{
+					"env":  []any{"production"},
+					"team": []any{"platform", "infra"},
+				},
 			},
 		},
 		{

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -100,6 +100,7 @@ func TestRedact(t *testing.T) {
 		},
 		{
 			name: "URL credentials are redacted",
+			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[string]any{
 				"url":       "https://user:pass@example.com/path",
 				"other_url": "https://example.com/path",
@@ -130,6 +131,7 @@ func TestRedact(t *testing.T) {
 		},
 		{
 			name: "sensitive key wins over URL redaction",
+			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[string]any{
 				"secret_url": "https://user:pass@example.com",
 			},
@@ -462,7 +464,6 @@ func TestRedact(t *testing.T) {
 		},
 		{
 			name: "map[string][]string URL credentials in values are redacted",
-			//nolint:gosec // this test is meant to redact sensitive values
 			input: map[string]any{
 				"endpoints": map[string][]string{
 					"hosts": {


### PR DESCRIPTION
## What does this PR do?
While doing `elastic-agent inspect`, we perform an additional step to redact sensitive information.

OTeL pipeline contains two additional maps that are not handled during redaction:
1. `map[string][]string`: This is the list of components we specify under `service.pipeline`.
2.  `[]map[string]interface{}`: These are individual configuration of components. Receivers, Exporters, Extensions etc.

## Why is it important?

```yaml
receivers:
  filelog:
    include: [ /var/log/system.log ]
    start_at: beginning
    storage: file_storage/filelogreceiver
...
service:
  pipeline:
    receivers: [filelog]
```

In above config, the type of `receivers` is `[]map[string]interface{}` and type of `service.pipeline` is `map[string][]string`

This is needed for https://github.com/elastic/elastic-agent/pull/13941

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- Relates https://github.com/elastic/elastic-agent/pull/13941

