### PR TITLE
remove obsolete .golangci.yml target from bump-golang manifest

### DIFF
--- a/.github/tools/updatecli/bump-golang.yml
+++ b/.github/tools/updatecli/bump-golang.yml
@@ -90,15 +90,6 @@ targets:
       content: '{{ source "latestGoVersion" }}'
       file: .go-version
       matchpattern: '\d+.\d+.\d+'
-  update-golang.ci:
-    name: "Update .golangci.yml"
-    sourceid: latestGoVersion
-    scmid: githubConfig
-    kind: file
-    spec:
-      content: '{{ source "latestGoVersion" }}'
-      file: .golangci.yml
-      matchpattern: '\d+.\d+.\d+'
   update-gomod:
     name: "Update go.mod"
     sourceid: gomod


### PR DESCRIPTION
## What does this PR do?

Fixes the scheduled "Bump golang version" automation, which has been failing.

### Failing example

https://github.com/elastic/elastic-agent-libs/actions/runs/28300863240/job/83848781362

```
update-golang.ci
----------------

ERROR: something went wrong in target "update-golang.ci" : "No line matched in the file \"/tmp/updatecli/github/elastic/elastic-agent-libs/.golangci.yml\" for the pattern \"\\\\d+.\\\\d+.\\\\d+\""

Pipeline "Bump golang-version to latest version" failed
Skipping due to:
	targets stage:	"something went wrong during target execution"
```

## Why is it important?

An old config file it tries to update no longer needs that update, so the job kept erroring out instead of skipping it. This removes the stale step so the automation can run cleanly again.

## Checklist

- [x] My code follows the style guidelines of this project
- ~~I have commented my code, particularly in hard-to-understand areas~~
- ~~I have added tests that prove my fix is effective or that my feature works~~

## Author's Checklist

- [x] Verified the removed step is no longer needed

## Related issues

-
