### PR TITLE
fix(httpcommon): preserve TLS metadata for HTTPS via custom dialer

### DIFF
--- a/transport/httpcommon/httpcommon.go
+++ b/transport/httpcommon/httpcommon.go
@@ -265,10 +265,6 @@ func (settings *HTTPTransportSettings) RoundTripper(opts ...TransportOption) (ht
 		return nil, err
 	}
 
-	// Apply stats and logging to the TCP dialer before wrapping it with TLS, so
-	// the TLS dialer stays outermost and returns a *tls.Conn. net/http only sets
-	// Response.TLS when DialTLSContext yields a *tls.Conn (it does conn.(*tls.Conn)
-	// in Transport.dialConn); wrapping it would drop all tls.* metadata.
 	for _, opt := range opts {
 		if dialOpt, ok := opt.(dialerModOption); ok {
 			dialer = dialOpt.applyDialer(settings, dialer)
@@ -279,6 +275,10 @@ func (settings *HTTPTransportSettings) RoundTripper(opts ...TransportOption) (ht
 		dialer = transport.LoggingDialer(dialer, logger)
 	}
 
+	// Wrap the TCP dialer (already decorated with stats/logging above) with TLS
+	// last, so the TLS dialer stays outermost and returns a *tls.Conn. net/http
+	// only sets Response.TLS when DialTLSContext yields a *tls.Conn (it does
+	// conn.(*tls.Conn) in Transport.dialConn); wrapping it would drop tls.* metadata.
 	tlsDialer := transport.TLSDialer(dialer, tls, settings.Timeout, extra.logger)
 
 	var rt http.RoundTripper

--- a/transport/httpcommon/httpcommon.go
+++ b/transport/httpcommon/httpcommon.go
@@ -265,18 +265,10 @@ func (settings *HTTPTransportSettings) RoundTripper(opts ...TransportOption) (ht
 		return nil, err
 	}
 
-	// Apply dialer modifications (e.g. I/O stats) and connection logging to the
-	// plain TCP dialer *before* wrapping it with TLS, so the TLS dialer remains
-	// the outermost layer and returns a *tls.Conn.
-	//
-	// net/http only records the TLS connection state (and therefore populates
-	// Response.TLS) when the connection produced by Transport.DialTLSContext is a
-	// *tls.Conn (see (*http.Transport).dialConn, which does a concrete-type
-	// assertion `conn.(*tls.Conn)`). Wrapping the *tls.Conn in any other net.Conn
-	// implementation (stats or logging) makes that assertion fail and silently
-	// drops all tls.* metadata for HTTPS requests. Wrapping the underlying TCP
-	// connection instead keeps both behaviours: connection-level logging/stats and
-	// a usable *tls.Conn for net/http.
+	// Apply stats and logging to the TCP dialer before wrapping it with TLS, so
+	// the TLS dialer stays outermost and returns a *tls.Conn. net/http only sets
+	// Response.TLS when DialTLSContext yields a *tls.Conn (it does conn.(*tls.Conn)
+	// in Transport.dialConn); wrapping it would drop all tls.* metadata.
 	for _, opt := range opts {
 		if dialOpt, ok := opt.(dialerModOption); ok {
 			dialer = dialOpt.applyDialer(settings, dialer)

--- a/transport/httpcommon/httpcommon.go
+++ b/transport/httpcommon/httpcommon.go
@@ -265,18 +265,29 @@ func (settings *HTTPTransportSettings) RoundTripper(opts ...TransportOption) (ht
 		return nil, err
 	}
 
-	tlsDialer := transport.TLSDialer(dialer, tls, settings.Timeout, extra.logger)
+	// Apply dialer modifications (e.g. I/O stats) and connection logging to the
+	// plain TCP dialer *before* wrapping it with TLS, so the TLS dialer remains
+	// the outermost layer and returns a *tls.Conn.
+	//
+	// net/http only records the TLS connection state (and therefore populates
+	// Response.TLS) when the connection produced by Transport.DialTLSContext is a
+	// *tls.Conn (see (*http.Transport).dialConn, which does a concrete-type
+	// assertion `conn.(*tls.Conn)`). Wrapping the *tls.Conn in any other net.Conn
+	// implementation (stats or logging) makes that assertion fail and silently
+	// drops all tls.* metadata for HTTPS requests. Wrapping the underlying TCP
+	// connection instead keeps both behaviours: connection-level logging/stats and
+	// a usable *tls.Conn for net/http.
 	for _, opt := range opts {
 		if dialOpt, ok := opt.(dialerModOption); ok {
 			dialer = dialOpt.applyDialer(settings, dialer)
-			tlsDialer = dialOpt.applyDialer(settings, tlsDialer)
 		}
 	}
 
 	if logger := extra.logger; logger != nil {
 		dialer = transport.LoggingDialer(dialer, logger)
-		tlsDialer = transport.LoggingDialer(tlsDialer, logger)
 	}
+
+	tlsDialer := transport.TLSDialer(dialer, tls, settings.Timeout, extra.logger)
 
 	var rt http.RoundTripper
 	if extra.http2 {

--- a/transport/httpcommon/httpcommon_test.go
+++ b/transport/httpcommon/httpcommon_test.go
@@ -19,10 +19,13 @@ package httpcommon
 
 import (
 	"bytes"
+	"crypto/tls"
+	"encoding/pem"
 	"fmt"
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -334,6 +337,76 @@ func Test_HTTPTransportSettings_RoundTripper(t *testing.T) {
 			require.Equal(t, http.StatusOK, resp.StatusCode)
 		})
 	}
+}
+
+// countingStatser is a minimal transport.IOStatser used to verify the I/O stats
+// dialer still observes traffic when wrapped beneath the TLS layer.
+type countingStatser struct {
+	readBytes  atomic.Int64
+	writeBytes atomic.Int64
+}
+
+func (c *countingStatser) WriteError(error) {}
+func (c *countingStatser) WriteBytes(n int) { c.writeBytes.Add(int64(n)) }
+func (c *countingStatser) ReadError(error)  {}
+func (c *countingStatser) ReadBytes(n int)  { c.readBytes.Add(int64(n)) }
+
+// Test_HTTPTransportSettings_RoundTripper_TLSMetadata is a regression test for
+// https://github.com/elastic/beats/issues/48335. The RoundTripper installs a
+// custom DialTLSContext, and net/http only populates Response.TLS when that
+// dialer returns a *tls.Conn. Connection logging is always enabled (a default
+// logger is set when none is provided) and the I/O stats dialer is optional;
+// both used to wrap the *tls.Conn in another net.Conn, which made net/http drop
+// all TLS metadata for HTTPS requests.
+func Test_HTTPTransportSettings_RoundTripper_TLSMetadata(t *testing.T) {
+	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	ca := pem.EncodeToMemory(&pem.Block{
+		Type:  "CERTIFICATE",
+		Bytes: srv.TLS.Certificates[0].Certificate[0],
+	})
+	require.NotEmpty(t, ca)
+
+	newSettings := func() *HTTPTransportSettings {
+		s := DefaultHTTPTransportSettings()
+		s.TLS = &tlscommon.Config{CAs: []string{string(ca)}}
+		return &s
+	}
+
+	doRequest := func(t *testing.T, rt http.RoundTripper) *tls.ConnectionState {
+		t.Helper()
+		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+		require.NoError(t, err)
+		resp, err := rt.RoundTrip(req)
+		require.NoError(t, err)
+		defer resp.Body.Close()
+		require.Equal(t, http.StatusOK, resp.StatusCode)
+		return resp.TLS
+	}
+
+	t.Run("populates Response.TLS for HTTPS requests", func(t *testing.T) {
+		rt, err := newSettings().RoundTripper()
+		require.NoError(t, err)
+
+		tlsState := doRequest(t, rt)
+		require.NotNil(t, tlsState, "Response.TLS must be set for HTTPS requests")
+		require.NotEmpty(t, tlsState.PeerCertificates, "TLS peer certificates must be present")
+	})
+
+	t.Run("populates Response.TLS and records stats with WithIOStats", func(t *testing.T) {
+		stats := &countingStatser{}
+		rt, err := newSettings().RoundTripper(WithIOStats(stats))
+		require.NoError(t, err)
+
+		tlsState := doRequest(t, rt)
+		require.NotNil(t, tlsState, "Response.TLS must be set for HTTPS requests")
+		require.NotEmpty(t, tlsState.PeerCertificates, "TLS peer certificates must be present")
+		require.Positive(t, stats.readBytes.Load(), "stats dialer must record bytes read over the TLS connection")
+		require.Positive(t, stats.writeBytes.Load(), "stats dialer must record bytes written over the TLS connection")
+	})
 }
 
 func Test_HTTPAuthorization_ToMap(t *testing.T) {

--- a/transport/httpcommon/httpcommon_test.go
+++ b/transport/httpcommon/httpcommon_test.go
@@ -19,7 +19,6 @@ package httpcommon
 
 import (
 	"bytes"
-	"crypto/tls"
 	"encoding/pem"
 	"fmt"
 	"io"
@@ -358,6 +357,9 @@ func (c *countingStatser) ReadBytes(n int)  { c.readBytes.Add(int64(n)) }
 // logger is set when none is provided) and the I/O stats dialer is optional;
 // both used to wrap the *tls.Conn in another net.Conn, which made net/http drop
 // all TLS metadata for HTTPS requests.
+//
+// WithIOStats is used so the test exercises both wrappers (stats and the
+// always-on logging dialer) that previously hid the *tls.Conn from net/http.
 func Test_HTTPTransportSettings_RoundTripper_TLSMetadata(t *testing.T) {
 	srv := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
@@ -368,45 +370,25 @@ func Test_HTTPTransportSettings_RoundTripper_TLSMetadata(t *testing.T) {
 		Type:  "CERTIFICATE",
 		Bytes: srv.TLS.Certificates[0].Certificate[0],
 	})
-	require.NotEmpty(t, ca)
 
-	newSettings := func() *HTTPTransportSettings {
-		s := DefaultHTTPTransportSettings()
-		s.TLS = &tlscommon.Config{CAs: []string{string(ca)}}
-		return &s
-	}
+	settings := DefaultHTTPTransportSettings()
+	settings.TLS = &tlscommon.Config{CAs: []string{string(ca)}}
 
-	doRequest := func(t *testing.T, rt http.RoundTripper) *tls.ConnectionState {
-		t.Helper()
-		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
-		require.NoError(t, err)
-		resp, err := rt.RoundTrip(req)
-		require.NoError(t, err)
-		defer resp.Body.Close()
-		require.Equal(t, http.StatusOK, resp.StatusCode)
-		return resp.TLS
-	}
+	stats := &countingStatser{}
+	rt, err := settings.RoundTripper(WithIOStats(stats))
+	require.NoError(t, err)
 
-	t.Run("populates Response.TLS for HTTPS requests", func(t *testing.T) {
-		rt, err := newSettings().RoundTripper()
-		require.NoError(t, err)
+	req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, srv.URL, nil)
+	require.NoError(t, err)
+	resp, err := rt.RoundTrip(req)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+	require.Equal(t, http.StatusOK, resp.StatusCode)
 
-		tlsState := doRequest(t, rt)
-		require.NotNil(t, tlsState, "Response.TLS must be set for HTTPS requests")
-		require.NotEmpty(t, tlsState.PeerCertificates, "TLS peer certificates must be present")
-	})
-
-	t.Run("populates Response.TLS and records stats with WithIOStats", func(t *testing.T) {
-		stats := &countingStatser{}
-		rt, err := newSettings().RoundTripper(WithIOStats(stats))
-		require.NoError(t, err)
-
-		tlsState := doRequest(t, rt)
-		require.NotNil(t, tlsState, "Response.TLS must be set for HTTPS requests")
-		require.NotEmpty(t, tlsState.PeerCertificates, "TLS peer certificates must be present")
-		require.Positive(t, stats.readBytes.Load(), "stats dialer must record bytes read over the TLS connection")
-		require.Positive(t, stats.writeBytes.Load(), "stats dialer must record bytes written over the TLS connection")
-	})
+	require.NotNil(t, resp.TLS, "Response.TLS must be set for HTTPS requests")
+	require.NotEmpty(t, resp.TLS.PeerCertificates, "TLS peer certificates must be present")
+	require.Positive(t, stats.readBytes.Load(), "stats dialer must record bytes read over the TLS connection")
+	require.Positive(t, stats.writeBytes.Load(), "stats dialer must record bytes written over the TLS connection")
 }
 
 func Test_HTTPAuthorization_ToMap(t *testing.T) {


### PR DESCRIPTION
## TL;DR

`RoundTripper` installs a custom `DialTLSContext`, but it wrapped the resulting `*tls.Conn` in a logging/stats connection. `net/http` only populates `Response.TLS` when the connection from `DialTLSContext` is concretely a `*tls.Conn`, so TLS metadata was silently dropped for **every** HTTPS request through this transport. The fix moves the wrappers under the TLS layer so the dialer returns a real `*tls.Conn` again.

## What does this PR do?

`HTTPTransportSettings.RoundTripper` builds an `*http.Transport` and sets a custom `DialTLSContext` (`tlsDialer.DialContext`). The dialer wrappers were applied in the wrong order:

```
Before:  net/http  ←  loggingConn  ←  (statsConn)  ←  *tls.Conn  ←  TCP socket
                       └── outermost conn is NOT a *tls.Conn ──┘

After:   net/http  ←  *tls.Conn  ←  loggingConn  ←  (statsConn)  ←  TCP socket
                       └── outermost conn IS a *tls.Conn ──┘
```

- **Before:** logging (always on, since a default logger is set when none is provided) and the optional `WithIOStats` dialer wrapped the `*tls.Conn`, so `net/http` received a `*loggingConn` / `*statsConn`.
- **After:** those wrappers are applied to the **plain TCP dialer**, then TLS wraps that. The TLS dialer stays the outermost layer and returns a real `*tls.Conn`, while logging/stats keep operating on the underlying socket.

### Why `Response.TLS` was `nil`

`net/http` records the TLS connection state — and therefore sets `Response.TLS` — only when the connection returned by a custom `DialTLSContext` is concretely a `*tls.Conn`:

```go
// (*http.Transport).dialConn
pconn.conn, err = t.customDialTLS(ctx, "tcp", cm.addr())
if tc, ok := pconn.conn.(*tls.Conn); ok { // a wrapped conn fails this assertion
    ...
    pconn.tlsState = &cs               // → later assigned to resp.TLS
}
```

A wrapped connection fails the `*tls.Conn` assertion, so `pconn.tlsState` (and `Response.TLS`) stayed `nil`.

## Why is it important?

Any consumer relying on `Response.TLS` loses all TLS metadata for HTTPS made through a custom dialer. Concretely, **Heartbeat HTTP monitors with `max_redirects > 0` (or a proxy) stopped emitting `tls.*` fields** after the 8.0 migration to `elastic-agent-libs`, breaking TLS certificate-expiry monitoring for redirecting endpoints (elastic/beats#48335). This restores the pre-8.0 behaviour.

## Behaviour change (release note)

For HTTPS connections, `WithIOStats` byte counts now reflect on-the-wire encrypted traffic (including the TLS handshake) instead of decrypted application-layer bytes, because the stats dialer now sits beneath the TLS layer.

## Testing

Added `Test_HTTPTransportSettings_RoundTripper_TLSMetadata`:

- Passes with the fix; fails on `main` (reproduces the regression).
- Covers both the default (logging-only) path and the `WithIOStats` path.
- Verifies I/O stats are still recorded over TLS (now counted at the socket layer rather than the plaintext layer).

```
go test ./transport/...   # passes
```

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Related issues

- Relates elastic/beats#48335
- Regression test (beats): elastic/beats#51339