### PR TITLE
Remove global logger from tlscommon package

### DIFF
--- a/transport/tlscommon/ca_reloader.go
+++ b/transport/tlscommon/ca_reloader.go
@@ -50,7 +50,7 @@ type CAReloader struct {
 // strings are also accepted and will be included on every reload (they never
 // change, but are needed to build a complete pool). An initial load is
 // performed; an error is returned only if no CA could be loaded at all.
-func NewCAReloader(caPaths []string, reloadInterval time.Duration) (*CAReloader, error) {
+func NewCAReloader(caPaths []string, reloadInterval time.Duration, logger *logp.Logger) (*CAReloader, error) {
 	if len(caPaths) == 0 {
 		return nil, fmt.Errorf("at least one CA path must be provided")
 	}
@@ -62,10 +62,10 @@ func NewCAReloader(caPaths []string, reloadInterval time.Duration) (*CAReloader,
 	r := &CAReloader{
 		caPaths:        caPaths,
 		reloadInterval: reloadInterval,
-		log:            logp.NewLogger("tls"),
+		log:            logger.Named("tls"),
 	}
 
-	pool, errs := LoadCertificateAuthorities(r.caPaths)
+	pool, errs := LoadCertificateAuthorities(r.caPaths, logger)
 	if len(errs) == len(r.caPaths) {
 		return nil, fmt.Errorf("initial CA load failed, none of the %d CA(s) could be loaded: %v", len(r.caPaths), errs)
 	}
@@ -96,7 +96,7 @@ func (r *CAReloader) GetCertPool() *x509.CertPool {
 
 	r.nextReload = time.Now().Add(r.reloadInterval)
 
-	pool, errs := LoadCertificateAuthorities(r.caPaths)
+	pool, errs := LoadCertificateAuthorities(r.caPaths, r.log)
 	if len(errs) == len(r.caPaths) {
 		r.log.Warnf("CA reload failed for all %d CA(s), keeping previous pool: %v", len(r.caPaths), errs)
 		return r.pool

--- a/transport/tlscommon/ca_reloader_test.go
+++ b/transport/tlscommon/ca_reloader_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/elastic/elastic-agent-libs/testing/certutil"
 )
 
@@ -44,7 +45,7 @@ func TestNewCAReloader_ValidCA(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 5*time.Second)
+	r, err := NewCAReloader([]string{caPath}, 5*time.Second, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	pool := r.GetCertPool()
@@ -56,17 +57,17 @@ func TestNewCAReloader_InvalidCA(t *testing.T) {
 	path := filepath.Join(dir, "bad.pem")
 	require.NoError(t, os.WriteFile(path, []byte("not a cert"), 0o600))
 
-	_, err := NewCAReloader([]string{path}, 5*time.Second)
+	_, err := NewCAReloader([]string{path}, 5*time.Second, logptest.NewTestingLogger(t, ""))
 	assert.Error(t, err)
 }
 
 func TestNewCAReloader_MissingFile(t *testing.T) {
-	_, err := NewCAReloader([]string{"/nonexistent/ca.pem"}, 5*time.Second)
+	_, err := NewCAReloader([]string{"/nonexistent/ca.pem"}, 5*time.Second, logptest.NewTestingLogger(t, ""))
 	assert.Error(t, err)
 }
 
 func TestNewCAReloader_EmptyPaths(t *testing.T) {
-	_, err := NewCAReloader([]string{}, 5*time.Second)
+	_, err := NewCAReloader([]string{}, 5*time.Second, logptest.NewTestingLogger(t, ""))
 	assert.Error(t, err)
 }
 
@@ -74,7 +75,7 @@ func TestCAReloader_ReloadsAfterInterval(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	initialPool := r.GetCertPool()
@@ -95,7 +96,7 @@ func TestCAReloader_InvalidNewCA_KeepsOld(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	initialPool := r.GetCertPool()
@@ -115,7 +116,7 @@ func TestCAReloader_NoReloadBeforeInterval(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 1*time.Hour)
+	r, err := NewCAReloader([]string{caPath}, 1*time.Hour, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	initialPool := r.GetCertPool()
@@ -133,7 +134,7 @@ func TestCAReloader_PartialReloadFailure_UsesSuccessfulCAs(t *testing.T) {
 	caPath1 := writeCAFile(t, dir, "ca1.pem")
 	caPath2 := writeCAFile(t, dir, "ca2.pem")
 
-	r, err := NewCAReloader([]string{caPath1, caPath2}, 100*time.Millisecond)
+	r, err := NewCAReloader([]string{caPath1, caPath2}, 100*time.Millisecond, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	initialPool := r.GetCertPool()
@@ -154,7 +155,7 @@ func TestCAReloader_TotalReloadFailure_KeepsOldPool(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	initialPool := r.GetCertPool()
@@ -175,7 +176,7 @@ func TestCAReloader_AddTrustedCert_SurvivesReload(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond)
+	r, err := NewCAReloader([]string{caPath}, 100*time.Millisecond, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	// Generate a separate CA cert and add it via AddTrustedCert.
@@ -207,7 +208,7 @@ func TestCAReloader_AddTrustedCert_Deduplicates(t *testing.T) {
 	dir := t.TempDir()
 	caPath := writeCAFile(t, dir, "ca.pem")
 
-	r, err := NewCAReloader([]string{caPath}, 1*time.Hour)
+	r, err := NewCAReloader([]string{caPath}, 1*time.Hour, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	_, _, pair, err := certutil.NewRootCA()
@@ -232,7 +233,7 @@ func TestCAReloader_InlinePEM(t *testing.T) {
 	require.NoError(t, err)
 
 	// Pass the PEM directly as an inline string (starts with "-").
-	r, err := NewCAReloader([]string{string(pair.Cert)}, 5*time.Second)
+	r, err := NewCAReloader([]string{string(pair.Cert)}, 5*time.Second, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	pool := r.GetCertPool()

--- a/transport/tlscommon/cert_reloader.go
+++ b/transport/tlscommon/cert_reloader.go
@@ -78,7 +78,7 @@ func WithDisableLegacyPEMSupport(disable bool) CertReloaderOption {
 // NewCertReloader creates a CertReloader for the given cert and key file paths.
 // It performs an initial load of the certificate pair, returning an error if the
 // initial load fails.
-func NewCertReloader(certPath, keyPath string, opts ...CertReloaderOption) (*CertReloader, error) {
+func NewCertReloader(certPath, keyPath string, logger *logp.Logger, opts ...CertReloaderOption) (*CertReloader, error) {
 	if certPath == "" || keyPath == "" {
 		return nil, fmt.Errorf("certificate and key paths must be non-empty")
 	}
@@ -93,7 +93,7 @@ func NewCertReloader(certPath, keyPath string, opts ...CertReloaderOption) (*Cer
 		certPath:       certPath,
 		keyPath:        keyPath,
 		reloadInterval: defaultReloadInterval,
-		log:            logp.NewLogger("tls"),
+		log:            logger.Named("tls"),
 	}
 	for _, opt := range opts {
 		opt(r)

--- a/transport/tlscommon/cert_reloader_nofips_test.go
+++ b/transport/tlscommon/cert_reloader_nofips_test.go
@@ -29,9 +29,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 func writeEncryptedKeyAndCertFiles(t *testing.T, dir string, blockType int, passphrase string) (certPath, keyPath string) {

--- a/transport/tlscommon/cert_reloader_nofips_test.go
+++ b/transport/tlscommon/cert_reloader_nofips_test.go
@@ -29,6 +29,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -51,7 +52,7 @@ func TestNewCertReloader_WithPassphrase_PKCS1(t *testing.T) {
 	passphrase := "test-passphrase"
 	certPath, keyPath := writeEncryptedKeyAndCertFiles(t, dir, blockTypePKCS1Encrypted, passphrase)
 
-	r, err := NewCertReloader(certPath, keyPath, WithPassphrase(passphrase))
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithPassphrase(passphrase))
 	require.NoError(t, err)
 
 	got, err := r.GetCertificate(nil)
@@ -65,7 +66,7 @@ func TestNewCertReloader_WithPassphrase_PKCS8(t *testing.T) {
 	passphrase := "test-passphrase"
 	certPath, keyPath := writeEncryptedKeyAndCertFiles(t, dir, blockTypePKCS8Encrypted, passphrase)
 
-	r, err := NewCertReloader(certPath, keyPath, WithPassphrase(passphrase))
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithPassphrase(passphrase))
 	require.NoError(t, err)
 
 	got, err := r.GetCertificate(nil)
@@ -78,7 +79,7 @@ func TestNewCertReloader_WithPassphrase_WrongPassphrase(t *testing.T) {
 	dir := t.TempDir()
 	certPath, keyPath := writeEncryptedKeyAndCertFiles(t, dir, blockTypePKCS8Encrypted, "correct-passphrase")
 
-	_, err := NewCertReloader(certPath, keyPath, WithPassphrase("wrong-passphrase"))
+	_, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithPassphrase("wrong-passphrase"))
 	assert.Error(t, err)
 }
 
@@ -87,7 +88,7 @@ func TestCertReloader_WithPassphrase_ReloadsAfterInterval(t *testing.T) {
 	passphrase := "test-passphrase"
 	certPath, keyPath := writeEncryptedKeyAndCertFiles(t, dir, blockTypePKCS8Encrypted, passphrase)
 
-	r, err := NewCertReloader(certPath, keyPath, WithPassphrase(passphrase), WithReloadInterval(100*time.Millisecond))
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithPassphrase(passphrase), WithReloadInterval(100*time.Millisecond))
 	require.NoError(t, err)
 
 	initial, err := r.GetCertificate(nil)

--- a/transport/tlscommon/cert_reloader_test.go
+++ b/transport/tlscommon/cert_reloader_test.go
@@ -24,6 +24,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -47,7 +48,7 @@ func TestNewCertReloader_ValidCertPair(t *testing.T) {
 	dir := t.TempDir()
 	certPath, keyPath := writeKeyAndCertFiles(t, dir)
 
-	r, err := NewCertReloader(certPath, keyPath)
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	got, err := r.GetCertificate(nil)
@@ -68,17 +69,17 @@ func TestNewCertReloader_InvalidCertPair(t *testing.T) {
 	require.NoError(t, os.WriteFile(certPath, []byte(certPEM1), 0o600))
 	require.NoError(t, os.WriteFile(keyPath, []byte(keyPEM2), 0o600))
 
-	_, err := NewCertReloader(certPath, keyPath)
+	_, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""))
 	assert.Error(t, err)
 }
 
 func TestNewCertReloader_MissingFiles(t *testing.T) {
-	_, err := NewCertReloader("/nonexistent/cert.pem", "/nonexistent/key.pem")
+	_, err := NewCertReloader("/nonexistent/cert.pem", "/nonexistent/key.pem", logptest.NewTestingLogger(t, ""))
 	assert.Error(t, err)
 }
 
 func TestNewCertReloader_EmptyPaths(t *testing.T) {
-	_, err := NewCertReloader("", "")
+	_, err := NewCertReloader("", "", logptest.NewTestingLogger(t, ""))
 	assert.Error(t, err)
 }
 
@@ -86,7 +87,7 @@ func TestCertReloader_ReloadsAfterInterval(t *testing.T) {
 	dir := t.TempDir()
 	certPath, keyPath := writeKeyAndCertFiles(t, dir)
 
-	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(100*time.Millisecond))
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithReloadInterval(100*time.Millisecond))
 	require.NoError(t, err)
 
 	// Capture the initial certificate bytes.
@@ -108,7 +109,7 @@ func TestCertReloader_InvalidNewCert_KeepsOld(t *testing.T) {
 	dir := t.TempDir()
 	certPath, keyPath := writeKeyAndCertFiles(t, dir)
 
-	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(100*time.Millisecond))
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithReloadInterval(100*time.Millisecond))
 	require.NoError(t, err)
 
 	initial, err := r.GetCertificate(nil)
@@ -134,7 +135,7 @@ func TestCertReloader_NoReloadBeforeInterval(t *testing.T) {
 	certPath, keyPath := writeKeyAndCertFiles(t, dir)
 
 	// Use a long reload interval so it won't elapse during the test.
-	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(1*time.Hour))
+	r, err := NewCertReloader(certPath, keyPath, logptest.NewTestingLogger(t, ""), WithReloadInterval(1*time.Hour))
 	require.NoError(t, err)
 
 	initial, err := r.GetCertificate(nil)

--- a/transport/tlscommon/cert_reloader_test.go
+++ b/transport/tlscommon/cert_reloader_test.go
@@ -24,9 +24,10 @@ import (
 	"testing"
 	"time"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 // writeKeyAndCertFiles generates a cert/key pair and writes them to dir,

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -92,7 +92,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		if config.CertificateReload.ReloadInterval > 0 {
 			reloadOpts = append(reloadOpts, WithReloadInterval(config.CertificateReload.ReloadInterval))
 		}
-		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, reloadOpts...)
+		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, logger, reloadOpts...)
 		logFail(err)
 	} else {
 		cert, err := LoadCertificate(&config.Certificate)

--- a/transport/tlscommon/config.go
+++ b/transport/tlscommon/config.go
@@ -65,13 +65,13 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 	var rootCAs certPoolProvider
 
 	if len(config.CAs) > 0 && config.CertificateReload.IsEnabled() {
-		reloader, err := NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
+		reloader, err := NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval, logger)
 		logFail(err)
 		if reloader != nil {
 			rootCAs = reloader
 		}
 	} else if len(config.CAs) > 0 {
-		pool, errs := LoadCertificateAuthorities(config.CAs)
+		pool, errs := LoadCertificateAuthorities(config.CAs, logger)
 		logFail(errs...)
 		rootCAs = newStaticCertPool(pool)
 	}
@@ -95,7 +95,7 @@ func LoadTLSConfig(config *Config, logger *logp.Logger) (*TLSConfig, error) {
 		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, logger, reloadOpts...)
 		logFail(err)
 	} else {
-		cert, err := LoadCertificate(&config.Certificate)
+		cert, err := LoadCertificate(&config.Certificate, logger)
 		logFail(err)
 		if cert != nil {
 			certs = []tls.Certificate{*cert}

--- a/transport/tlscommon/diag.go
+++ b/transport/tlscommon/diag.go
@@ -25,6 +25,8 @@ import (
 	"io"
 	"log"
 	"time"
+
+	"github.com/elastic/elastic-agent-libs/logp"
 )
 
 // DiagCerts returns a diagnostics hook callback that will validate if the certifiactes (cert + key, and CAs) present in the config are valid.
@@ -84,7 +86,7 @@ func diagCertificate(logger *log.Logger, cfg *CertificateConfig) {
 		logger.Print("certificate keypair is nil.")
 		return
 	}
-	crt, err := LoadCertificate(cfg)
+	crt, err := LoadCertificate(cfg, logp.NewNopLogger())
 	if err != nil {
 		logger.Printf("certificate keypair error: %v", err)
 		return

--- a/transport/tlscommon/diag.go
+++ b/transport/tlscommon/diag.go
@@ -86,6 +86,9 @@ func diagCertificate(logger *log.Logger, cfg *CertificateConfig) {
 		logger.Print("certificate keypair is nil.")
 		return
 	}
+
+	// Since current method accepts a std logger which is incompatible
+	// with *logp.Logger type expected below - we use a no-op logger instead.
 	crt, err := LoadCertificate(cfg, logp.NewNopLogger())
 	if err != nil {
 		logger.Printf("certificate keypair error: %v", err)

--- a/transport/tlscommon/reload_bench_test.go
+++ b/transport/tlscommon/reload_bench_test.go
@@ -86,7 +86,7 @@ func BenchmarkCertLoad(b *testing.B) {
 		b.ReportAllocs()
 		var sink *CertReloader
 		for i := 0; i < b.N; i++ {
-			r, err := NewCertReloader(certPath, keyPath)
+			r, err := NewCertReloader(certPath, keyPath, logp.NewNopLogger())
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -218,7 +218,7 @@ func BenchmarkLoadTLSServerConfig(b *testing.B) {
 func BenchmarkCertReloader_GetCertificate_WithinInterval(b *testing.B) {
 	dir := b.TempDir()
 	certPath, keyPath := writeKeyAndCertFiles(b, dir)
-	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(time.Hour))
+	r, err := NewCertReloader(certPath, keyPath, logp.NewNopLogger(), WithReloadInterval(time.Hour))
 	if err != nil {
 		b.Fatalf("creating cert reloader: %v", err)
 	}
@@ -256,7 +256,7 @@ func BenchmarkCAReloader_GetCertPool_WithinInterval(b *testing.B) {
 func BenchmarkCertReloader_GetCertificate_ReloadEveryCall(b *testing.B) {
 	dir := b.TempDir()
 	certPath, keyPath := writeKeyAndCertFiles(b, dir)
-	r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(time.Nanosecond))
+	r, err := NewCertReloader(certPath, keyPath, logp.NewNopLogger(), WithReloadInterval(time.Nanosecond))
 	if err != nil {
 		b.Fatalf("creating cert reloader: %v", err)
 	}
@@ -369,7 +369,7 @@ func BenchmarkCertReloader_HeapAfterManyReloadCycles(b *testing.B) {
 	certPath, keyPath := writeKeyAndCertFiles(b, dir)
 
 	for i := 0; i < b.N; i++ {
-		r, err := NewCertReloader(certPath, keyPath, WithReloadInterval(time.Nanosecond))
+		r, err := NewCertReloader(certPath, keyPath, logp.NewNopLogger(), WithReloadInterval(time.Nanosecond))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -453,7 +453,7 @@ func setupBenchEndpoints(b *testing.B, n int) []benchEndpoint {
 		}
 		certPath, keyPath := writeKeyAndCertFiles(b, dir)
 		caPath := writeCAFile(b, dir, "ca.pem")
-		certReloader, err := NewCertReloader(certPath, keyPath, WithReloadInterval(time.Nanosecond))
+		certReloader, err := NewCertReloader(certPath, keyPath, logp.NewNopLogger(), WithReloadInterval(time.Nanosecond))
 		if err != nil {
 			b.Fatalf("creating cert reloader for endpoint %d: %v", i, err)
 		}

--- a/transport/tlscommon/reload_bench_test.go
+++ b/transport/tlscommon/reload_bench_test.go
@@ -73,7 +73,7 @@ func BenchmarkCertLoad(b *testing.B) {
 		b.ReportAllocs()
 		var sink *tls.Certificate
 		for i := 0; i < b.N; i++ {
-			cert, err := LoadCertificate(cfg)
+			cert, err := LoadCertificate(cfg, logp.NewNopLogger())
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -105,7 +105,7 @@ func BenchmarkCAPoolLoad(b *testing.B) {
 		b.ReportAllocs()
 		var sink *staticCertPool
 		for i := 0; i < b.N; i++ {
-			pool, errs := LoadCertificateAuthorities(caPaths)
+			pool, errs := LoadCertificateAuthorities(caPaths, logp.NewNopLogger())
 			if len(errs) > 0 {
 				b.Fatal(errs)
 			}
@@ -118,7 +118,7 @@ func BenchmarkCAPoolLoad(b *testing.B) {
 		b.ReportAllocs()
 		var sink *CAReloader
 		for i := 0; i < b.N; i++ {
-			r, err := NewCAReloader(caPaths, time.Hour)
+			r, err := NewCAReloader(caPaths, time.Hour, logp.NewNopLogger())
 			if err != nil {
 				b.Fatal(err)
 			}
@@ -136,7 +136,7 @@ func BenchmarkLoadTLSConfig(b *testing.B) {
 	dir := b.TempDir()
 	caPath := writeCAFile(b, dir, "ca.pem")
 	certPath, keyPath := writeKeyAndCertFiles(b, dir)
-	logger := logp.NewLogger("bench")
+	logger := logp.NewNopLogger()
 
 	disabled, enabled := false, true
 
@@ -175,7 +175,7 @@ func BenchmarkLoadTLSServerConfig(b *testing.B) {
 	dir := b.TempDir()
 	caPath := writeCAFile(b, dir, "ca.pem")
 	certPath, keyPath := writeKeyAndCertFiles(b, dir)
-	logger := logp.NewLogger("bench")
+	logger := logp.NewNopLogger()
 
 	disabled, enabled := false, true
 
@@ -236,7 +236,7 @@ func BenchmarkCertReloader_GetCertificate_WithinInterval(b *testing.B) {
 func BenchmarkCAReloader_GetCertPool_WithinInterval(b *testing.B) {
 	dir := b.TempDir()
 	caPath := writeCAFile(b, dir, "ca.pem")
-	r, err := NewCAReloader([]string{caPath}, time.Hour)
+	r, err := NewCAReloader([]string{caPath}, time.Hour, logp.NewNopLogger())
 	if err != nil {
 		b.Fatalf("creating CA reloader: %v", err)
 	}
@@ -274,7 +274,7 @@ func BenchmarkCertReloader_GetCertificate_ReloadEveryCall(b *testing.B) {
 func BenchmarkCAReloader_GetCertPool_ReloadEveryCall(b *testing.B) {
 	dir := b.TempDir()
 	caPath := writeCAFile(b, dir, "ca.pem")
-	r, err := NewCAReloader([]string{caPath}, time.Nanosecond)
+	r, err := NewCAReloader([]string{caPath}, time.Nanosecond, logp.NewNopLogger())
 	if err != nil {
 		b.Fatalf("creating CA reloader: %v", err)
 	}
@@ -302,7 +302,7 @@ func BenchmarkTLSConfigMemoryFootprint(b *testing.B) {
 	dir := b.TempDir()
 	caPath := writeCAFile(b, dir, "ca.pem")
 	certPath, keyPath := writeKeyAndCertFiles(b, dir)
-	logger := logp.NewLogger("bench")
+	logger := logp.NewNopLogger()
 	disabled, enabled := false, true
 
 	run := func(b *testing.B, reload CertificateReload) {
@@ -407,7 +407,7 @@ func BenchmarkCAReloader_HeapAfterManyReloadCycles(b *testing.B) {
 	caPath := writeCAFile(b, dir, "ca.pem")
 
 	for i := 0; i < b.N; i++ {
-		r, err := NewCAReloader([]string{caPath}, time.Nanosecond)
+		r, err := NewCAReloader([]string{caPath}, time.Nanosecond, logp.NewNopLogger())
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -457,7 +457,7 @@ func setupBenchEndpoints(b *testing.B, n int) []benchEndpoint {
 		if err != nil {
 			b.Fatalf("creating cert reloader for endpoint %d: %v", i, err)
 		}
-		caReloader, err := NewCAReloader([]string{caPath}, time.Nanosecond)
+		caReloader, err := NewCAReloader([]string{caPath}, time.Nanosecond, logp.NewNopLogger())
 		if err != nil {
 			b.Fatalf("creating CA reloader for endpoint %d: %v", i, err)
 		}

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -93,13 +93,13 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 	var clientCAs certPoolProvider
 
 	if len(config.CAs) > 0 && config.CertificateReload.IsEnabled() {
-		reloader, err := NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval)
+		reloader, err := NewCAReloader(config.CAs, config.CertificateReload.ReloadInterval, logger)
 		logFail(err)
 		if reloader != nil {
 			clientCAs = reloader
 		}
 	} else if len(config.CAs) > 0 {
-		pool, errs := LoadCertificateAuthorities(config.CAs)
+		pool, errs := LoadCertificateAuthorities(config.CAs, logger)
 		logFail(errs...)
 		clientCAs = newStaticCertPool(pool)
 	}
@@ -118,7 +118,7 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, logger, reloadOpts...)
 		logFail(err)
 	} else {
-		cert, err := LoadCertificate(&config.Certificate)
+		cert, err := LoadCertificate(&config.Certificate, logger)
 		logFail(err)
 		if cert != nil {
 			certs = []tls.Certificate{*cert}

--- a/transport/tlscommon/server_config.go
+++ b/transport/tlscommon/server_config.go
@@ -115,7 +115,7 @@ func LoadTLSServerConfig(config *ServerConfig, logger *logp.Logger) (*TLSConfig,
 		if config.CertificateReload.ReloadInterval > 0 {
 			reloadOpts = append(reloadOpts, WithReloadInterval(config.CertificateReload.ReloadInterval))
 		}
-		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, reloadOpts...)
+		reloader, err = NewCertReloader(config.Certificate.Certificate, config.Certificate.Key, logger, reloadOpts...)
 		logFail(err)
 	} else {
 		cert, err := LoadCertificate(&config.Certificate)

--- a/transport/tlscommon/tls.go
+++ b/transport/tlscommon/tls.go
@@ -31,10 +31,8 @@ import (
 	"github.com/elastic/elastic-agent-libs/logp"
 )
 
-const logSelector = "tls"
-
 // LoadCertificate will load a certificate from disk and return a tls.Certificate or error
-func LoadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
+func LoadCertificate(config *CertificateConfig, logger *logp.Logger) (*tls.Certificate, error) {
 	if err := config.Validate(); err != nil {
 		return nil, err
 	}
@@ -45,7 +43,7 @@ func LoadCertificate(config *CertificateConfig) (*tls.Certificate, error) {
 		return nil, nil
 	}
 
-	log := logp.NewLogger(logSelector)
+	log := logger.Named("tls")
 	passphrase, err := config.resolvePassphrase()
 	if err != nil {
 		return nil, err
@@ -157,14 +155,14 @@ func readPEMFile(log *logp.Logger, s, passphrase string, disableLegacy bool) ([]
 }
 
 // LoadCertificateAuthorities read the slice of CAcert and return a Certpool.
-func LoadCertificateAuthorities(CAs []string) (*x509.CertPool, []error) {
+func LoadCertificateAuthorities(CAs []string, logger *logp.Logger) (*x509.CertPool, []error) {
 	errors := []error{}
 
 	if len(CAs) == 0 {
 		return nil, nil
 	}
 
-	log := logp.NewLogger(logSelector)
+	log := logger.Named("tls")
 	roots := x509.NewCertPool()
 	for _, s := range CAs {
 		r, err := NewPEMReader(s)

--- a/transport/tlscommon/tls_config_test.go
+++ b/transport/tlscommon/tls_config_test.go
@@ -325,7 +325,7 @@ func TestTrustRootCA_WithCAReloader(t *testing.T) {
 		Bytes: certs["ca"].Raw,
 	}), 0o600))
 
-	reloader, err := NewCAReloader([]string{caPath}, 1*time.Hour)
+	reloader, err := NewCAReloader([]string{caPath}, 1*time.Hour, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 
 	cfg := TLSConfig{

--- a/transport/tlscommon/tls_fips_test.go
+++ b/transport/tlscommon/tls_fips_test.go
@@ -363,6 +363,7 @@ func TestFIPSVerifyServerConnectionDynamicCAs(t *testing.T) {
 	reloader, err := NewCAReloader(
 		[]string{filepath.Join("testdata", "ca.crt")},
 		0,
+		logptest.NewTestingLogger(t, ""),
 	)
 	require.NoError(t, err)
 	require.True(t, reloader.IsDynamic())


### PR DESCRIPTION
<!-- Type of change
Please label this PR with one of the following labels, depending on the scope of your change:
- Bug
- Enhancement
- Breaking change
- Deprecation
- Cleanup
- Docs
-->

## What does this PR do?
This PR removes global logger instances from tlscommon package

<!-- Mandatory
Explain here the changes you made on the PR. Please explain the WHAT: patterns used, algorithms implemented, design architecture, message processing, etc.
-->

## Why is it important?
To be able to run beatreceivers with their loggers colliding



