### PR TITLE
Add opt-in header-value expansion to the redact package

### DIFF
--- a/redact/redact.go
+++ b/redact/redact.go
@@ -40,7 +40,7 @@ type redactOptions struct {
 	errOut          io.Writer
 	markerPrefix    string
 	ignoreKeys      []string
-	headerValueKeys []string
+	headerValueKeys map[string]struct{}
 }
 
 type headerPair struct {
@@ -49,8 +49,9 @@ type headerPair struct {
 }
 
 type headerExpansion struct {
-	origKey string
-	pairs   []headerPair
+	origKey     string
+	pairs       []headerPair
+	anyRedacted bool
 }
 
 // WithErrorOutput determines where any error messages that are encountered are written to.
@@ -84,7 +85,12 @@ func WithIgnoreKeys(keys ...string) RedactOption {
 // replaced with REDACTED.
 func WithHeaderValueKeys(keys ...string) RedactOption {
 	return func(ro *redactOptions) {
-		ro.headerValueKeys = append(ro.headerValueKeys, keys...)
+		if ro.headerValueKeys == nil {
+			ro.headerValueKeys = make(map[string]struct{}, len(keys))
+		}
+		for _, k := range keys {
+			ro.headerValueKeys[k] = struct{}{}
+		}
 	}
 }
 
@@ -177,16 +183,20 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 					val = REDACTED
 				} else if redactedValue, redact := redactURL(cast); redact {
 					val = redactedValue
-				} else if len(ro.headerValueKeys) > 0 {
-					if keyString, ok := any(key).(string); ok && slices.Contains(ro.headerValueKeys, keyString) {
+				} else if keyString, ok := any(key).(string); ok {
+					if _, isHeaderKey := ro.headerValueKeys[keyString]; isHeaderKey {
 						pairs := parseHeaderPairs(cast)
-						for i := range pairs {
-							if redactKey(pairs[i].name, ro) {
-								pairs[i].value = REDACTED
+						if len(pairs) > 0 {
+							anyRedacted := false
+							for i := range pairs {
+								if redactKey(pairs[i].name, ro) {
+									pairs[i].value = REDACTED
+									anyRedacted = true
+								}
 							}
+							headerExpansions = append(headerExpansions, headerExpansion{origKey: keyString, pairs: pairs, anyRedacted: anyRedacted})
+							continue
 						}
-						headerExpansions = append(headerExpansions, headerExpansion{origKey: keyString, pairs: pairs})
-						continue
 					}
 				}
 			case bool: // redaction marker values are always going to be bool, process redaction markers in this case
@@ -225,9 +235,18 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 	}
 
 	for _, exp := range headerExpansions {
-		if k, ok := any(exp.origKey).(K); ok {
-			delete(obj, k)
+		// No sensitive header found in this value, leave the original entry unchanged.
+		if !exp.anyRedacted {
+			continue
 		}
+		// At least one header was sensitive: overwrite the original flat value with
+		// REDACTED so it is clear the entry contained a secret, without leaking which
+		// specific part of the string held it.
+		if k, ok := any(exp.origKey).(K); ok {
+			obj[k] = REDACTED
+		}
+		// Add one sub-entry per parsed header so reviewers can see which headers were
+		// present and which ones were the sensitive ones.
 		for _, p := range exp.pairs {
 			expandedKey := exp.origKey + HeaderValueKeySeparator + p.name
 			if k, ok := any(expandedKey).(K); ok {

--- a/redact/redact.go
+++ b/redact/redact.go
@@ -29,13 +29,28 @@ import (
 // REDACTED is the value that replaces sensitive values.
 const REDACTED = "REDACTED"
 
+// HeaderValueKeySeparator is used when expanding header-valued keys into
+// per-header sub-entries in the redacted output.
+const HeaderValueKeySeparator = "::"
+
 // RedactOption is an optional arg to control how the Redact method works.
 type RedactOption func(ro *redactOptions)
 
 type redactOptions struct {
-	errOut       io.Writer
-	markerPrefix string
-	ignoreKeys   []string
+	errOut          io.Writer
+	markerPrefix    string
+	ignoreKeys      []string
+	headerValueKeys []string
+}
+
+type headerPair struct {
+	name  string
+	value string
+}
+
+type headerExpansion struct {
+	origKey string
+	pairs   []headerPair
 }
 
 // WithErrorOutput determines where any error messages that are encountered are written to.
@@ -61,6 +76,18 @@ func WithIgnoreKeys(keys ...string) RedactOption {
 	}
 }
 
+// WithHeaderValueKeys registers keys whose string values are formatted as
+// comma-separated "Name=Value" pairs (e.g. HTTP header env vars). During
+// redaction each such entry is expanded into "originalKey::Name" sub-entries
+// so that the standard redactKey rules can match the individual header names.
+// Non-sensitive headers are kept with their original value; sensitive ones are
+// replaced with REDACTED.
+func WithHeaderValueKeys(keys ...string) RedactOption {
+	return func(ro *redactOptions) {
+		ro.headerValueKeys = append(ro.headerValueKeys, keys...)
+	}
+}
+
 // Redact walks obj and replaces values of sensitive keys with a redacted
 // placeholder. It mutates obj in place; nested maps and slice elements are
 // modified directly and no copy is returned.
@@ -82,6 +109,7 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 	}
 
 	markers := make([]string, 0)
+	headerExpansions := make([]headerExpansion, 0)
 	for key, val := range obj {
 		// detect if the obj has entries of the form:
 		// - name: Authorization
@@ -149,6 +177,17 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 					val = REDACTED
 				} else if redactedValue, redact := redactURL(cast); redact {
 					val = redactedValue
+				} else if len(ro.headerValueKeys) > 0 {
+					if keyString, ok := any(key).(string); ok && slices.Contains(ro.headerValueKeys, keyString) {
+						pairs := parseHeaderPairs(cast)
+						for i := range pairs {
+							if redactKey(pairs[i].name, ro) {
+								pairs[i].value = REDACTED
+							}
+						}
+						headerExpansions = append(headerExpansions, headerExpansion{origKey: keyString, pairs: pairs})
+						continue
+					}
 				}
 			case bool: // redaction marker values are always going to be bool, process redaction markers in this case
 				if keyString, ok := any(key).(string); ok {
@@ -184,6 +223,35 @@ func redactMap[K comparable](obj map[K]any, ro *redactOptions) {
 			}
 		}
 	}
+
+	for _, exp := range headerExpansions {
+		if k, ok := any(exp.origKey).(K); ok {
+			delete(obj, k)
+		}
+		for _, p := range exp.pairs {
+			expandedKey := exp.origKey + HeaderValueKeySeparator + p.name
+			if k, ok := any(expandedKey).(K); ok {
+				obj[k] = p.value
+			}
+		}
+	}
+}
+
+// parseHeaderPairs splits a comma-separated "Name=Value,Name=Value" string
+// into individual header pairs. Segments without an '=' or with an empty name
+// are silently skipped.
+func parseHeaderPairs(val string) []headerPair {
+	segments := strings.Split(val, ",")
+	pairs := make([]headerPair, 0, len(segments))
+	for _, seg := range segments {
+		seg = strings.TrimSpace(seg)
+		idx := strings.IndexByte(seg, '=')
+		if idx <= 0 {
+			continue
+		}
+		pairs = append(pairs, headerPair{name: seg[:idx], value: seg[idx+1:]})
+	}
+	return pairs
 }
 
 func redactKey(k string, ro *redactOptions) bool {

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -636,6 +636,7 @@ func TestRedactHeaderValueKeys(t *testing.T) {
 		},
 		{
 			name: "key-based redaction takes priority over header expansion",
+			//nolint:gosec // fake credentials for testing
 			input: map[string]any{
 				// SECRET_HEADER matches redactKey via "secret", so it is redacted
 				// wholesale before the header expansion logic is reached.

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -592,32 +592,34 @@ func TestRedactHeaderValueKeys(t *testing.T) {
 		expect map[string]any
 	}{
 		{
-			name: "single sensitive header is expanded and redacted",
+			name: "single sensitive header: original becomes REDACTED, expanded entry added",
 			input: map[string]any{
 				"FLEET_HEADER": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9",
 			},
 			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER")},
 			expect: map[string]any{
+				"FLEET_HEADER":                     REDACTED,
 				"FLEET_HEADER::X-Elastic-App-Auth": REDACTED,
 			},
 		},
 		{
-			name: "non-sensitive header is expanded with original value",
+			name: "non-sensitive header: original preserved, no expansion",
 			input: map[string]any{
 				"FLEET_HEADER": "Accept=application/json",
 			},
 			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER")},
 			expect: map[string]any{
-				"FLEET_HEADER::Accept": "application/json",
+				"FLEET_HEADER": "Accept=application/json",
 			},
 		},
 		{
-			name: "multi-header value expands selectively",
+			name: "multi-header value: original becomes REDACTED when any header is sensitive",
 			input: map[string]any{
 				"FLEET_HEADERS": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9,Accept=application/json",
 			},
 			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADERS")},
 			expect: map[string]any{
+				"FLEET_HEADERS":                     REDACTED,
 				"FLEET_HEADERS::X-Elastic-App-Auth": REDACTED,
 				"FLEET_HEADERS::Accept":             "application/json",
 			},
@@ -630,8 +632,36 @@ func TestRedactHeaderValueKeys(t *testing.T) {
 			},
 			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER", "FLEET_KIBANA_HEADER")},
 			expect: map[string]any{
+				"FLEET_HEADER":                            REDACTED,
 				"FLEET_HEADER::X-Elastic-App-Auth":        REDACTED,
+				"FLEET_KIBANA_HEADER":                     REDACTED,
 				"FLEET_KIBANA_HEADER::X-Elastic-App-Auth": REDACTED,
+			},
+		},
+		{
+			name: "multi-header value: original preserved, no expansion when no header is sensitive",
+			input: map[string]any{
+				"FLEET_HEADERS": "Accept=application/json,Content-Type=application/json",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADERS")},
+			expect: map[string]any{
+				"FLEET_HEADERS": "Accept=application/json,Content-Type=application/json",
+			},
+		},
+		{
+			name: "one key with sensitive headers expanded, another with only innocuous headers left unchanged",
+			input: map[string]any{
+				"FLEET_HEADERS":        "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9,Accept=application/json",
+				"FLEET_KIBANA_HEADERS": "Accept=application/json,Content-Type=application/json",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADERS", "FLEET_KIBANA_HEADERS")},
+			expect: map[string]any{
+				// FLEET_HEADERS had a sensitive header — original redacted, sub-entries added
+				"FLEET_HEADERS":                     REDACTED,
+				"FLEET_HEADERS::X-Elastic-App-Auth": REDACTED,
+				"FLEET_HEADERS::Accept":             "application/json",
+				// FLEET_KIBANA_HEADERS had no sensitive headers — left completely unchanged
+				"FLEET_KIBANA_HEADERS": "Accept=application/json,Content-Type=application/json",
 			},
 		},
 		{
@@ -658,14 +688,15 @@ func TestRedactHeaderValueKeys(t *testing.T) {
 			},
 		},
 		{
-			name: "value with no equals sign produces no expanded entries",
+			name: "value with no equals sign: original preserved, no expanded entries",
 			input: map[string]any{
 				"FLEET_HEADER": "not-a-header-value",
 				"OTHER":        "safe",
 			},
 			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER")},
 			expect: map[string]any{
-				"OTHER": "safe",
+				"FLEET_HEADER": "not-a-header-value",
+				"OTHER":        "safe",
 			},
 		},
 	}

--- a/redact/redact_test.go
+++ b/redact/redact_test.go
@@ -531,6 +531,157 @@ func TestRedact(t *testing.T) {
 	}
 }
 
+func TestParseHeaderPairs(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  string
+		expect []headerPair
+	}{
+		{
+			name:   "single sensitive header",
+			input:  "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9",
+			expect: []headerPair{{name: "X-Elastic-App-Auth", value: "eyJhbGciOiJSUzI1NiJ9"}},
+		},
+		{
+			name:  "multiple headers",
+			input: "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9,Accept=application/json",
+			expect: []headerPair{
+				{name: "X-Elastic-App-Auth", value: "eyJhbGciOiJSUzI1NiJ9"},
+				{name: "Accept", value: "application/json"},
+			},
+		},
+		{
+			name:   "value contains equals sign",
+			input:  "X-Elastic-App-Auth=a=b=c",
+			expect: []headerPair{{name: "X-Elastic-App-Auth", value: "a=b=c"}},
+		},
+		{
+			name:   "whitespace trimmed around segment",
+			input:  " X-Elastic-App-Auth=token , Accept=application/json ",
+			expect: []headerPair{{name: "X-Elastic-App-Auth", value: "token"}, {name: "Accept", value: "application/json"}},
+		},
+		{
+			name:   "segment without equals is skipped",
+			input:  "no-equals,Accept=application/json",
+			expect: []headerPair{{name: "Accept", value: "application/json"}},
+		},
+		{
+			name:   "segment with empty name is skipped",
+			input:  "=emptyname,Accept=application/json",
+			expect: []headerPair{{name: "Accept", value: "application/json"}},
+		},
+		{
+			name:   "empty string yields no pairs",
+			input:  "",
+			expect: []headerPair{},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.expect, parseHeaderPairs(tc.input))
+		})
+	}
+}
+
+func TestRedactHeaderValueKeys(t *testing.T) {
+	tests := []struct {
+		name   string
+		input  map[string]any
+		opts   []RedactOption
+		expect map[string]any
+	}{
+		{
+			name: "single sensitive header is expanded and redacted",
+			input: map[string]any{
+				"FLEET_HEADER": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER")},
+			expect: map[string]any{
+				"FLEET_HEADER::X-Elastic-App-Auth": REDACTED,
+			},
+		},
+		{
+			name: "non-sensitive header is expanded with original value",
+			input: map[string]any{
+				"FLEET_HEADER": "Accept=application/json",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER")},
+			expect: map[string]any{
+				"FLEET_HEADER::Accept": "application/json",
+			},
+		},
+		{
+			name: "multi-header value expands selectively",
+			input: map[string]any{
+				"FLEET_HEADERS": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9,Accept=application/json",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADERS")},
+			expect: map[string]any{
+				"FLEET_HEADERS::X-Elastic-App-Auth": REDACTED,
+				"FLEET_HEADERS::Accept":             "application/json",
+			},
+		},
+		{
+			name: "multiple registered keys each expand independently",
+			input: map[string]any{
+				"FLEET_HEADER":        "X-Elastic-App-Auth=jwt1",
+				"FLEET_KIBANA_HEADER": "X-Elastic-App-Auth=jwt2",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER", "FLEET_KIBANA_HEADER")},
+			expect: map[string]any{
+				"FLEET_HEADER::X-Elastic-App-Auth":        REDACTED,
+				"FLEET_KIBANA_HEADER::X-Elastic-App-Auth": REDACTED,
+			},
+		},
+		{
+			name: "key-based redaction takes priority over header expansion",
+			input: map[string]any{
+				// SECRET_HEADER matches redactKey via "secret", so it is redacted
+				// wholesale before the header expansion logic is reached.
+				"SECRET_HEADER": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("SECRET_HEADER")},
+			expect: map[string]any{
+				"SECRET_HEADER": REDACTED,
+			},
+		},
+		{
+			name: "without WithHeaderValueKeys option the value is unchanged",
+			input: map[string]any{
+				"FLEET_HEADER": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9",
+			},
+			opts: nil,
+			expect: map[string]any{
+				"FLEET_HEADER": "X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9",
+			},
+		},
+		{
+			name: "value with no equals sign produces no expanded entries",
+			input: map[string]any{
+				"FLEET_HEADER": "not-a-header-value",
+				"OTHER":        "safe",
+			},
+			opts: []RedactOption{WithHeaderValueKeys("FLEET_HEADER")},
+			expect: map[string]any{
+				"OTHER": "safe",
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var errOut bytes.Buffer
+			opts := append([]RedactOption{WithErrorOutput(&errOut)}, tc.opts...)
+
+			Redact(tc.input, opts...)
+
+			assert.Equal(t, tc.expect, tc.input)
+			assert.Empty(t, errOut.String(), "no warnings expected")
+		})
+	}
+}
+
 func TestRedactURL(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

Adds `WithHeaderValueKeys(...)` so specific map keys can hold comma-separated HTTP headers (`Name=Value,Name=Value`).

During redaction, those values are parsed, each header name is checked with the existing redactKey rules, and the original key is replaced with expanded entries like `FLEET_HEADER::X-Elastic-App-Auth`. Sensitive headers become `REDACTED`; others keep their values.

## Why is it important?

<!-- Mandatory
Explain here the WHY, or the rationale/motivation for the changes.
-->

Environment variables can store HTTP headers in a single string field (e.g. `FLEET_HEADER`). The redactor only looked at map keys before, so secrets inside those strings could leak into diagnostics. This lets us redact sensitive headers without wiping the whole field.

Example of problematic ENV var:
```yaml
FLEET_HEADER: X-Elastic-App-Auth=eyJhbGciOiJSUzI1NiJ9... 
```

Result after redaction:
```yaml
FLEET_HEADER: REDACTED # to understand that this is the original value, and the variable was set
FLEET_HEADER::X-Elastic-App-Auth: REDACTED # to understand each individual header that was set
```

Please check the added test cases to get an overview of how this applies in multiple scenarios.

## Checklist

<!-- Mandatory
Add a checklist of things that are required to be reviewed in order to have the PR approved

List here all the items you have verified BEFORE sending this PR. Please DO NOT remove any item, striking through those that do not apply. (Just in case, strikethrough uses two tildes. ~~Scratch this.~~)
-->

- [x] My code follows the style guidelines of this project
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works

## Author's Checklist

<!-- Recommended
Add a checklist of things that are required to be reviewed in order to have the PR approved
-->
- [ ]

## Related issues

<!-- Recommended
Link related issues below. Insert the issue link or reference after the word "Closes" if merging this should automatically close it.

- Closes #123
- Relates #123
- Requires #123
- Superseds #123
-->
- 

