### PR TITLE
Fix golang ci lint

### DIFF
--- a/transport/tlscommon/cert_reloader_test.go
+++ b/transport/tlscommon/cert_reloader_test.go
@@ -109,7 +109,7 @@ func TestNewCertReloader_RejectsInlinePEM(t *testing.T) {
 
 	for name, tc := range tests {
 		t.Run(name, func(t *testing.T) {
-			_, err := NewCertReloader(tc.cert, tc.key)
+			_, err := NewCertReloader(tc.cert, tc.key, logptest.NewTestingLogger(t, ""))
 			require.Error(t, err)
 		})
 	}

--- a/transport/tlscommon/tls_redact_test.go
+++ b/transport/tlscommon/tls_redact_test.go
@@ -23,9 +23,10 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 )
 
 // midBodyLine returns a line from the middle of a PEM block, i.e. real base64

--- a/transport/tlscommon/tls_redact_test.go
+++ b/transport/tlscommon/tls_redact_test.go
@@ -23,6 +23,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/elastic/elastic-agent-libs/logp/logptest"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -92,12 +93,13 @@ func TestLoadCertificateDoesNotLeakPEM(t *testing.T) {
 		},
 	}
 
+	logger := logptest.NewTestingLogger(t, "")
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			_, err := LoadCertificate(&CertificateConfig{
 				Certificate: tc.certificate,
 				Key:         tc.key,
-			})
+			}, logger)
 			require.Error(t, err)
 
 			msg := err.Error()
@@ -133,11 +135,12 @@ func TestLoadCertificateAuthoritiesDoesNotLeakPEM(t *testing.T) {
 		},
 	}
 
+	logger := logptest.NewTestingLogger(t, "")
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			secret := midBodyLine(t, certPEM)
 
-			_, errs := LoadCertificateAuthorities([]string{tc.ca})
+			_, errs := LoadCertificateAuthorities([]string{tc.ca}, logger)
 			require.NotEmpty(t, errs)
 
 			for _, err := range errs {
@@ -158,7 +161,7 @@ func TestLoadCertificateAuthoritiesDoesNotLeakPEM(t *testing.T) {
 func TestLoadCertificateValidInlinePEM(t *testing.T) {
 	keyPEM, certPEM := makeKeyCertPair(t, blockTypePKCS8, "")
 
-	cert, err := LoadCertificate(&CertificateConfig{Certificate: certPEM, Key: keyPEM})
+	cert, err := LoadCertificate(&CertificateConfig{Certificate: certPEM, Key: keyPEM}, logptest.NewTestingLogger(t, ""))
 	require.NoError(t, err)
 	require.NotNil(t, cert)
 	assert.NotEmpty(t, cert.Certificate)
@@ -170,7 +173,7 @@ func TestLoadCertificateValidInlinePEM(t *testing.T) {
 func TestLoadCertificateMissingFileShowsPath(t *testing.T) {
 	missing := filepath.Join(t.TempDir(), "does-not-exist.pem")
 
-	_, err := LoadCertificate(&CertificateConfig{Certificate: missing, Key: missing})
+	_, err := LoadCertificate(&CertificateConfig{Certificate: missing, Key: missing}, logptest.NewTestingLogger(t, ""))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), missing, "missing file path should be visible")
 	assert.NotContains(t, err.Error(), "PEM REDACTED", "a real path must not be redacted")
@@ -254,7 +257,7 @@ func TestLoadCertificatePathWithTrailingNewlineIsNotRedacted(t *testing.T) {
 	_, err := LoadCertificate(&CertificateConfig{
 		Certificate: certPath + "\n",
 		Key:         keyPath + "\n",
-	})
+	}, logptest.NewTestingLogger(t, ""))
 	require.Error(t, err)
 	assert.NotContains(t, err.Error(), "PEM REDACTED",
 		"a file path must not be redacted just because it has a trailing newline")


### PR DESCRIPTION
This PR https://github.com/elastic/elastic-agent-libs/pull/433 introduced some ci lint failures. Fixing them here