### PR TITLE
feat(testing/fipsscan): add FIPS dependency scanner helper package

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,5 +21,6 @@ Provided packages:
 * `github.com/elastic/elastic-agent-libs/service` utilities to inspect services and collect debug data.
 * `github.com/elastic/elastic-agent-libs/str` the previous `stringset.go` file from `github.com/elastic/beats/v7/libbeat/common`. It provides a string set implementation. 
 * `github.com/elastic/elastic-agent-libs/testing` Testing helpers for network communication and outputs.
+* `github.com/elastic/elastic-agent-libs/testing/fipsscan` Test helper for auditing FIPS 140-3 compliance — scans a binary's dependency tree for forbidden (non-certified) crypto imports and maintains a known-violations allowlist. Requires the `requirefips` build tag.
 * `github.com/elastic/elastic-agent-libs/transport/tlscommon` TLS configuration and validation, CA pinning, etc.
 * `github.com/elastic/elastic-agent-libs/transport` Dialers for testing, TLS, etc.

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -1,0 +1,203 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+// Package fipsscan provides helpers for auditing FIPS 140-3 compliance of Go
+// binaries by scanning their dependency trees for forbidden (non-FIPS) imports.
+// Only crypto/* stdlib packages are covered by Go's certified FIPS 140-3 module
+// (GOFIPS140=v1.0.0); other crypto implementations are potential violations.
+package fipsscan
+
+import (
+	"encoding/json"
+	"errors"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+// XCrypto is the import path prefix for golang.org/x/crypto, which is not
+// covered by Go's certified FIPS 140-3 module. Use as the forbiddenPkgs entry
+// for standard FIPS compliance checks.
+const XCrypto = "golang.org/x/crypto/"
+
+// Violation is a forbidden import discovered in the dependency tree.
+type Violation struct {
+	Importer string // package that imports the forbidden package
+	Imported string // forbidden package being imported
+}
+
+type goListPackage struct {
+	ImportPath string
+	Imports    []string
+}
+
+// Scan runs `go list -json -deps -tags requirefips <pkg>` and returns all
+// packages that directly import golang.org/x/crypto or any prefix in
+// extraForbiddenPkgs, along with the full import graph. Packages whose own
+// path matches a forbidden prefix are skipped (avoids flagging internal refs).
+// Calls t.Fatalf on subprocess or parse errors.
+func Scan(t testing.TB, pkg string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "go", "list", "-json", "-deps", "-tags", "requirefips", pkg)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			t.Fatalf("go list failed: %v\n%s", err, exitErr.Stderr)
+		}
+		t.Fatalf("go list failed: %v", err)
+	}
+
+	forbidden := append([]string{XCrypto}, extraForbiddenPkgs...)
+
+	importGraph := make(map[string][]string)
+	var violations []Violation
+
+	dec := json.NewDecoder(strings.NewReader(string(out)))
+	for dec.More() {
+		var p goListPackage
+		if err := dec.Decode(&p); err != nil {
+			t.Fatalf("parsing go list output: %v", err)
+		}
+		importGraph[p.ImportPath] = p.Imports
+
+		if isForbidden(p.ImportPath, forbidden) {
+			continue
+		}
+		for _, imp := range p.Imports {
+			if isForbidden(imp, forbidden) {
+				violations = append(violations, Violation{
+					Importer: p.ImportPath,
+					Imported: imp,
+				})
+			}
+		}
+	}
+
+	return violations, importGraph
+}
+
+func isForbidden(pkg string, forbiddenPkgs []string) bool {
+	for _, prefix := range forbiddenPkgs {
+		if strings.HasPrefix(pkg, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// ShortestChain returns the shortest path from `from` to `to` using forward
+// edges in importGraph (package -> packages it imports). Returns nil if no path.
+func ShortestChain(from, to string, importGraph map[string][]string) []string {
+	if from == to {
+		return []string{from}
+	}
+
+	type state struct {
+		pkg  string
+		path []string
+	}
+
+	visited := make(map[string]bool)
+	visited[from] = true
+	queue := []state{{pkg: from, path: []string{from}}}
+
+	for len(queue) > 0 {
+		cur := queue[0]
+		queue = queue[1:]
+
+		for _, next := range importGraph[cur.pkg] {
+			if visited[next] {
+				continue
+			}
+			newPath := make([]string, len(cur.path)+1)
+			copy(newPath, cur.path)
+			newPath[len(cur.path)] = next
+
+			if next == to {
+				return newPath
+			}
+
+			visited[next] = true
+			queue = append(queue, state{pkg: next, path: newPath})
+		}
+	}
+
+	return nil
+}
+
+// FormatChain joins a chain with indented " -> " separators for readable output:
+//
+//	pkg/a
+//	      -> pkg/b
+//	      -> pkg/c
+func FormatChain(chain []string) string {
+	if len(chain) == 0 {
+		return ""
+	}
+	parts := make([]string, len(chain))
+	parts[0] = chain[0]
+	for i := 1; i < len(chain); i++ {
+		parts[i] = "      -> " + chain[i]
+	}
+	return strings.Join(parts, "\n")
+}
+
+// CheckViolations scans binaryPkg for golang.org/x/crypto imports and any
+// additional prefixes in extraForbiddenPkgs, attributes each violation to the
+// first-hop component from rootPkg, and reports unknown violations or stale
+// knownViolations entries via t.Errorf.
+func CheckViolations(t testing.TB, binaryPkg, rootPkg string, extraForbiddenPkgs []string, knownViolations map[string]string) {
+	t.Helper()
+
+	violations, importGraph := Scan(t, binaryPkg, extraForbiddenPkgs)
+
+	found := make(map[string]bool)
+
+	for _, v := range violations {
+		chain := ShortestChain(rootPkg, v.Importer, importGraph)
+		if chain == nil {
+			chain = []string{v.Importer}
+		}
+		displayChain := make([]string, len(chain)+1)
+		copy(displayChain, chain)
+		displayChain[len(chain)] = v.Imported
+
+		var component string
+		if len(chain) > 1 {
+			component = chain[1]
+		} else {
+			component = chain[0]
+		}
+
+		if reason, ok := knownViolations[component]; !ok {
+			t.Errorf("NEW violation via unknown component — add to knownViolations or remove the dependency:\n      -> %s", FormatChain(displayChain))
+		} else {
+			t.Logf("known violation [%s] via %s:\n      -> %s\n      reason: %s", v.Imported, component, FormatChain(displayChain), reason)
+			found[component] = true
+		}
+	}
+
+	for component := range knownViolations {
+		if !found[component] {
+			t.Errorf("stale knownViolations entry (component no longer reaches a forbidden package — remove it): %s", component)
+		}
+	}
+}

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -1,0 +1,128 @@
+// Licensed to Elasticsearch B.V. under one or more contributor
+// license agreements. See the NOTICE file distributed with
+// this work for additional information regarding copyright
+// ownership. Elasticsearch B.V. licenses this file to you under
+// the Apache License, Version 2.0 (the "License"); you may
+// not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+//go:build requirefips
+
+package fipsscan
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestShortestChain(t *testing.T) {
+	graph := map[string][]string{
+		"root":   {"a", "b"},
+		"a":      {"c", "d"},
+		"b":      {"d", "e"},
+		"c":      {"target"},
+		"d":      {"e"},
+		"e":      {},
+		"target": {},
+	}
+
+	tests := []struct {
+		name string
+		from string
+		to   string
+		want []string
+	}{
+		{
+			name: "direct child",
+			from: "root",
+			to:   "a",
+			want: []string{"root", "a"},
+		},
+		{
+			name: "two hops",
+			from: "root",
+			to:   "c",
+			want: []string{"root", "a", "c"},
+		},
+		{
+			name: "shortest of two paths",
+			from: "root",
+			to:   "target",
+			want: []string{"root", "a", "c", "target"},
+		},
+		{
+			name: "same node",
+			from: "root",
+			to:   "root",
+			want: []string{"root"},
+		},
+		{
+			name: "no path",
+			from: "root",
+			to:   "unreachable",
+			want: nil,
+		},
+		{
+			name: "leaf with no edges",
+			from: "root",
+			to:   "e",
+			want: []string{"root", "b", "e"},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ShortestChain(tc.from, tc.to, graph)
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("ShortestChain(%q, %q) = %v, want %v", tc.from, tc.to, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestFormatChain(t *testing.T) {
+	tests := []struct {
+		name  string
+		chain []string
+		want  string
+	}{
+		{
+			name:  "empty",
+			chain: []string{},
+			want:  "",
+		},
+		{
+			name:  "single",
+			chain: []string{"pkg/a"},
+			want:  "pkg/a",
+		},
+		{
+			name:  "two",
+			chain: []string{"pkg/a", "pkg/b"},
+			want:  "pkg/a\n      -> pkg/b",
+		},
+		{
+			name:  "three",
+			chain: []string{"pkg/a", "pkg/b", "pkg/c"},
+			want:  "pkg/a\n      -> pkg/b\n      -> pkg/c",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := FormatChain(tc.chain)
+			if got != tc.want {
+				t.Errorf("FormatChain(%v) =\n%q\nwant:\n%q", tc.chain, got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds `testing/fipsscan` — a helper package for testing and documenting FIPS 140-3 compliance violations in Go binaries.

I would like to use it across different repos, so we can track the status of strict FIPS compliance adoption and prevent regressions

Go's certified FIPS 140-3 module (`GOFIPS140=v1.0.0`) only covers `crypto/*` stdlib packages. `golang.org/x/crypto` and other third-party crypto implementations are not covered. This package scans a binary's full dependency tree and surfaces every such import, attributing it to the responsible component and tracking known exceptions.

## Usage

```go
//go:build requirefips

package main_test

import (
    "testing"
    "github.com/elastic/elastic-agent-libs/testing/fipsscan"
)

var knownViolations = map[string]string{
    "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/sqlserverreceiver": "transitively imports x/crypto/md4 (Kerberos RC4-HMAC, NTLM)",
    "github.com/open-telemetry/opentelemetry-collector-contrib/receiver/mongodbreceiver":  "transitively imports x/crypto/pbkdf2, x/crypto/scrypt, x/crypto/ocsp",
}

const (
    binaryPkg = "github.com/elastic/elastic-agent/internal/edot"
    rootPkg   = "github.com/elastic/elastic-agent/internal/edot"
)

func TestFIPSFullyCompliant(t *testing.T) {
    fipsscan.CheckViolations(t, binaryPkg, rootPkg, nil, knownViolations)
}
```

`CheckViolations` fails the test for any new unknown violation (must be added to `knownViolations` or the dependency removed) and for any stale entry in `knownViolations` that no longer reaches a forbidden package. Pass `extraForbiddenPkgs` to flag additional non-FIPS packages beyond `x/crypto`.
