### PR TITLE
feat(testing/fipsscan): extend the fipsscan package to improve FIPS auto-audit

### DIFF
--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -46,7 +46,11 @@ func TestFIPSCompliance(t *testing.T) {
         skipBinaries,
         nil, // project-specific extra forbidden pkgs; nil for the default set
         map[string]map[string][]fipsscan.KnownViolation{
-            // Outer key: binary entry-point path, or "" for all binaries.
+            // Outer key: binary entry-point import path, a module-root prefix
+            //   that matches any binary under it, or "" for all binaries.
+            //   E.g. "github.com/elastic/myagent" matches both
+            //   "github.com/elastic/myagent/cmd/agent" and
+            //   "github.com/elastic/myagent/cmd/other".
             // Inner key: component — a package path or module-root prefix that
             //   must be reachable from the binary AND able to reach the importer.
             //   Use a specific component (e.g. "receiver/kafkareceiver") to
@@ -54,20 +58,15 @@ func TestFIPSCompliance(t *testing.T) {
             //   (Importer, Imported) under multiple components when several are
             //   affected by the same shared library.
             //   Use "" to match any violation within that binary.
-            "github.com/elastic/myagent/cmd/agent": {
+            "github.com/elastic/myagent": {
+                // Importer is optional: "" matches any package inside the component.
+                // Imported supports module-root prefixes (trailing slash stripped automatically).
                 "github.com/elastic/gokrb5/v8": {
-                    {
-                        Importer: "github.com/elastic/gokrb5/v8/crypto/rfc3962",
-                        Imported: "github.com/jcmturner/aescts/v2",
-                        Reason:   "Elastic gokrb5 fork depends on jcmturner aescts for AES-CBC-CTS",
-                    },
+                    {Imported: "github.com/jcmturner/aescts", Reason: "Elastic gokrb5 fork depends on jcmturner aescts for AES-CBC-CTS"},
+                    {Imported: "golang.org/x/crypto/md4",     Reason: "Kerberos RC4-HMAC requires MD4; no FIPS-approved substitute"},
                 },
                 "github.com/twmb/franz-go": {
-                    {
-                        Importer: "github.com/twmb/franz-go/pkg/sasl/scram",
-                        Imported: "golang.org/x/crypto/pbkdf2",
-                        Reason:   "Kafka SCRAM SASL key derivation uses PBKDF2; x/crypto not FIPS-certified",
-                    },
+                    {Imported: "golang.org/x/crypto/pbkdf2", Reason: "Kafka SCRAM SASL key derivation uses PBKDF2; x/crypto not FIPS-certified"},
                 },
             },
         },
@@ -149,7 +148,8 @@ CheckModule(t, patterns, skipBinaries, extraForbiddenPkgs, knownViolations)
     Scans all packages matching patterns and their transitive dependencies.
     skipBinaries lists binary import paths to exclude (dev tools, scripts,
     non-shipped assets). knownViolations is map[binary]map[component][]KnownViolation:
-      - outer key: binary entry-point path, or "" for all binaries
+      - outer key: binary entry-point path, a module-root prefix (matches any
+        binary whose import path starts with it), or "" for all binaries
       - inner key: component — a package path or module-root prefix that must
         be reachable from the binary AND able to reach the violating importer;
         "" matches any violation within that binary

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -1,0 +1,136 @@
+# fipsscan
+
+`fipsscan` is a Go testing helper for auditing FIPS 140-3 compliance. It scans a package's dependency tree for imports of known non-FIPS crypto libraries and reports violations.
+
+The package is guarded by the `requirefips` build tag so it compiles — and incurs zero overhead — only in FIPS-focused test runs.
+
+## Naming convention
+
+> **Recommendation:** use the filename `fips_compliance_test.go` and the test function `TestFIPSCompliance` in every module that adopts this package.
+
+Consistent naming makes it easy to audit coverage across the Elastic ecosystem:
+
+```
+# find all modules that have a FIPS compliance test
+grep -rl 'TestFIPSCompliance' .
+
+# run only the FIPS compliance test across all modules in a monorepo
+go test -tags requirefips -run TestFIPSCompliance ./...
+```
+
+It also makes CI configuration uniform: a single `-run TestFIPSCompliance` flag works everywhere without per-module customisation.
+
+## Quick start
+
+For most modules, `CheckModule` is all you need. Create `fips_compliance_test.go`:
+
+```go
+//go:build requirefips
+
+package fips_test
+
+import (
+    "testing"
+
+    "github.com/elastic/elastic-agent-libs/testing/fipsscan"
+)
+
+func TestFIPSCompliance(t *testing.T) {
+    fipsscan.CheckModule(t,
+        "./...",
+        nil, // project-specific extra forbidden pkgs, nil for the default set
+        map[string][]fipsscan.KnownViolation{
+            // Map key is the binary entry point path.
+            // Use "" for violations that apply to all binaries or library modules.
+            // Fails on new unlisted violations AND on entries that are no
+            // longer reachable (stale), keeping this map honest over time.
+            "github.com/elastic/myagent/cmd/agent": {
+                // Kerberos AD auth — tracked in FIPS-123
+                {Importer: "github.com/jcmturner/gokrb5/v8/krb5", Imported: "github.com/jcmturner/aescts/v2"},
+            },
+        },
+    )
+}
+```
+
+Run with:
+
+```
+go test -tags requirefips ./...
+```
+
+`CheckModule` scans all packages and their transitive dependencies — binaries and libraries alike — so it works the same way regardless of module type.
+
+## Bootstrapping the known-violations map
+
+1. Call `CheckModule` with an empty map (`map[string]string{}`).
+2. The test output lists every violation: `NEW violation: <importer> imports forbidden <imported>`.
+3. Copy the importer paths into the map with a justification comment.
+4. From that point on CI enforces the contract automatically.
+
+## Advanced usage
+
+`CheckModule` covers most cases. Use the lower-level functions when you need to build a custom reporting pipeline:
+
+```go
+// all packages in the module (no BinaryPath set)
+violations, importGraph := fipsscan.Scan(t, "./...", nil)
+
+// only package main entry points (fatals if none found; BinaryPath is set on each violation)
+violations, importGraph := fipsscan.ScanBinaries(t, "./...", nil)
+
+for _, v := range violations {
+    chain := fipsscan.ShortestChain(v.BinaryPath, v.Importer, importGraph)
+    fmt.Println(fipsscan.FormatChain(append(chain, v.Imported)))
+}
+```
+
+## What is checked
+
+All functions check against `ForbiddenPkgs()` by default — a curated list of third-party crypto libraries that are not part of any FIPS 140-3 certified module boundary:
+
+| Constant | Module prefix | Reason |
+|---|---|---|
+| `XCrypto` | `golang.org/x/crypto/` | Not in Go's GOFIPS140 certified module |
+| `JcmturnerAescts` | `github.com/jcmturner/aescts/` | Own AES block cipher, not `crypto/aes` |
+| `JcmturnerGofork` | `github.com/jcmturner/gofork/` | Fork of stdlib with non-FIPS modifications |
+| `JcmturnerGokrb5` | `github.com/jcmturner/gokrb5/` | Kerberos 5; pulls in the two above |
+| `XdgGoPbkdf2` | `github.com/xdg-go/pbkdf2` | Standalone PBKDF2, not `crypto/pbkdf2` |
+| `ProtonMailGoCrypto` | `github.com/ProtonMail/go-crypto/` | OpenPGP with non-FIPS algorithms |
+| `CloudflareCircl` | `github.com/cloudflare/circl/` | SIDH, FourQ, Ristretto255, etc. |
+| `AzureGoNtlmssp` | `github.com/Azure/go-ntlmssp` | NTLM/SSPI — uses MD4/MD5/DES |
+| `YoumarkPkcs8` | `github.com/youmark/pkcs8` | May negotiate RC2/3DES/SM4 |
+| `FilippioIO` | `filippo.io/` | edwards25519, age, etc. (outside certified boundary even when implementing a FIPS-standardized algorithm) |
+
+Pass additional prefixes via `extraForbiddenPkgs` for project-specific libraries not in this list.
+
+**Deferred — `github.com/go-jose/`:** go-jose wraps stdlib `crypto/aes`, `crypto/rsa`, and `crypto/ecdsa` rather than implementing its own primitives, and its SHA-1 usage in RSA-OAEP is permitted under FIPS for key transport (NIST SP 800-131A). It is not in the baseline list to avoid false positives for common JWT/JWE usage. Projects that want stricter coverage can add it via `extraForbiddenPkgs` and manually review each hit.
+
+## API reference
+
+```
+CheckModule(t, pattern, extraForbiddenPkgs, knownViolations)
+    Scans all packages matching pattern and their transitive dependencies.
+    knownViolations is map[binary][]KnownViolation; use "" as the key for
+    violations that apply to all binaries or to library modules. t.Errorf on
+    new violations or stale entries.
+
+Scan(t, pkg, extraForbiddenPkgs)
+    Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).
+    BinaryPath is not set on violations.
+
+ScanBinaries(t, pattern, extraForbiddenPkgs)
+    Discovers all package main entries matching pattern, scans the combined
+    dependency tree in one go list pass. Sets BinaryPath on each violation.
+    Fatals if no binaries are found.
+
+ForbiddenPkgs() []string
+    Returns a fresh copy of the baseline forbidden-prefix list.
+
+ShortestChain(from, to, importGraph) []string
+    BFS shortest path through the import graph. Useful for building custom
+    violation reporters.
+
+FormatChain(chain []string) string
+    Formats an import chain for human-readable output.
+```

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -35,21 +35,38 @@ import (
     "github.com/elastic/elastic-agent-libs/testing/fipsscan"
 )
 
+// skipBinaries lists non-shipped binaries excluded from the FIPS scan.
+var skipBinaries = []string{
+    // "github.com/elastic/myagent/dev-tools/cmd/sometool",
+}
+
 func TestFIPSCompliance(t *testing.T) {
     fipsscan.CheckModule(t,
         []string{"./..."},
-        nil, // binaries to skip (dev tools, scripts, non-shipped assets)
-        nil, // project-specific extra forbidden pkgs, nil for the default set
-        map[string][]fipsscan.KnownViolation{
-            // Map key is the binary entry point path.
-            // Use "" for violations shared across all binaries or for library modules.
-            // Stale detection is scoped to binaries found in this scan, so
-            // per-binary subtest calls work correctly with per-binary keys.
+        skipBinaries,
+        nil, // project-specific extra forbidden pkgs; nil for the default set
+        map[string]map[string][]fipsscan.KnownViolation{
+            // Outer key: binary entry-point path, or "" for all binaries.
+            // Inner key: component — any package path or module prefix that
+            //   must appear in the BFS chain from the binary to the importer.
+            //   Use a module root (e.g. "github.com/twmb/franz-go") to group
+            //   all subpackage violations under one entry, making it clear
+            //   which library introduces the violation.
+            //   Use "" to match any chain within that binary.
             "github.com/elastic/myagent/cmd/agent": {
-                {
-                    Importer: "github.com/jcmturner/gokrb5/v8/krb5",
-                    Imported: "github.com/jcmturner/aescts/v2",
-                    Reason:   "Kerberos AD auth, tracked in FIPS-123",
+                "github.com/elastic/gokrb5/v8": {
+                    {
+                        Importer: "github.com/elastic/gokrb5/v8/crypto/rfc3962",
+                        Imported: "github.com/jcmturner/aescts/v2",
+                        Reason:   "Elastic gokrb5 fork depends on jcmturner aescts for AES-CBC-CTS",
+                    },
+                },
+                "github.com/twmb/franz-go": {
+                    {
+                        Importer: "github.com/twmb/franz-go/pkg/sasl/scram",
+                        Imported: "golang.org/x/crypto/pbkdf2",
+                        Reason:   "Kafka SCRAM SASL key derivation uses PBKDF2; x/crypto not FIPS-certified",
+                    },
                 },
             },
         },
@@ -67,10 +84,11 @@ go test -tags requirefips ./...
 
 ## Bootstrapping the known-violations map
 
-1. Call `CheckModule` with an empty map (`map[string][]fipsscan.KnownViolation{}`).
-2. The test output lists every violation: `NEW violation: <importer> imports forbidden <imported>`.
-3. Copy the importer paths into the map with a justification comment.
-4. From that point on CI enforces the contract automatically.
+1. Call `CheckModule` with an empty map (`map[string]map[string][]fipsscan.KnownViolation{}`).
+2. The test output lists every violation with its full import chain.
+3. Group violations by the module root of the importer (e.g. `"github.com/twmb/franz-go"`) to make it clear which library introduces each violation.
+4. Add a `Reason` explaining why the dependency cannot be replaced.
+5. From that point on CI enforces the contract automatically.
 
 ## Advanced usage
 
@@ -116,10 +134,14 @@ Pass additional prefixes via `extraForbiddenPkgs` for project-specific libraries
 CheckModule(t, patterns, skipBinaries, extraForbiddenPkgs, knownViolations)
     Scans all packages matching patterns and their transitive dependencies.
     skipBinaries lists binary import paths to exclude (dev tools, scripts,
-    non-shipped assets). knownViolations is map[binary][]KnownViolation; use
-    "" as the key for violations shared across all binaries or for library
-    modules. Stale detection is scoped to binaries found in this scan.
-    t.Errorf on new violations or stale entries.
+    non-shipped assets). knownViolations is map[binary]map[component][]KnownViolation:
+      - outer key: binary entry-point path, or "" for all binaries
+      - inner key: component prefix that must appear in the BFS chain from
+        the binary to the importer; "" matches any chain
+    Stale detection: entries are flagged stale when the binary was scanned and
+    the component is reachable but the (Importer, Imported) pair is no longer
+    a violation. If the component is no longer reachable, its entries are
+    silently skipped. t.Errorf on new violations or stale entries.
 
 Scan(t, pkg, extraForbiddenPkgs)
     Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -1,8 +1,8 @@
 # fipsscan
 
-`fipsscan` is a Go testing helper for auditing FIPS 140-3 compliance. It scans a package's dependency tree for imports of known non-FIPS crypto libraries and reports violations.
+`fipsscan` is a Go testing helper for auditing import-policy compliance of Go binaries. It scans a module's dependency tree for imports of forbidden packages and reports violations against a caller-supplied allowlist.
 
-The package is guarded by the `requirefips` build tag so it compiles — and incurs zero overhead — only in FIPS-focused test runs.
+The package carries **no build constraints** and ships **no default forbidden-package list** — both are the caller's responsibility. This makes it reusable for any import-policy audit, not just FIPS.
 
 ## Naming convention
 
@@ -35,6 +35,14 @@ import (
     "github.com/elastic/elastic-agent-libs/testing/fipsscan"
 )
 
+// forbiddenPkgs lists import-path prefixes that are not permitted in this
+// module's dependency tree. Adjust to match your project's FIPS policy.
+var forbiddenPkgs = []string{
+    "golang.org/x/crypto/",
+    "github.com/jcmturner/gokrb5/",
+    "github.com/cloudflare/circl/",
+}
+
 // skipBinaries lists non-shipped binaries excluded from the FIPS scan.
 var skipBinaries = []string{
     // "github.com/elastic/myagent/dev-tools/cmd/sometool",
@@ -44,7 +52,7 @@ func TestFIPSCompliance(t *testing.T) {
     fipsscan.CheckModule(t,
         []string{"./..."},
         skipBinaries,
-        nil, // project-specific extra forbidden pkgs; nil for the default set
+        forbiddenPkgs,
         map[string]map[string][]fipsscan.KnownViolation{
             // Outer key: binary entry-point import path, a module-root prefix
             //   that matches any binary under it, or "" for all binaries.
@@ -109,10 +117,10 @@ go test -tags requirefips ./...
 
 ```go
 // all packages in the module (Binary not set on violations)
-violations, importGraph := fipsscan.Scan(t, "./...", nil)
+violations, importGraph := fipsscan.Scan(t, "./...", forbiddenPkgs)
 
 // only package main entry points (fatals if none found; Binary is set on each violation)
-violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/agent", "./cmd/other"}, nil)
+violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/agent", "./cmd/other"}, nil, forbiddenPkgs)
 
 for _, v := range violations {
     chain := fipsscan.ShortestChain(v.Binary, v.Importer, importGraph)
@@ -120,34 +128,15 @@ for _, v := range violations {
 }
 ```
 
-## What is checked
-
-All functions check against `ForbiddenPkgs()` by default — a curated list of third-party crypto libraries that are not part of any FIPS 140-3 certified module boundary:
-
-| Constant | Module prefix | Reason |
-|---|---|---|
-| `XCrypto` | `golang.org/x/crypto/` | Not in Go's GOFIPS140 certified module |
-| `JcmturnerAescts` | `github.com/jcmturner/aescts/` | Own AES block cipher, not `crypto/aes` |
-| `JcmturnerGofork` | `github.com/jcmturner/gofork/` | Fork of stdlib with non-FIPS modifications |
-| `JcmturnerGokrb5` | `github.com/jcmturner/gokrb5/` | Kerberos 5; pulls in the two above |
-| `XdgGoPbkdf2` | `github.com/xdg-go/pbkdf2` | Standalone PBKDF2, not `crypto/pbkdf2` |
-| `ProtonMailGoCrypto` | `github.com/ProtonMail/go-crypto/` | OpenPGP with non-FIPS algorithms |
-| `CloudflareCircl` | `github.com/cloudflare/circl/` | SIDH, FourQ, Ristretto255, etc. |
-| `AzureGoNtlmssp` | `github.com/Azure/go-ntlmssp` | NTLM/SSPI — uses MD4/MD5/DES |
-| `YoumarkPkcs8` | `github.com/youmark/pkcs8` | May negotiate RC2/3DES/SM4 |
-| `FilippioIO` | `filippo.io/` | edwards25519, age, etc. (outside certified boundary even when implementing a FIPS-standardized algorithm) |
-
-Pass additional prefixes via `extraForbiddenPkgs` for project-specific libraries not in this list.
-
-**Deferred — `github.com/go-jose/`:** go-jose wraps stdlib `crypto/aes`, `crypto/rsa`, and `crypto/ecdsa` rather than implementing its own primitives, and its SHA-1 usage in RSA-OAEP is permitted under FIPS for key transport (NIST SP 800-131A). It is not in the baseline list to avoid false positives for common JWT/JWE usage. Projects that want stricter coverage can add it via `extraForbiddenPkgs` and manually review each hit.
-
 ## API reference
 
 ```
-CheckModule(t, patterns, skipBinaries, extraForbiddenPkgs, knownViolations)
+CheckModule(t, patterns, skipBinaries, forbiddenPkgs, knownViolations)
     Scans all packages matching patterns and their transitive dependencies.
     skipBinaries lists binary import paths to exclude (dev tools, scripts,
-    non-shipped assets). knownViolations is map[binary]map[component][]KnownViolation:
+    non-shipped assets). forbiddenPkgs is the complete list of import-path
+    prefixes to flag as violations — the caller owns this list entirely.
+    knownViolations is map[binary]map[component][]KnownViolation:
       - outer key: binary entry-point path, a module-root prefix (matches any
         binary whose import path starts with it), or "" for all binaries
       - inner key: component — a package path or module-root prefix that must
@@ -163,18 +152,15 @@ CheckModule(t, patterns, skipBinaries, extraForbiddenPkgs, knownViolations)
     reachable from the binary, or whose component can no longer reach the
     importer, are silently skipped. t.Errorf on new violations or stale entries.
 
-Scan(t, pkg, extraForbiddenPkgs)
+Scan(t, pkg, forbiddenPkgs)
     Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).
     Binary is not set on violations.
 
-ScanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
+ScanBinaries(t, patterns, skipBinaries, forbiddenPkgs)
     Discovers all package main entries matching patterns, scans the combined
     dependency tree in one go list pass. skipBinaries lists binary import
     paths to exclude. Sets Binary on each violation. Fatals if no binaries
     are found.
-
-ForbiddenPkgs() []string
-    Returns a fresh copy of the baseline forbidden-prefix list.
 
 ShortestChain(from, to, importGraph) []string
     BFS shortest path through the import graph. Useful for building custom

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -47,12 +47,13 @@ func TestFIPSCompliance(t *testing.T) {
         nil, // project-specific extra forbidden pkgs; nil for the default set
         map[string]map[string][]fipsscan.KnownViolation{
             // Outer key: binary entry-point path, or "" for all binaries.
-            // Inner key: component — any package path or module prefix that
-            //   must appear in the BFS chain from the binary to the importer.
-            //   Use a module root (e.g. "github.com/twmb/franz-go") to group
-            //   all subpackage violations under one entry, making it clear
-            //   which library introduces the violation.
-            //   Use "" to match any chain within that binary.
+            // Inner key: component — a package path or module-root prefix that
+            //   must be reachable from the binary AND able to reach the importer.
+            //   Use a specific component (e.g. "receiver/kafkareceiver") to
+            //   document which component owns the violation. List the same
+            //   (Importer, Imported) under multiple components when several are
+            //   affected by the same shared library.
+            //   Use "" to match any violation within that binary.
             "github.com/elastic/myagent/cmd/agent": {
                 "github.com/elastic/gokrb5/v8": {
                     {
@@ -149,12 +150,18 @@ CheckModule(t, patterns, skipBinaries, extraForbiddenPkgs, knownViolations)
     skipBinaries lists binary import paths to exclude (dev tools, scripts,
     non-shipped assets). knownViolations is map[binary]map[component][]KnownViolation:
       - outer key: binary entry-point path, or "" for all binaries
-      - inner key: component prefix that must appear in the BFS chain from
-        the binary to the importer; "" matches any chain
-    Stale detection: entries are flagged stale when the binary was scanned and
-    the component is reachable but the (Importer, Imported) pair is no longer
-    a violation. If the component is no longer reachable, its entries are
-    silently skipped. t.Errorf on new violations or stale entries.
+      - inner key: component — a package path or module-root prefix that must
+        be reachable from the binary AND able to reach the violating importer;
+        "" matches any violation within that binary
+    A single violation can match multiple component keys simultaneously. List
+    the same (Importer, Imported) pair under each component that transitively
+    imports the forbidden package — all matched entries are suppressed, none
+    are flagged stale as long as the violation persists.
+    Stale detection: an entry is flagged stale when the binary was scanned,
+    the component can still reach the importer, but the (Importer, Imported)
+    pair is no longer a violation. Entries whose component is no longer
+    reachable from the binary, or whose component can no longer reach the
+    importer, are silently skipped. t.Errorf on new violations or stale entries.
 
 Scan(t, pkg, extraForbiddenPkgs)
     Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -38,6 +38,7 @@ import (
 func TestFIPSCompliance(t *testing.T) {
     fipsscan.CheckModule(t,
         []string{"./..."},
+        nil, // binaries to skip (dev tools, scripts, non-shipped assets)
         nil, // project-specific extra forbidden pkgs, nil for the default set
         map[string][]fipsscan.KnownViolation{
             // Map key is the binary entry point path.
@@ -112,21 +113,23 @@ Pass additional prefixes via `extraForbiddenPkgs` for project-specific libraries
 ## API reference
 
 ```
-CheckModule(t, patterns, extraForbiddenPkgs, knownViolations)
+CheckModule(t, patterns, skipBinaries, extraForbiddenPkgs, knownViolations)
     Scans all packages matching patterns and their transitive dependencies.
-    knownViolations is map[binary][]KnownViolation; use "" as the key for
-    violations shared across all binaries or for library modules. Stale
-    detection is scoped to binaries found in this scan. t.Errorf on new
-    violations or stale entries.
+    skipBinaries lists binary import paths to exclude (dev tools, scripts,
+    non-shipped assets). knownViolations is map[binary][]KnownViolation; use
+    "" as the key for violations shared across all binaries or for library
+    modules. Stale detection is scoped to binaries found in this scan.
+    t.Errorf on new violations or stale entries.
 
 Scan(t, pkg, extraForbiddenPkgs)
     Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).
     Binary is not set on violations.
 
-ScanBinaries(t, patterns, extraForbiddenPkgs)
+ScanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
     Discovers all package main entries matching patterns, scans the combined
-    dependency tree in one go list pass. Sets Binary on each violation.
-    Fatals if no binaries are found.
+    dependency tree in one go list pass. skipBinaries lists binary import
+    paths to exclude. Sets Binary on each violation. Fatals if no binaries
+    are found.
 
 ForbiddenPkgs() []string
     Returns a fresh copy of the baseline forbidden-prefix list.

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -53,6 +53,7 @@ func TestFIPSCompliance(t *testing.T) {
         []string{"./..."},
         skipBinaries,
         forbiddenPkgs,
+        []string{"requirefips"},
         map[string]map[string][]fipsscan.KnownViolation{
             // Outer key: binary entry-point import path, a module-root prefix
             //   that matches any binary under it, or "" for all binaries.
@@ -117,10 +118,10 @@ go test -tags requirefips ./...
 
 ```go
 // all packages in the module (Binary not set on violations)
-violations, importGraph := fipsscan.Scan(t, "./...", forbiddenPkgs)
+violations, importGraph := fipsscan.Scan(t, "./...", forbiddenPkgs, []string{"requirefips"})
 
 // only package main entry points (fatals if none found; Binary is set on each violation)
-violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/agent", "./cmd/other"}, nil, forbiddenPkgs)
+violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/agent", "./cmd/other"}, nil, forbiddenPkgs, []string{"requirefips"})
 
 for _, v := range violations {
     chain := fipsscan.ShortestChain(v.Binary, v.Importer, importGraph)
@@ -131,11 +132,13 @@ for _, v := range violations {
 ## API reference
 
 ```
-CheckModule(t, patterns, skipBinaries, forbiddenPkgs, knownViolations)
+CheckModule(t, patterns, skipBinaries, forbiddenPkgs, tags, knownViolations)
     Scans all packages matching patterns and their transitive dependencies.
     skipBinaries lists binary import paths to exclude (dev tools, scripts,
     non-shipped assets). forbiddenPkgs is the complete list of import-path
     prefixes to flag as violations — the caller owns this list entirely.
+    tags is the list of build tags passed to go list (e.g. []string{"requirefips"});
+    pass nil or an empty slice for no tags.
     knownViolations is map[binary]map[component][]KnownViolation:
       - outer key: binary entry-point path, a module-root prefix (matches any
         binary whose import path starts with it), or "" for all binaries
@@ -152,11 +155,11 @@ CheckModule(t, patterns, skipBinaries, forbiddenPkgs, knownViolations)
     reachable from the binary, or whose component can no longer reach the
     importer, are silently skipped. t.Errorf on new violations or stale entries.
 
-Scan(t, pkg, forbiddenPkgs)
+Scan(t, pkg, forbiddenPkgs, tags)
     Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).
     Binary is not set on violations.
 
-ScanBinaries(t, patterns, skipBinaries, forbiddenPkgs)
+ScanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
     Discovers all package main entries matching patterns, scans the combined
     dependency tree in one go list pass. skipBinaries lists binary import
     paths to exclude. Sets Binary on each violation. Fatals if no binaries

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -37,16 +37,19 @@ import (
 
 func TestFIPSCompliance(t *testing.T) {
     fipsscan.CheckModule(t,
-        "./...",
+        []string{"./..."},
         nil, // project-specific extra forbidden pkgs, nil for the default set
         map[string][]fipsscan.KnownViolation{
             // Map key is the binary entry point path.
-            // Use "" for violations that apply to all binaries or library modules.
-            // Fails on new unlisted violations AND on entries that are no
-            // longer reachable (stale), keeping this map honest over time.
+            // Use "" for violations shared across all binaries or for library modules.
+            // Stale detection is scoped to binaries found in this scan, so
+            // per-binary subtest calls work correctly with per-binary keys.
             "github.com/elastic/myagent/cmd/agent": {
-                // Kerberos AD auth — tracked in FIPS-123
-                {Importer: "github.com/jcmturner/gokrb5/v8/krb5", Imported: "github.com/jcmturner/aescts/v2"},
+                {
+                    Importer: "github.com/jcmturner/gokrb5/v8/krb5",
+                    Imported: "github.com/jcmturner/aescts/v2",
+                    Reason:   "Kerberos AD auth, tracked in FIPS-123",
+                },
             },
         },
     )
@@ -63,7 +66,7 @@ go test -tags requirefips ./...
 
 ## Bootstrapping the known-violations map
 
-1. Call `CheckModule` with an empty map (`map[string]string{}`).
+1. Call `CheckModule` with an empty map (`map[string][]fipsscan.KnownViolation{}`).
 2. The test output lists every violation: `NEW violation: <importer> imports forbidden <imported>`.
 3. Copy the importer paths into the map with a justification comment.
 4. From that point on CI enforces the contract automatically.
@@ -73,14 +76,14 @@ go test -tags requirefips ./...
 `CheckModule` covers most cases. Use the lower-level functions when you need to build a custom reporting pipeline:
 
 ```go
-// all packages in the module (no BinaryPath set)
+// all packages in the module (Binary not set on violations)
 violations, importGraph := fipsscan.Scan(t, "./...", nil)
 
-// only package main entry points (fatals if none found; BinaryPath is set on each violation)
-violations, importGraph := fipsscan.ScanBinaries(t, "./...", nil)
+// only package main entry points (fatals if none found; Binary is set on each violation)
+violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/agent", "./cmd/other"}, nil)
 
 for _, v := range violations {
-    chain := fipsscan.ShortestChain(v.BinaryPath, v.Importer, importGraph)
+    chain := fipsscan.ShortestChain(v.Binary, v.Importer, importGraph)
     fmt.Println(fipsscan.FormatChain(append(chain, v.Imported)))
 }
 ```
@@ -109,19 +112,20 @@ Pass additional prefixes via `extraForbiddenPkgs` for project-specific libraries
 ## API reference
 
 ```
-CheckModule(t, pattern, extraForbiddenPkgs, knownViolations)
-    Scans all packages matching pattern and their transitive dependencies.
+CheckModule(t, patterns, extraForbiddenPkgs, knownViolations)
+    Scans all packages matching patterns and their transitive dependencies.
     knownViolations is map[binary][]KnownViolation; use "" as the key for
-    violations that apply to all binaries or to library modules. t.Errorf on
-    new violations or stale entries.
+    violations shared across all binaries or for library modules. Stale
+    detection is scoped to binaries found in this scan. t.Errorf on new
+    violations or stale entries.
 
 Scan(t, pkg, extraForbiddenPkgs)
     Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).
-    BinaryPath is not set on violations.
+    Binary is not set on violations.
 
-ScanBinaries(t, pattern, extraForbiddenPkgs)
-    Discovers all package main entries matching pattern, scans the combined
-    dependency tree in one go list pass. Sets BinaryPath on each violation.
+ScanBinaries(t, patterns, extraForbiddenPkgs)
+    Discovers all package main entries matching patterns, scans the combined
+    dependency tree in one go list pass. Sets Binary on each violation.
     Fatals if no binaries are found.
 
 ForbiddenPkgs() []string

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -1,8 +1,8 @@
 # fipsscan
 
-`fipsscan` is a Go testing helper for auditing import-policy compliance of Go binaries. It scans a module's dependency tree for imports of forbidden packages and reports violations against a caller-supplied allowlist.
+`fipsscan` is a Go testing helper for auditing import-policy compliance of Go modules. It scans a module's dependency tree for imports of forbidden packages and reports violations against a caller-supplied allowlist.
 
-The package carries **no build constraints** and ships **no default forbidden-package list** — both are the caller's responsibility. This makes it reusable for any import-policy audit, not just FIPS.
+The package ships with **no default forbidden-package list** — that is the caller's responsibility. This makes it reusable for any import-policy audit, not just FIPS. The package itself carries no build constraints; the `//go:build requirefips` tag in the example below is a convention for the *caller's* test file.
 
 ## Naming convention
 
@@ -14,11 +14,11 @@ Consistent naming makes it easy to audit coverage across the Elastic ecosystem:
 # find all modules that have a FIPS compliance test
 grep -rl 'TestFIPSCompliance' .
 
-# run only the FIPS compliance test across all modules in a monorepo
+# run only the FIPS compliance test in a single module
 go test -tags requirefips -run TestFIPSCompliance ./...
 ```
 
-It also makes CI configuration uniform: a single `-run TestFIPSCompliance` flag works everywhere without per-module customisation.
+Note: `./...` stays within one Go module. In a multi-module workspace you need `go work` or a loop over module roots.
 
 ## Quick start
 
@@ -35,17 +35,20 @@ import (
     "github.com/elastic/elastic-agent-libs/testing/fipsscan"
 )
 
-// forbiddenPkgs lists import-path prefixes that are not permitted in this
-// module's dependency tree. Adjust to match your project's FIPS policy.
 var forbiddenPkgs = []string{
     "golang.org/x/crypto/",
     "github.com/jcmturner/gokrb5/",
+    "github.com/jcmturner/aescts/",
+    "github.com/jcmturner/gofork/",
+    "github.com/xdg-go/pbkdf2",
+    "github.com/ProtonMail/go-crypto/",
     "github.com/cloudflare/circl/",
+    "github.com/Azure/go-ntlmssp",
+    "github.com/youmark/pkcs8",
 }
 
-// skipBinaries lists non-shipped binaries excluded from the FIPS scan.
 var skipBinaries = []string{
-    // "github.com/elastic/myagent/dev-tools/cmd/sometool",
+    // "github.com/elastic/mymodule/dev-tools/cmd/tool",
 }
 
 func TestFIPSCompliance(t *testing.T) {
@@ -55,27 +58,11 @@ func TestFIPSCompliance(t *testing.T) {
         forbiddenPkgs,
         []string{"requirefips"},
         map[string]map[string][]fipsscan.KnownViolation{
-            // Outer key: binary entry-point import path, a module-root prefix
-            //   that matches any binary under it, or "" for all binaries.
-            //   E.g. "github.com/elastic/myagent" matches both
-            //   "github.com/elastic/myagent/cmd/agent" and
-            //   "github.com/elastic/myagent/cmd/other".
-            // Inner key: component — a package path or module-root prefix that
-            //   must be reachable from the binary AND able to reach the importer.
-            //   Use a specific component (e.g. "receiver/kafkareceiver") to
-            //   document which component owns the violation. List the same
-            //   (Importer, Imported) under multiple components when several are
-            //   affected by the same shared library.
-            //   Use "" to match any violation within that binary.
-            "github.com/elastic/myagent": {
-                // Importer is optional: "" matches any package inside the component.
-                // Imported supports module-root prefixes (trailing slash stripped automatically).
+            // See "Known-violations map" below.
+            "github.com/elastic/mymodule": {
                 "github.com/elastic/gokrb5/v8": {
-                    {Imported: "github.com/jcmturner/aescts", Reason: "Elastic gokrb5 fork depends on jcmturner aescts for AES-CBC-CTS"},
-                    {Imported: "golang.org/x/crypto/md4",     Reason: "Kerberos RC4-HMAC requires MD4; no FIPS-approved substitute"},
-                },
-                "github.com/twmb/franz-go": {
-                    {Imported: "golang.org/x/crypto/pbkdf2", Reason: "Kafka SCRAM SASL key derivation uses PBKDF2; x/crypto not FIPS-certified"},
+                    {Imported: "github.com/jcmturner/aescts", Reason: "elastic/gokrb5 fork: AES-CBC-CTS key derivation"},
+                    {Imported: "golang.org/x/crypto/md4",     Reason: "Kerberos RC4-HMAC; no FIPS-approved substitute"},
                 },
             },
         },
@@ -89,86 +76,177 @@ Run with:
 go test -tags requirefips ./...
 ```
 
-`CheckModule` scans all packages and their transitive dependencies — binaries and libraries alike — so it works the same way regardless of module type.
+`go list` runs from the module root (the nearest `go.mod` above the test file), so `"./..."` covers the entire module regardless of where the test lives. On a cold module cache `go list` may download dependencies.
+
+## How the scan works
+
+`CheckModule` runs `go list -deps` once and checks every package in the dependency graph in two passes:
+
+**Binary scope** — packages pulled in by each non-skipped `package main`. Violations carry the binary's import path in `Violation.Binary`.
+
+**Flat scope** — packages not pulled in by any binary, i.e. library-only code. Violations carry `Binary=""` and `Importer` set to the package that directly imports the forbidden one.
+
+Both passes always run. A pure-library module (no `package main`) is fully covered by the flat scope.
+
+## Known-violations map
+
+The `known` argument to `CheckModule` is `map[binary]map[component][]KnownViolation`.
+
+### Binary key (outer map)
+
+Scopes an entry to a specific binary (or set of binaries via prefix). An empty key `""` covers all violations — binary-scope and flat-scope alike — so use it with care.
+
+| Key | Matches |
+|---|---|
+| `"github.com/elastic/agent/cmd/otelcol"` | that binary and any binary whose path starts with it |
+| `"github.com/elastic/agent"` | any binary whose import path starts with this prefix |
+| `""` | every violation in the module — binary-scope and flat-scope alike (wildcard) |
+
+A non-`""` key that matches no scanned binary is reported as an error — it is a typo or a stale entry. Entries under an unknown key are skipped (not reported stale); fix the key path to see their stale status.
+
+### Component key (inner map)
+
+Identifies which library is responsible for pulling in the forbidden package. The entry matches a violation only when that library lies on the import chain from the binary to the forbidden package.
+
+| Key | Meaning |
+|---|---|
+| `"github.com/twmb/franz-go"` | franz-go (or a sub-package) is responsible for the forbidden import |
+| `"github.com/elastic/gokrb5/v8/client"` | this specific sub-package is responsible |
+| `""` | no constraint — any import chain from binary to forbidden matches |
+
+The component key makes entries self-maintaining: when the responsible library stops importing the forbidden package, the entry goes stale automatically, even if the forbidden package is still reachable via a different route.
+
+A non-`""` component key never matches flat-scope violations — use `""` as the component key for library-only entries.
+
+### KnownViolation fields
+
+| Field | Description |
+|---|---|
+| `Imported` | prefix-matched against the forbidden package; `""` matches any forbidden package |
+| `Reason` | free-text explanation for documentation; never printed or validated |
+
+### Stale detection
+
+`CheckModule` reports a stale entry when an allowlist entry no longer matches any actual violation. This catches:
+
+- A dependency that was updated to remove the forbidden import.
+- A component library that was removed from the module.
+- A binary key that was renamed or removed.
+
+The `""` binary key is always checked for stale entries. A non-`""` key is only checked when it matches at least one scanned binary; if it matches none, a separate "unknown binary key" error fires instead.
+
+## skipBinaries
+
+`skipBinaries` accepts import paths and module-root prefixes (same matching rules as binary keys). A skip entry that matches no discovered binary is reported as an error.
+
+**Important:** skipping a binary removes it from the binary-scope scan. Any package used exclusively by the skipped binary re-appears as a flat-scope violation (`Binary=""`), which cannot be keyed by binary path. Dev-tool binaries whose violations are already documented under a binary key will produce fresh "unknown binary key" errors when added to `skipBinaries`; remove their allowlist entries at the same time.
+
+## Prefix matching
+
+The same matching rule applies everywhere — `forbiddenPkgs`, `skipBinaries`, binary keys, component keys, and `KnownViolation.Imported`:
+
+- Trailing slashes are stripped from the **pattern** before matching (not from the path).
+- `""` (or `"/"` after stripping) is a wildcard that matches anything.
+- Otherwise a match requires `path == pattern` or `path` starts with `pattern + "/"`, so `"github.com/foo"` matches `"github.com/foo/bar"` but not `"github.com/foobar"`.
 
 ## Bootstrapping the known-violations map
 
 1. Call `CheckModule` with an empty map (`map[string]map[string][]fipsscan.KnownViolation{}`).
-2. The test output lists every `NEW violation` with its full import chain, e.g.:
-   ```
-   cmd/kafkareceiver
-         -> otel-contrib/receiver/kafkareceiver
-         -> otel-contrib/internal/kafka          ← Importer
-         -> gokrb5/v8/client                     ← Imported (forbidden)
-   ```
-3. Choose a component key — any package or prefix in the chain from the binary down to the Importer (not the forbidden package itself):
-   | Component key | Meaning |
-   |---|---|
-   | `""` | matches any chain in this binary |
-   | `"cmd/kafkareceiver"` | binary-level — don't need to know which package does the import |
-   | `"otel-contrib"` | external module root — groups all violations from that module |
-   | `"otel-contrib/receiver/kafkareceiver"` | specific receiver package |
-   | `"otel-contrib/internal/kafka"` | exact direct importer |
-4. Add a `Reason` explaining why the dependency cannot be replaced.
-5. From that point on CI enforces the contract automatically.
+2. Every `NEW violation` is printed with its full import chain. Binary-scope violations show the full path from the binary to the forbidden package:
 
-## Advanced usage
-
-`CheckModule` covers most cases. Use the lower-level functions when you need to build a custom reporting pipeline:
-
-```go
-// all packages in the module (Binary not set on violations)
-violations, importGraph := fipsscan.Scan(t, "./...", forbiddenPkgs, []string{"requirefips"})
-
-// only package main entry points (fatals if none found; Binary is set on each violation)
-violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/agent", "./cmd/other"}, nil, forbiddenPkgs, []string{"requirefips"})
-
-for _, v := range violations {
-    chain := fipsscan.ShortestChain(v.Binary, v.Importer, importGraph)
-    fmt.Println(fipsscan.FormatChain(append(chain, v.Imported)))
-}
 ```
+fips_compliance_test.go:XX: NEW violation:
+    github.com/elastic/agent/internal/edot/cmd/otelcol
+          -> github.com/open-telemetry/otelcol-contrib/receiver/kafkareceiver
+          -> github.com/twmb/franz-go/pkg/sasl/scram
+          -> golang.org/x/crypto/pbkdf2
+```
+
+Flat-scope violations show only the direct importer and the forbidden package:
+
+```
+fips_compliance_test.go:XX: NEW violation:
+    github.com/elastic/elastic-agent-libs/transport/tlscommon
+          -> golang.org/x/crypto/md4
+```
+
+3. Fill in the map from the chain (binary-scope example):
+
+| Map field | From the chain |
+|---|---|
+| binary key | first line: `"github.com/elastic/agent/internal/edot/cmd/otelcol"` |
+| component key | any library between binary and forbidden, or its module-root prefix: `"github.com/twmb/franz-go"` |
+| `Imported` | last line (or a prefix of it): `"golang.org/x/crypto/pbkdf2"` |
+| `Reason` | the receiver visible in the chain: `"kafkareceiver: Kafka SCRAM SASL key derivation"` |
+
+4. Re-run the test. Repeat until clean.
+
+Binary-scope violations are deduplicated per binary/forbidden-package pair — one error showing the shortest chain. Flat-scope violations are deduplicated per importer/forbidden-package pair. Fixing the printed chain may surface another chain for the same pair; repeat until the violation disappears.
+
+For flat-scope violations, use `""` as both the binary key and the component key. Note that a `""` binary key also covers binary-scope violations.
+
+## Coverage limits
+
+`go list` runs without `-test`, so test-only imports are not scanned. Build constraints are evaluated for the current `GOOS`/`GOARCH`, so platform-specific imports (e.g. a `_windows.go` file) are not scanned on Linux CI.
 
 ## API reference
 
+### CheckModule
+
+```go
+func CheckModule(
+    t             testing.TB,
+    patterns      []string,                        // passed to go list, e.g. []string{"./..."}
+    skipBinaries  []string,                        // binary import paths/prefixes to exclude
+    forbiddenPkgs []string,                        // import-path prefixes to flag as violations
+    tags          []string,                        // build tags for go list (e.g. []string{"requirefips"})
+    known         map[string]map[string][]KnownViolation,
+)
 ```
-CheckModule(t, patterns, skipBinaries, forbiddenPkgs, tags, knownViolations)
-    Scans all packages matching patterns and their transitive dependencies.
-    skipBinaries lists binary import paths to exclude (dev tools, scripts,
-    non-shipped assets). forbiddenPkgs is the complete list of import-path
-    prefixes to flag as violations — the caller owns this list entirely.
-    tags is the list of build tags passed to go list (e.g. []string{"requirefips"});
-    pass nil or an empty slice for no tags.
-    knownViolations is map[binary]map[component][]KnownViolation:
-      - outer key: binary entry-point path, a module-root prefix (matches any
-        binary whose import path starts with it), or "" for all binaries
-      - inner key: component — a package path or module-root prefix that must
-        be reachable from the binary AND able to reach the violating importer;
-        "" matches any violation within that binary
-    A single violation can match multiple component keys simultaneously. List
-    the same (Importer, Imported) pair under each component that transitively
-    imports the forbidden package — all matched entries are suppressed, none
-    are flagged stale as long as the violation persists.
-    Stale detection: an entry is flagged stale when the binary was scanned,
-    the component can still reach the importer, but the (Importer, Imported)
-    pair is no longer a violation. Entries whose component is no longer
-    reachable from the binary, or whose component can no longer reach the
-    importer, are silently skipped. t.Errorf on new violations or stale entries.
 
-Scan(t, pkg, forbiddenPkgs, tags)
-    Scans pkg and its full dependency tree. Returns ([]Violation, importGraph).
-    Binary is not set on violations.
+Fatals (`t.Fatalf`) on empty `patterns`, empty `forbiddenPkgs`, `go list` failure, or missing `go.mod`. Reports via `t.Errorf`:
 
-ScanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
-    Discovers all package main entries matching patterns, scans the combined
-    dependency tree in one go list pass. skipBinaries lists binary import
-    paths to exclude. Sets Binary on each violation. Fatals if no binaries
-    are found.
+- `NEW violation` — forbidden import with no matching known entry
+- `stale entry in knownViolations` — known entry whose violation no longer exists
+- `knownViolations binary key ... matches no scanned binary` — non-`""` binary key matching no scanned binary
+- `skipBinaries entry ... matches no discovered binary` — skip entry matching no discovered binary
 
-ShortestChain(from, to, importGraph) []string
-    BFS shortest path through the import graph. Useful for building custom
-    violation reporters.
+### Scan
 
-FormatChain(chain []string) string
-    Formats an import chain for human-readable output.
+```go
+func Scan(
+    t             testing.TB,
+    patterns      []string,
+    skipBinaries  []string,
+    forbiddenPkgs []string,
+    tags          []string,
+) []Violation
 ```
+
+Returns raw violations without consulting an allowlist. Useful for bootstrapping or custom reporting.
+
+### ShortestChain / FormatChain
+
+```go
+func ShortestChain(from, to string, graph map[string][]string) []string
+func FormatChain(chain []string) string
+```
+
+Graph-walking helpers available for callers that build their own import graph.
+
+### Types
+
+```go
+type Violation struct {
+    Binary   string // binary import path; "" for flat-scope violations
+    Importer string // direct importer of the forbidden package; set only for flat-scope violations
+    Imported string // the forbidden package
+}
+
+type KnownViolation struct {
+    Imported string // prefix-matched against Violation.Imported; "" matches anything
+    Reason   string // why this violation is accepted; documentation only, never printed
+}
+```
+
+`Violation.Importer` is empty for binary-scope violations — the full chain is reconstructed via `ShortestChain` internally.

--- a/testing/fipsscan/README.md
+++ b/testing/fipsscan/README.md
@@ -85,8 +85,21 @@ go test -tags requirefips ./...
 ## Bootstrapping the known-violations map
 
 1. Call `CheckModule` with an empty map (`map[string]map[string][]fipsscan.KnownViolation{}`).
-2. The test output lists every violation with its full import chain.
-3. Group violations by the module root of the importer (e.g. `"github.com/twmb/franz-go"`) to make it clear which library introduces each violation.
+2. The test output lists every `NEW violation` with its full import chain, e.g.:
+   ```
+   cmd/kafkareceiver
+         -> otel-contrib/receiver/kafkareceiver
+         -> otel-contrib/internal/kafka          ← Importer
+         -> gokrb5/v8/client                     ← Imported (forbidden)
+   ```
+3. Choose a component key — any package or prefix in the chain from the binary down to the Importer (not the forbidden package itself):
+   | Component key | Meaning |
+   |---|---|
+   | `""` | matches any chain in this binary |
+   | `"cmd/kafkareceiver"` | binary-level — don't need to know which package does the import |
+   | `"otel-contrib"` | external module root — groups all violations from that module |
+   | `"otel-contrib/receiver/kafkareceiver"` | specific receiver package |
+   | `"otel-contrib/internal/kafka"` | exact direct importer |
 4. Add a `Reason` explaining why the dependency cannot be replaced.
 5. From that point on CI enforces the contract automatically.
 

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -415,8 +415,14 @@ func FormatChain(chain []string) string {
 // Binaries in skipBinaries are excluded from the scan and from stale detection.
 func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
-
 	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
+	checkViolations(t, violations, importGraph, mains, knownViolations)
+}
+
+// checkViolations is the matching and stale-detection logic for CheckModule,
+// extracted to allow unit testing without a go list subprocess.
+func checkViolations(t testing.TB, violations []Violation, importGraph map[string][]string, mains []string, knownViolations map[string]map[string][]KnownViolation) {
+	t.Helper()
 
 	// matched[binKey][compKey][i] tracks whether knownViolations[binKey][compKey][i] was hit.
 	matched := make(map[string]map[string][]bool)
@@ -427,7 +433,7 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		}
 	}
 
-	// Pre-compute reachable set per binary for stale detection.
+	// Pre-compute reachable set per binary for attribution and stale detection.
 	reachableFrom := make(map[string]map[string]bool, len(mains))
 	for _, bin := range mains {
 		reachableFrom[bin] = bfsReachable(bin, importGraph)
@@ -535,15 +541,21 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		return keys
 	}
 
-	// markKnown finds ALL known entries where the component can reach importer
-	// and (Importer, Imported) matches. Marks each matched entry and returns the
-	// full list so the caller can log reasons. A single violation can match
-	// multiple component keys.
+	// markKnown finds ALL known entries where the component can reach the
+	// importer AND is reachable from the binary, and (Importer, Imported)
+	// matches. Marks each matched entry and returns the full list so the caller
+	// can log reasons. A single violation can match multiple component keys.
 	markKnown := func(binary, importer, imported string) ([]KnownViolation, bool) {
 		var results []KnownViolation
 		for _, binKey := range binKeysForBinary(binary) {
 			for compKey, kvs := range knownViolations[binKey] {
 				if !componentCanReach(compKey, importer) {
+					continue
+				}
+				// The component must also be reachable from the violation's binary.
+				// Without this check a component in a different binary can suppress
+				// violations here via the shared merged import graph.
+				if binary != "" && compKey != "" && !isReachableFromAny(compKey, []string{binary}, reachableFrom) {
 					continue
 				}
 				for i, kv := range kvs {

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -17,8 +17,8 @@
 
 // Package fipsscan provides helpers for auditing import-policy compliance of Go
 // binaries by scanning their dependency trees for forbidden imports.
-// Callers supply the forbidden-package prefixes and known-violations allowlist;
-// the package itself is policy-agnostic and carries no build constraints.
+// The package is policy-agnostic: callers supply the forbidden-package prefixes
+// and the known-violations allowlist.
 package fipsscan
 
 import (
@@ -28,32 +28,97 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
 
-// Violation is a forbidden import discovered in the dependency tree.
+// Violation is a forbidden import found in the dependency graph.
 type Violation struct {
-	Binary   string // binary entry point; empty for library modules
-	Importer string // package that directly imports the forbidden package
-	Imported string // forbidden package being imported
+	Binary   string // entry-point binary import path; "" for library-scope violations (flat scan)
+	Importer string // the package directly importing the forbidden one; set for flat-scan violations
+	Imported string // the forbidden package
 }
 
-// KnownViolation documents an accepted import exception for use in knownViolations maps.
+// KnownViolation documents one accepted violation for a specific binary and component.
 //
-// Both Importer and Imported support three forms:
-//   - "" (empty): wildcard — matches anything in that position.
-//     Importer "" matches any intermediate package; Imported "" matches any forbidden package.
-//   - exact path: matches only that specific package.
-//   - module-root prefix: "github.com/foo/bar" matches "github.com/foo/bar" itself
-//     and any subpackage "github.com/foo/bar/baz".
-//
-// Use prefix or wildcard to collapse many per-subpackage entries into one. For example,
-// {Imported: "github.com/jcmturner/gokrb5/v8"} matches violations from any gokrb5 subpackage.
+//	Imported: prefix-matched against the forbidden package; "" matches anything.
+//	Reason:   why this violation is accepted; documentation only, never printed.
 type KnownViolation struct {
-	Importer string
 	Imported string
-	Reason   string // why this violation is acceptable; shown in test output
+	Reason   string
+}
+
+// CheckModule scans all packages matching patterns and reports via t.Errorf:
+//
+//   - NEW violation: a forbidden import with no matching knownViolations entry.
+//   - stale entry:   a knownViolations entry whose violation no longer exists.
+//   - unknown key:   a non-"" binary key that matches no scanned binary.
+//
+// known is map[binary]map[component][]KnownViolation:
+//
+//	binary key    — full import path of a package main, or "" for library scope.
+//	                "" is always active. Non-"" keys that match no scanned binary
+//	                are reported as errors.
+//	component key — full import path prefix of a package that must lie on the
+//	                path from the binary to the forbidden package. "" skips this
+//	                check (any path from binary to forbidden is covered).
+//
+// Matching is by path prefix everywhere; trailing slashes in patterns are ignored.
+//
+// Both binary and flat scopes always run:
+//
+//	Binary scope: every package transitively imported by a non-skipped package main.
+//	Flat scope:   all packages not reachable from any binary (library packages).
+//
+// Violations from the flat scope carry Binary="".
+func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string, known map[string]map[string][]KnownViolation) {
+	t.Helper()
+	violations, graph, scannedBinaries := scan(t, patterns, skipBinaries, forbiddenPkgs, tags)
+	checkViolations(t, violations, graph, scannedBinaries, known)
+}
+
+// Scan returns raw violations without consulting an allowlist.
+// Useful for bootstrapping a new allowlist or custom reporting.
+func Scan(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) []Violation {
+	t.Helper()
+	violations, _, _ := scan(t, patterns, skipBinaries, forbiddenPkgs, tags)
+	return violations
+}
+
+// scan returns scanned binaries with skipBinaries already filtered out.
+func scan(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string, []string) {
+	t.Helper()
+	if len(patterns) == 0 {
+		t.Fatalf("fipsscan: patterns must not be empty")
+	}
+	if len(forbiddenPkgs) == 0 {
+		t.Fatalf("fipsscan: forbiddenPkgs must not be empty")
+	}
+
+	graph, allMains := goListPackages(t, moduleRoot(t), patterns, tags)
+	validateSkipBinaries(t, skipBinaries, allMains)
+
+	var scannedBinaries []string
+	for _, m := range allMains {
+		if !isSkipped(m, skipBinaries) {
+			scannedBinaries = append(scannedBinaries, m)
+		}
+	}
+
+	violations, unionReach := scanBinaryViolations(graph, scannedBinaries, forbiddenPkgs)
+	violations = append(violations, scanFlatViolations(graph, unionReach, forbiddenPkgs)...)
+
+	sort.Slice(violations, func(i, j int) bool {
+		if violations[i].Binary != violations[j].Binary {
+			return violations[i].Binary < violations[j].Binary
+		}
+		if violations[i].Importer != violations[j].Importer {
+			return violations[i].Importer < violations[j].Importer
+		}
+		return violations[i].Imported < violations[j].Imported
+	})
+	return violations, graph, scannedBinaries
 }
 
 type goListPackage struct {
@@ -62,9 +127,45 @@ type goListPackage struct {
 	Imports    []string
 }
 
-// moduleRoot walks up from the working directory to find the nearest go.mod
-// and returns its containing directory. go test sets cwd to the test package
-// directory, so relative patterns like ./... need to run from the module root.
+func goListPackages(t testing.TB, dir string, patterns []string, tags []string) (map[string][]string, []string) {
+	t.Helper()
+	// Field filtering keeps the decoded output small on large dependency trees.
+	args := []string{"list", "-json=ImportPath,Name,Imports", "-deps"}
+	if len(tags) > 0 {
+		args = append(args, "-tags", strings.Join(tags, ","))
+	}
+	args = append(args, patterns...)
+
+	cmd := exec.CommandContext(t.Context(), "go", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			t.Fatalf("go list failed: %v\n%s", err, exitErr.Stderr)
+		}
+		t.Fatalf("go list failed: %v", err)
+	}
+
+	graph := make(map[string][]string)
+	var mains []string
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var p goListPackage
+		if err := dec.Decode(&p); err != nil {
+			t.Fatalf("parsing go list output: %v", err)
+		}
+		graph[p.ImportPath] = p.Imports
+		if p.Name == "main" {
+			mains = append(mains, p.ImportPath)
+		}
+	}
+	sort.Strings(mains)
+	return graph, mains
+}
+
+// go test sets cwd to the test package directory, so relative patterns like
+// ./... need to run from the module root.
 func moduleRoot(t testing.TB) string {
 	t.Helper()
 	dir, err := os.Getwd()
@@ -78,228 +179,288 @@ func moduleRoot(t testing.TB) string {
 		parent := filepath.Dir(dir)
 		if parent == dir {
 			t.Fatalf("finding module root: go.mod not found starting from %s", dir)
+			return ""
 		}
 		dir = parent
 	}
 }
 
-// goListPackages runs go list -json -deps from the module root and decodes the output.
-func goListPackages(t testing.TB, patterns []string, tags []string) []goListPackage {
-	t.Helper()
-	base := []string{"list", "-json", "-deps"}
-	if len(tags) > 0 {
-		base = append(base, "-tags", strings.Join(tags, ","))
-	}
-	args := append(base[:len(base):len(base)], patterns...)
-	cmd := exec.CommandContext(t.Context(), "go", args...)
-	cmd.Dir = moduleRoot(t)
-	out, err := cmd.Output()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			t.Fatalf("go list failed: %v\n%s", err, exitErr.Stderr)
-		}
-		t.Fatalf("go list failed: %v", err)
-	}
-	var pkgs []goListPackage
-	dec := json.NewDecoder(bytes.NewReader(out))
-	for dec.More() {
-		var p goListPackage
-		if err := dec.Decode(&p); err != nil {
-			t.Fatalf("parsing go list output: %v", err)
-		}
-		pkgs = append(pkgs, p)
-	}
-	return pkgs
-}
-
-// scanBinaries runs a single go list pass over all patterns, attributes each
-// violation to its binary entry point, and returns the binaries found.
-// When no binaries are present (library module) it falls back to flat violation
-// detection with no Binary set. binaryModule reports whether any package main
-// was discovered at all (before skip filtering).
-func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) (violations []Violation, importGraph map[string][]string, mains []string, binaryModule bool) {
-	t.Helper()
-
-	pkgs := goListPackages(t, patterns, tags)
-
-	skip := make(map[string]bool, len(skipBinaries))
+func isSkipped(binary string, skipBinaries []string) bool {
 	for _, s := range skipBinaries {
-		skip[s] = true
-	}
-
-	importGraph = make(map[string][]string, len(pkgs))
-	var allMains []string
-
-	for _, p := range pkgs {
-		if p.Name == "main" {
-			allMains = append(allMains, p.ImportPath)
-		}
-		importGraph[p.ImportPath] = p.Imports
-	}
-
-	binaryModule = len(allMains) > 0
-
-	if !binaryModule {
-		// True library module — no binary entry points.
-		return findViolations(importGraph, forbiddenPkgs), importGraph, nil, false
-	}
-
-	for _, m := range allMains {
-		if !skip[m] {
-			mains = append(mains, m)
-		}
-	}
-
-	if len(mains) == 0 {
-		// All discovered binaries were skipped — nothing to scan.
-		return nil, importGraph, nil, true
-	}
-
-	// Per-binary BFS attribution so each violation carries the entry point
-	// that pulls it in.
-	seen := make(map[string]bool)
-	for _, bin := range mains {
-		for pkg := range bfsReachable(bin, importGraph) {
-			if isForbidden(pkg, forbiddenPkgs) {
-				continue
-			}
-			for _, imp := range importGraph[pkg] {
-				if isForbidden(imp, forbiddenPkgs) {
-					if key := bin + "\x00" + pkg + "\x00" + imp; !seen[key] {
-						seen[key] = true
-						violations = append(violations, Violation{Binary: bin, Importer: pkg, Imported: imp})
-					}
-				}
-			}
-		}
-	}
-	return violations, importGraph, mains, true
-}
-
-// bfsReachable returns the set of all packages reachable from from (inclusive).
-func bfsReachable(from string, importGraph map[string][]string) map[string]bool {
-	reachable := map[string]bool{from: true}
-	queue := []string{from}
-	for len(queue) > 0 {
-		pkg := queue[0]
-		queue = queue[1:]
-		for _, dep := range importGraph[pkg] {
-			if !reachable[dep] {
-				reachable[dep] = true
-				queue = append(queue, dep)
-			}
-		}
-	}
-	return reachable
-}
-
-// findViolations returns all (Importer, Imported) pairs in importGraph where
-// Importer is not itself forbidden but directly imports a forbidden package.
-func findViolations(importGraph map[string][]string, forbidden []string) []Violation {
-	var violations []Violation
-	for pkg, imports := range importGraph {
-		if isForbidden(pkg, forbidden) {
-			continue
-		}
-		for _, imp := range imports {
-			if isForbidden(imp, forbidden) {
-				violations = append(violations, Violation{Importer: pkg, Imported: imp})
-			}
-		}
-	}
-	return violations
-}
-
-// ScanBinaries scans all patterns, attributes each violation to its binary entry
-// point (Violation.Binary), and returns all violations and the merged import graph.
-// Binaries whose import path appears in skipBinaries are excluded from the scan.
-// tags is passed as -tags to go list; nil or empty means no tags.
-// Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
-func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
-	t.Helper()
-	violations, importGraph, _, binaryModule := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
-	if !binaryModule {
-		t.Fatalf("ScanBinaries: no package main found matching %v", patterns)
-	}
-	return violations, importGraph
-}
-
-// Scan scans pkg and its full dependency tree and returns all violations and the
-// import graph. tags is passed as -tags to go list; nil or empty means no tags.
-// Calls t.Fatalf on subprocess or parse errors.
-func Scan(t testing.TB, pkg string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
-	t.Helper()
-	pkgs := goListPackages(t, []string{pkg}, tags)
-	importGraph := make(map[string][]string, len(pkgs))
-	for _, p := range pkgs {
-		importGraph[p.ImportPath] = p.Imports
-	}
-	return findViolations(importGraph, forbiddenPkgs), importGraph
-}
-
-// matchesBinaryKey reports whether a binary key matches an actual binary import
-// path. The key may be an exact import path, a module-root prefix, or "" which
-// matches any binary.
-func matchesBinaryKey(key, binary string) bool {
-	if key == "" {
-		return true
-	}
-	bare := strings.TrimRight(key, "/")
-	return binary == bare || strings.HasPrefix(binary, bare+"/")
-}
-
-func isForbidden(pkg string, forbiddenPkgs []string) bool {
-	for _, prefix := range forbiddenPkgs {
-		bare := strings.TrimRight(prefix, "/")
-		if pkg == bare || strings.HasPrefix(pkg, bare+"/") {
+		if pathMatches(s, binary) {
 			return true
 		}
 	}
 	return false
 }
 
-// ShortestChain returns the shortest path from `from` to `to` using forward
-// edges in importGraph (package -> packages it imports). Returns nil if no path.
-func ShortestChain(from, to string, importGraph map[string][]string) []string {
+func checkViolations(t testing.TB, violations []Violation, graph map[string][]string, scannedBinaries []string, known map[string]map[string][]KnownViolation) {
+	t.Helper()
+
+	// reach memoizes bfsReachable: the same binary or component root is queried
+	// once per violation, so cache results to avoid redundant graph walks.
+	reachCache := make(map[string]map[string]bool)
+	reach := func(pkg string) map[string]bool {
+		if r, ok := reachCache[pkg]; ok {
+			return r
+		}
+		r := bfsReachable(pkg, graph)
+		reachCache[pkg] = r
+		return r
+	}
+
+	// Pre-resolve each non-empty component key to the concrete packages it
+	// matches. componentOnPath would otherwise scan the full graph on every
+	// (violation, component) pair.
+	componentPkgs := make(map[string][]string)
+	for _, comps := range known {
+		for ck := range comps {
+			if ck == "" {
+				continue
+			}
+			if _, done := componentPkgs[ck]; done {
+				continue
+			}
+			var pkgs []string
+			for pkg := range graph {
+				if pathMatches(ck, pkg) {
+					pkgs = append(pkgs, pkg)
+				}
+			}
+			sort.Strings(pkgs)
+			componentPkgs[ck] = pkgs
+		}
+	}
+
+	// entryKey identifies one KnownViolation by its position in the nested map.
+	// The index is needed because each entry goes stale independently: a wildcard
+	// "" Imported entry matches many violations but is stale only when none do.
+	type entryKey struct {
+		bk, ck string
+		i      int
+	}
+	matchedEntries := make(map[entryKey]bool)
+
+	for _, v := range violations {
+		matched := false
+		for bk, comps := range known {
+			if !pathMatches(bk, v.Binary) {
+				continue
+			}
+			for ck, kvs := range comps {
+				if !componentOnPath(v.Binary, ck, v.Imported, componentPkgs[ck], reach) {
+					continue
+				}
+				for i, kv := range kvs {
+					if pathMatches(kv.Imported, v.Imported) {
+						matchedEntries[entryKey{bk, ck, i}] = true
+						matched = true
+					}
+				}
+			}
+		}
+		if matched {
+			continue
+		}
+		// ShortestChain returns nil when Binary=="" (flat-scope violation) or
+		// the binary is absent from the graph; fall back to a minimal chain so
+		// the error message is still useful.
+		chain := ShortestChain(v.Binary, v.Imported, graph)
+		if chain == nil {
+			if v.Binary != "" {
+				chain = []string{v.Binary, v.Imported}
+			} else if v.Importer != "" {
+				chain = []string{v.Importer, v.Imported}
+			} else {
+				chain = []string{v.Imported}
+			}
+		}
+		t.Errorf("NEW violation:\n    %s", FormatChain(chain))
+	}
+
+	binKeys := make([]string, 0, len(known))
+	for bk := range known {
+		binKeys = append(binKeys, bk)
+	}
+	sort.Strings(binKeys)
+
+	for _, bk := range binKeys {
+		// The "" key is library scope: always active, never an unknown binary.
+		if bk != "" {
+			active := false
+			for _, sb := range scannedBinaries {
+				if pathMatches(bk, sb) {
+					active = true
+					break
+				}
+			}
+			if !active {
+				t.Errorf("knownViolations binary key %q matches no scanned binary — remove it or fix the path", bk)
+				continue
+			}
+		}
+		compKeys := make([]string, 0, len(known[bk]))
+		for ck := range known[bk] {
+			compKeys = append(compKeys, ck)
+		}
+		sort.Strings(compKeys)
+		for _, ck := range compKeys {
+			for i, kv := range known[bk][ck] {
+				if !matchedEntries[entryKey{bk, ck, i}] {
+					t.Errorf("stale entry in knownViolations: binary=%q component=%q imported=%q — remove it", bk, ck, kv.Imported)
+				}
+			}
+		}
+	}
+}
+
+// A single package matching ck must satisfy both halves: reachable from the
+// binary AND able to reach the forbidden package.
+func componentOnPath(binary, ck, forbidden string, pkgsForCK []string, reach func(string) map[string]bool) bool {
+	if ck == "" {
+		return true
+	}
+	if binary == "" {
+		// Flat-scan violations have no binary root; a component key has no
+		// meaningful path constraint without one.
+		return false
+	}
+	binaryReach := reach(binary)
+	for _, p := range pkgsForCK {
+		if !binaryReach[p] {
+			continue
+		}
+		if reach(p)[forbidden] {
+			return true
+		}
+	}
+	return false
+}
+
+func validateSkipBinaries(t testing.TB, skipBinaries, discoveredBinaries []string) {
+	t.Helper()
+	for _, skip := range skipBinaries {
+		found := false
+		for _, discovered := range discoveredBinaries {
+			if pathMatches(skip, discovered) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("skipBinaries entry %q matches no discovered binary — remove it or fix the path", skip)
+		}
+	}
+}
+
+func scanBinaryViolations(graph map[string][]string, binaries []string, forbiddenPkgs []string) ([]Violation, map[string]bool) {
+	var violations []Violation
+	// unionReach accumulates every package reachable from any binary.
+	// scanFlatViolations uses it to exclude binary-reachable packages from the
+	// flat scope, so they are not double-reported.
+	unionReach := make(map[string]bool)
+	seen := make(map[Violation]bool)
+
+	for _, bin := range binaries {
+		for pkg := range bfsReachable(bin, graph) {
+			unionReach[pkg] = true
+			for _, imp := range graph[pkg] {
+				if !isForbidden(imp, forbiddenPkgs) {
+					continue
+				}
+				v := Violation{Binary: bin, Imported: imp}
+				if !seen[v] {
+					seen[v] = true
+					violations = append(violations, v)
+				}
+			}
+		}
+	}
+	return violations, unionReach
+}
+
+// scanFlatViolations covers packages no binary reaches, so library code is
+// still audited.
+func scanFlatViolations(graph map[string][]string, unionReach map[string]bool, forbiddenPkgs []string) []Violation {
+	var violations []Violation
+	seen := make(map[string]bool)
+
+	for pkg, imports := range graph {
+		if unionReach[pkg] {
+			continue
+		}
+		for _, imp := range imports {
+			if !isForbidden(imp, forbiddenPkgs) {
+				continue
+			}
+			// NUL separator prevents "a/b"+"c" from colliding with "a"+"bc".
+			key := pkg + "\x00" + imp
+			if seen[key] {
+				continue
+			}
+			seen[key] = true
+			violations = append(violations, Violation{Importer: pkg, Imported: imp})
+		}
+	}
+	return violations
+}
+
+// bfsReachable returns the set of packages reachable from root, inclusive.
+// An absent root yields an empty set: it is not a real package, so returning it
+// would make a typo'd component key look reachable.
+func bfsReachable(root string, graph map[string][]string) map[string]bool {
+	visited := make(map[string]bool)
+	if _, ok := graph[root]; !ok {
+		return visited
+	}
+	visited[root] = true
+	queue := []string{root}
+	for i := 0; i < len(queue); i++ {
+		for _, dep := range graph[queue[i]] {
+			if !visited[dep] {
+				visited[dep] = true
+				queue = append(queue, dep)
+			}
+		}
+	}
+	return visited
+}
+
+// ShortestChain returns the shortest import path from→to in graph, inclusive.
+// Returns nil if no path exists.
+func ShortestChain(from, to string, graph map[string][]string) []string {
 	if from == to {
 		return []string{from}
 	}
 
-	type state struct {
-		pkg  string
-		path []string
-	}
-
-	visited := make(map[string]bool)
-	visited[from] = true
-	queue := []state{{pkg: from, path: []string{from}}}
-
-	for len(queue) > 0 {
-		cur := queue[0]
-		queue = queue[1:]
-
-		for _, next := range importGraph[cur.pkg] {
-			if visited[next] {
+	parent := map[string]string{from: ""}
+	queue := []string{from}
+	for i := 0; i < len(queue); i++ {
+		for _, next := range graph[queue[i]] {
+			if _, seen := parent[next]; seen {
 				continue
 			}
-			newPath := make([]string, len(cur.path)+1)
-			copy(newPath, cur.path)
-			newPath[len(cur.path)] = next
-
+			parent[next] = queue[i]
 			if next == to {
-				return newPath
+				// Reconstruct path by following parent pointers from target
+				// back to root, then reverse: BFS builds the path backward.
+				var chain []string
+				for p := to; p != from; p = parent[p] {
+					chain = append(chain, p)
+				}
+				chain = append(chain, from)
+				for l, r := 0, len(chain)-1; l < r; l, r = l+1, r-1 {
+					chain[l], chain[r] = chain[r], chain[l]
+				}
+				return chain
 			}
-
-			visited[next] = true
-			queue = append(queue, state{pkg: next, path: newPath})
+			queue = append(queue, next)
 		}
 	}
-
 	return nil
 }
 
-// FormatChain joins a chain with indented " -> " separators for readable output:
+// FormatChain renders an import chain as:
 //
 //	pkg/a
 //	      -> pkg/b
@@ -316,322 +477,17 @@ func FormatChain(chain []string) string {
 	return strings.Join(parts, "\n")
 }
 
-// CheckModule scans all packages and their transitive dependencies matching
-// patterns and reports unknown violations or stale knownViolations entries via
-// t.Errorf. Works for both binary and library modules.
-//
-// knownViolations is a two-level map:
-//   - Outer key: binary entry-point import path, or "" to match all binaries.
-//     May be a module-root prefix (e.g. "github.com/elastic/myagent") that
-//     matches any binary whose import path starts with that prefix.
-//   - Inner key: component — a package path or module-root prefix that must be
-//     reachable from the binary AND able to reach the violating importer in the
-//     import graph. Use "" to match any violation within that binary.
-//
-// A single violation can match multiple component keys simultaneously: if both
-// "fbreceiver" and "azureauthextension" can transitively reach the same
-// forbidden importer, listing the same (Importer, Imported) pair under both
-// component keys causes both to be suppressed and neither to be flagged stale.
-// This is the intended way to document violations shared by multiple components.
-//
-// For a violation like:
-//
-//	cmd/kafkareceiver
-//	      -> otel-contrib/receiver/kafkareceiver
-//	      -> otel-contrib/internal/kafka          ← Importer
-//	      -> gokrb5/v8/client                     ← Imported (forbidden)
-//
-// Any of the following are valid component keys:
-//
-//	""                                    — matches any violation in this binary
-//	"otel-contrib"                        — the external module root
-//	"otel-contrib/receiver/kafkareceiver" — the specific receiver package
-//	"otel-contrib/internal/kafka"         — the exact direct importer
-//
-// Stale detection: an entry is flagged stale when the binary was scanned, the
-// component can still reach the importer, but the (Importer, Imported) pair is
-// no longer a violation. Entries whose component is no longer reachable from the
-// binary, or whose component can no longer reach the importer, are silently
-// skipped (dependency removed or path broken).
-//
-// Binaries in skipBinaries are excluded from the scan and from stale detection.
-// tags is passed as -tags to go list; nil or empty means no tags.
-func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string, knownViolations map[string]map[string][]KnownViolation) {
-	t.Helper()
-	violations, importGraph, mains, binaryModule := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
-	if binaryModule && len(mains) == 0 {
-		return // all discovered binaries were skipped
-	}
-	checkViolations(t, violations, importGraph, mains, knownViolations)
+// pathMatches reports whether path equals pattern or is a sub-package of it.
+// An empty pattern is a wildcard.
+func pathMatches(pattern, path string) bool {
+	bare := strings.TrimRight(pattern, "/")
+	return bare == "" || path == bare || strings.HasPrefix(path, bare+"/")
 }
 
-// checkViolations matches violations against knownViolations and reports new
-// violations or stale entries via t.Errorf.
-func checkViolations(t testing.TB, violations []Violation, importGraph map[string][]string, mains []string, knownViolations map[string]map[string][]KnownViolation) {
-	t.Helper()
-
-	// matched[binKey][compKey][i] tracks whether knownViolations[binKey][compKey][i] was hit.
-	matched := make(map[string]map[string][]bool)
-	for binKey, comps := range knownViolations {
-		matched[binKey] = make(map[string][]bool, len(comps))
-		for compKey, kvs := range comps {
-			matched[binKey][compKey] = make([]bool, len(kvs))
-		}
-	}
-
-	// Pre-compute reachable set per binary for attribution and stale detection.
-	reachableFrom := make(map[string]map[string]bool, len(mains))
-	for _, bin := range mains {
-		reachableFrom[bin] = bfsReachable(bin, importGraph)
-	}
-
-	// Pre-compute which packages in importGraph match each component key
-	// (exact path or module-root prefix).
-	compPkgs := make(map[string][]string)
-	for _, comps := range knownViolations {
-		for compKey := range comps {
-			if compKey == "" {
-				continue
-			}
-			if _, seen := compPkgs[compKey]; seen {
-				continue
-			}
-			prefix := compKey + "/"
-			for pkg := range importGraph {
-				if pkg == compKey || strings.HasPrefix(pkg, prefix) {
-					compPkgs[compKey] = append(compPkgs[compKey], pkg)
-				}
-			}
-		}
-	}
-
-	// Build a reverse import graph so "can component reach importer?" becomes
-	// "is any component package in the reverse-reachable set of importer?" —
-	// O(graph) per unique importer rather than O(component-pkgs × graph).
-	reverseGraph := make(map[string][]string, len(importGraph))
-	for pkg, imports := range importGraph {
-		for _, imp := range imports {
-			reverseGraph[imp] = append(reverseGraph[imp], pkg)
-		}
-	}
-	reverseReach := newReachabilityCache(reverseGraph)
-
-	// componentCanReach reports whether the component identified by key can
-	// reach importer. key "" is a wildcard.
-	componentCanReach := func(key, importer string) bool {
-		if key == "" {
+func isForbidden(pkg string, forbiddenPkgs []string) bool {
+	for _, prefix := range forbiddenPkgs {
+		if pathMatches(prefix, pkg) {
 			return true
-		}
-		canReach := reverseReach.from(importer)
-		for _, pkg := range compPkgs[key] {
-			if canReach[pkg] {
-				return true
-			}
-		}
-		return false
-	}
-
-	// importerMatches reports whether kv.Importer matches the actual importer.
-	//   - kv.Importer == "": wildcard, matches any importer.
-	//   - exact path: must equal importer exactly.
-	//   - prefix: "github.com/foo/bar" matches "github.com/foo/bar/baz".
-	importerMatches := func(kv KnownViolation, importer string) bool {
-		if kv.Importer == "" {
-			return true
-		}
-		return kv.Importer == importer || strings.HasPrefix(importer, kv.Importer+"/")
-	}
-
-	// importedMatches reports whether kv.Imported matches the actual imported package.
-	//   - kv.Imported == "": wildcard, matches any forbidden package.
-	//   - exact path or prefix: trailing slash is stripped before matching.
-	importedMatches := func(kv KnownViolation, imported string) bool {
-		if kv.Imported == "" {
-			return true
-		}
-		bare := strings.TrimRight(kv.Imported, "/")
-		return imported == bare || strings.HasPrefix(imported, bare+"/")
-	}
-
-	// componentCanReachImporter is the stale-detection fast path: returns false
-	// when the component can provably no longer reach the importer (or any
-	// subpackage of it), signalling a silent skip instead of a stale error.
-	// When kv.Importer is empty the check is skipped (we can't narrow to a
-	// specific importer, so let the matched flag decide).
-	componentCanReachImporter := func(compKey string, kv KnownViolation) bool {
-		if compKey == "" || kv.Importer == "" {
-			return true
-		}
-		bare := kv.Importer
-		sub := bare + "/"
-		for imp := range importGraph {
-			if imp != bare && !strings.HasPrefix(imp, sub) {
-				continue
-			}
-			canReach := reverseReach.from(imp)
-			for _, pkg := range compPkgs[compKey] {
-				if canReach[pkg] {
-					return true
-				}
-			}
-		}
-		return false
-	}
-
-	// binKeysForBinary returns all knownViolations keys applicable to a binary:
-	// the exact path, any module-root prefix key, and always "".
-	binKeysForBinary := func(binary string) []string {
-		if binary == "" {
-			return []string{""}
-		}
-		keys := []string{binary, ""}
-		for key := range knownViolations {
-			if key == "" || key == binary {
-				continue
-			}
-			if matchesBinaryKey(key, binary) {
-				keys = append(keys, key)
-			}
-		}
-		return keys
-	}
-
-	// markKnown finds ALL known entries where the component can reach the
-	// importer AND is reachable from the binary, and (Importer, Imported)
-	// matches. Marks each matched entry and returns the full list so the caller
-	// can log reasons. A single violation can match multiple component keys.
-	markKnown := func(binary, importer, imported string) ([]KnownViolation, bool) {
-		var results []KnownViolation
-		for _, binKey := range binKeysForBinary(binary) {
-			for compKey, kvs := range knownViolations[binKey] {
-				if !componentCanReach(compKey, importer) {
-					continue
-				}
-				// The component must also be reachable from the violation's own binary;
-				// a component reachable only from a different binary must not suppress
-				// violations here.
-				if binary != "" && compKey != "" && !isReachableFromAny(compKey, []string{binary}, reachableFrom) {
-					continue
-				}
-				for i, kv := range kvs {
-					if importerMatches(kv, importer) && importedMatches(kv, imported) {
-						matched[binKey][compKey][i] = true
-						results = append(results, kv)
-					}
-				}
-			}
-		}
-		return results, len(results) > 0
-	}
-
-	for _, v := range violations {
-		var chain []string
-		if v.Binary != "" {
-			chain = ShortestChain(v.Binary, v.Importer, importGraph)
-			if chain == nil {
-				chain = []string{v.Importer}
-			}
-		} else {
-			chain = []string{v.Importer}
-		}
-		displayChain := make([]string, len(chain)+1)
-		copy(displayChain, chain)
-		displayChain[len(chain)] = v.Imported
-
-		if kvs, ok := markKnown(v.Binary, v.Importer, v.Imported); ok {
-			for _, kv := range kvs {
-				t.Logf("known violation (%s):\n%s\n      reason: %s", v.Imported, FormatChain(displayChain), kv.Reason)
-			}
-		} else {
-			t.Errorf("NEW violation — add to knownViolations or remove the dependency:\n%s", FormatChain(displayChain))
-		}
-	}
-
-	// binsForKey returns all scanned binaries matching a binary key
-	// (exact or module-root prefix; "" matches all).
-	binsForKey := func(key string) []string {
-		if key == "" {
-			return mains
-		}
-		var result []string
-		for _, bin := range mains {
-			if matchesBinaryKey(key, bin) {
-				result = append(result, bin)
-			}
-		}
-		return result
-	}
-
-	for binKey, comps := range matched {
-		binsToCheck := binsForKey(binKey)
-		// Skip entries whose binary key matched no scanned binary.
-		if binKey != "" && len(binsToCheck) == 0 {
-			continue
-		}
-		for compKey, hits := range comps {
-			if compKey != "" {
-				if len(binsToCheck) > 0 {
-					// Binary mode: component must be reachable from at least one matching binary.
-					if !isReachableFromAny(compKey, binsToCheck, reachableFrom) {
-						continue
-					}
-				} else {
-					// Library mode: no binary entry points. Check that the component
-					// still exists somewhere in the import graph.
-					if len(compPkgs[compKey]) == 0 {
-						continue
-					}
-				}
-			}
-			for i, hit := range hits {
-				if !hit {
-					kv := knownViolations[binKey][compKey][i]
-					// If the component can no longer reach the importer (or any
-					// subpackage of it), the import path was broken — skip silently.
-					if !componentCanReachImporter(compKey, kv) {
-						continue
-					}
-					t.Errorf("stale knownViolations entry (no longer a violation — remove it): binary=%q component=%q importer=%q imported=%q", binKey, compKey, kv.Importer, kv.Imported)
-				}
-			}
-		}
-	}
-}
-
-// reachabilityCache lazily computes and caches the reachable-package set for
-// any starting package so each BFS runs at most once.
-type reachabilityCache struct {
-	importGraph map[string][]string
-	cache       map[string]map[string]bool
-}
-
-func newReachabilityCache(importGraph map[string][]string) *reachabilityCache {
-	return &reachabilityCache{importGraph: importGraph, cache: make(map[string]map[string]bool)}
-}
-
-// from returns the full set of packages reachable from pkg (inclusive).
-func (r *reachabilityCache) from(pkg string) map[string]bool {
-	if cached, ok := r.cache[pkg]; ok {
-		return cached
-	}
-	result := bfsReachable(pkg, r.importGraph)
-	r.cache[pkg] = result
-	return result
-}
-
-// isReachableFromAny reports whether key or any subpackage of key is reachable
-// from at least one binary in bins.
-func isReachableFromAny(key string, bins []string, reachableFrom map[string]map[string]bool) bool {
-	prefix := key + "/"
-	for _, bin := range bins {
-		reachable := reachableFrom[bin]
-		if reachable[key] {
-			return true
-		}
-		for pkg := range reachable {
-			if strings.HasPrefix(pkg, prefix) {
-				return true
-			}
 		}
 	}
 	return false

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -34,52 +34,6 @@ import (
 	"testing"
 )
 
-// Non-FIPS crypto library prefixes. All are included in ForbiddenPkgs()
-// and checked by Scan automatically. Use individual constants only when
-// passing a subset via extraForbiddenPkgs.
-const (
-	// XCrypto covers golang.org/x/crypto, which is not part of Go's certified
-	// FIPS 140-3 module (GOFIPS140=v1.0.0).
-	XCrypto = "golang.org/x/crypto/"
-
-	// JcmturnerAescts covers github.com/jcmturner/aescts (AES-CBC-CTS, own
-	// AES block cipher implementation not using crypto/aes).
-	JcmturnerAescts = "github.com/jcmturner/aescts/"
-
-	// JcmturnerGofork covers github.com/jcmturner/gofork, a fork of stdlib
-	// encoding/asn1 and crypto packages with non-FIPS modifications.
-	JcmturnerGofork = "github.com/jcmturner/gofork/"
-
-	// JcmturnerGokrb5 covers github.com/jcmturner/gokrb5 (Kerberos 5); pulls
-	// in JcmturnerAescts and JcmturnerGofork.
-	JcmturnerGokrb5 = "github.com/jcmturner/gokrb5/"
-
-	// XdgGoPbkdf2 covers github.com/xdg-go/pbkdf2, a standalone PBKDF2
-	// implementation independent of Go's crypto/pbkdf2.
-	XdgGoPbkdf2 = "github.com/xdg-go/pbkdf2"
-
-	// ProtonMailGoCrypto covers github.com/ProtonMail/go-crypto (OpenPGP);
-	// implements its own OpenPGP cipher suite including non-FIPS algorithms.
-	ProtonMailGoCrypto = "github.com/ProtonMail/go-crypto/"
-
-	// CloudflareCircl covers github.com/cloudflare/circl; implements a wide
-	// variety of primitives (SIDH, FourQ, Ristretto255, etc.) outside FIPS scope.
-	CloudflareCircl = "github.com/cloudflare/circl/"
-
-	// AzureGoNtlmssp covers github.com/Azure/go-ntlmssp; implements NTLM/SSPI
-	// authentication which relies on MD4/MD5/DES — none FIPS-approved.
-	AzureGoNtlmssp = "github.com/Azure/go-ntlmssp"
-
-	// YoumarkPkcs8 covers github.com/youmark/pkcs8; handles PKCS#8 keys and
-	// may negotiate non-FIPS ciphers (RC2, 3DES, SM4) depending on the key file.
-	YoumarkPkcs8 = "github.com/youmark/pkcs8"
-
-	// FilippioIO covers filippo.io/ packages (edwards25519, age, mlkem768,
-	// etc.). None are part of a FIPS 140-3 certified module boundary, even
-	// when they implement a FIPS-standardized algorithm (e.g. FIPS 203 ML-KEM).
-	FilippioIO = "filippo.io/"
-)
-
 // Violation is a forbidden import discovered in the dependency tree.
 type Violation struct {
 	Binary   string // binary entry point; empty for library modules
@@ -102,28 +56,6 @@ type KnownViolation struct {
 	Importer string
 	Imported string
 	Reason   string // why this violation is acceptable; shown in test output
-}
-
-var forbiddenPkgs = []string{
-	XCrypto,
-	JcmturnerAescts,
-	JcmturnerGofork,
-	JcmturnerGokrb5,
-	XdgGoPbkdf2,
-	ProtonMailGoCrypto,
-	CloudflareCircl,
-	AzureGoNtlmssp,
-	YoumarkPkcs8,
-	FilippioIO,
-}
-
-// ForbiddenPkgs returns a fresh copy of the baseline non-FIPS crypto library
-// prefixes. Scan uses this automatically; pass extraForbiddenPkgs only for
-// project-specific additions beyond this list.
-func ForbiddenPkgs() []string {
-	cp := make([]string, len(forbiddenPkgs))
-	copy(cp, forbiddenPkgs)
-	return cp
 }
 
 type goListPackage struct {
@@ -185,12 +117,10 @@ func goListPackages(t testing.TB, patterns []string) []goListPackage {
 // violation to its binary entry point via BFS, and returns the binaries found.
 // When no binaries are present (library module) it falls back to flat violation
 // detection with no Binary set, so CheckModule works for both module types.
-func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
+func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
 	t.Helper()
 
 	pkgs := goListPackages(t, patterns)
-
-	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
 
 	skip := make(map[string]bool, len(skipBinaries))
 	for _, s := range skipBinaries {
@@ -208,7 +138,7 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraF
 	}
 
 	if len(mains) == 0 {
-		return findViolations(importGraph, forbidden), importGraph, nil
+		return findViolations(importGraph, forbiddenPkgs), importGraph, nil
 	}
 
 	// Per-binary BFS attribution so each violation carries the entry point
@@ -217,11 +147,11 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraF
 	var violations []Violation
 	for _, bin := range mains {
 		for pkg := range bfsReachable(bin, importGraph) {
-			if isForbidden(pkg, forbidden) {
+			if isForbidden(pkg, forbiddenPkgs) {
 				continue
 			}
 			for _, imp := range importGraph[pkg] {
-				if isForbidden(imp, forbidden) {
+				if isForbidden(imp, forbiddenPkgs) {
 					if key := bin + "\x00" + pkg + "\x00" + imp; !seen[key] {
 						seen[key] = true
 						violations = append(violations, Violation{Binary: bin, Importer: pkg, Imported: imp})
@@ -273,9 +203,9 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 // (Violation.Binary), and returns all violations and the merged import graph.
 // Binaries whose import path appears in skipBinaries are excluded from the scan.
 // Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
-func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
+func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs)
 	if len(mains) == 0 {
 		t.Fatalf("ScanBinaries: no package main found matching %v", patterns)
 	}
@@ -285,15 +215,14 @@ func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraF
 // Scan runs `go list -json -deps -tags requirefips <pkg>` and returns all
 // violations and the full import graph. Calls t.Fatalf on subprocess or parse
 // errors.
-func Scan(t testing.TB, pkg string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
+func Scan(t testing.TB, pkg string, forbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
 	pkgs := goListPackages(t, []string{pkg})
-	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
 	importGraph := make(map[string][]string, len(pkgs))
 	for _, p := range pkgs {
 		importGraph[p.ImportPath] = p.Imports
 	}
-	return findViolations(importGraph, forbidden), importGraph
+	return findViolations(importGraph, forbiddenPkgs), importGraph
 }
 
 // matchesBinaryKey reports whether a binary key matches an actual binary import
@@ -413,9 +342,9 @@ func FormatChain(chain []string) string {
 // skipped (dependency removed or path broken).
 //
 // Binaries in skipBinaries are excluded from the scan and from stale detection.
-func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string, knownViolations map[string]map[string][]KnownViolation) {
+func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs)
 	checkViolations(t, violations, importGraph, mains, knownViolations)
 }
 

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -116,8 +116,9 @@ func goListPackages(t testing.TB, patterns []string, tags []string) []goListPack
 // scanBinaries runs a single go list pass over all patterns, attributes each
 // violation to its binary entry point, and returns the binaries found.
 // When no binaries are present (library module) it falls back to flat violation
-// detection with no Binary set.
-func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string, []string) {
+// detection with no Binary set. binaryModule reports whether any package main
+// was discovered at all (before skip filtering).
+func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) (violations []Violation, importGraph map[string][]string, mains []string, binaryModule bool) {
 	t.Helper()
 
 	pkgs := goListPackages(t, patterns, tags)
@@ -127,24 +128,37 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbid
 		skip[s] = true
 	}
 
-	importGraph := make(map[string][]string, len(pkgs))
-	var mains []string
+	importGraph = make(map[string][]string, len(pkgs))
+	var allMains []string
 
 	for _, p := range pkgs {
-		if p.Name == "main" && !skip[p.ImportPath] {
-			mains = append(mains, p.ImportPath)
+		if p.Name == "main" {
+			allMains = append(allMains, p.ImportPath)
 		}
 		importGraph[p.ImportPath] = p.Imports
 	}
 
+	binaryModule = len(allMains) > 0
+
+	if !binaryModule {
+		// True library module — no binary entry points.
+		return findViolations(importGraph, forbiddenPkgs), importGraph, nil, false
+	}
+
+	for _, m := range allMains {
+		if !skip[m] {
+			mains = append(mains, m)
+		}
+	}
+
 	if len(mains) == 0 {
-		return findViolations(importGraph, forbiddenPkgs), importGraph, nil
+		// All discovered binaries were skipped — nothing to scan.
+		return nil, importGraph, nil, true
 	}
 
 	// Per-binary BFS attribution so each violation carries the entry point
 	// that pulls it in.
 	seen := make(map[string]bool)
-	var violations []Violation
 	for _, bin := range mains {
 		for pkg := range bfsReachable(bin, importGraph) {
 			if isForbidden(pkg, forbiddenPkgs) {
@@ -160,7 +174,7 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbid
 			}
 		}
 	}
-	return violations, importGraph, mains
+	return violations, importGraph, mains, true
 }
 
 // bfsReachable returns the set of all packages reachable from from (inclusive).
@@ -204,8 +218,8 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 // Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
 func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
-	if len(mains) == 0 {
+	violations, importGraph, _, binaryModule := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
+	if !binaryModule {
 		t.Fatalf("ScanBinaries: no package main found matching %v", patterns)
 	}
 	return violations, importGraph
@@ -344,7 +358,10 @@ func FormatChain(chain []string) string {
 // tags is passed as -tags to go list; nil or empty means no tags.
 func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
+	violations, importGraph, mains, binaryModule := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
+	if binaryModule && len(mains) == 0 {
+		return // all discovered binaries were skipped
+	}
 	checkViolations(t, violations, importGraph, mains, knownViolations)
 }
 
@@ -388,16 +405,26 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 		}
 	}
 
-	compReach := newReachabilityCache(importGraph)
+	// Build a reverse import graph so "can component reach importer?" becomes
+	// "is any component package in the reverse-reachable set of importer?" —
+	// O(graph) per unique importer rather than O(component-pkgs × graph).
+	reverseGraph := make(map[string][]string, len(importGraph))
+	for pkg, imports := range importGraph {
+		for _, imp := range imports {
+			reverseGraph[imp] = append(reverseGraph[imp], pkg)
+		}
+	}
+	reverseReach := newReachabilityCache(reverseGraph)
 
 	// componentCanReach reports whether the component identified by key can
-	// reach importer via forward edges in the import graph. key "" is a wildcard.
+	// reach importer. key "" is a wildcard.
 	componentCanReach := func(key, importer string) bool {
 		if key == "" {
 			return true
 		}
+		canReach := reverseReach.from(importer)
 		for _, pkg := range compPkgs[key] {
-			if compReach.from(pkg)[importer] {
+			if canReach[pkg] {
 				return true
 			}
 		}
@@ -435,14 +462,15 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 		if compKey == "" || kv.Importer == "" {
 			return true
 		}
-		sub := kv.Importer + "/"
-		for _, pkg := range compPkgs[compKey] {
-			reachable := compReach.from(pkg)
-			if reachable[kv.Importer] {
-				return true
+		bare := kv.Importer
+		sub := bare + "/"
+		for imp := range importGraph {
+			if imp != bare && !strings.HasPrefix(imp, sub) {
+				continue
 			}
-			for rPkg := range reachable {
-				if strings.HasPrefix(rPkg, sub) {
+			canReach := reverseReach.from(imp)
+			for _, pkg := range compPkgs[compKey] {
+				if canReach[pkg] {
 					return true
 				}
 			}

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -336,32 +336,59 @@ func FormatChain(chain []string) string {
 
 // CheckModule scans all packages and their transitive dependencies matching
 // patterns and reports unknown violations or stale knownViolations entries via
-// t.Errorf. Works for both binary and library modules. The map key is the
-// binary entry point path; use "" for violations that apply to all binaries or
-// to library modules. Binaries in skipBinaries are excluded from the scan and
-// from stale detection. Stale detection only covers binaries found in this scan,
-// so per-binary subtest calls work correctly with per-binary map keys.
-func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string, knownViolations map[string][]KnownViolation) {
+// t.Errorf. Works for both binary and library modules.
+//
+// knownViolations is a two-level map:
+//   - Outer key: binary entry-point import path, or "" to match all binaries.
+//   - Inner key: component prefix — a package path or module prefix that must
+//     appear in the BFS chain from the binary to the importer. Use "" to match
+//     any violation chain within that binary.
+//
+// Using a module root as the component key (e.g. "github.com/twmb/franz-go")
+// groups all violations from that module's subpackages under one entry, making
+// it obvious which library introduces each violation.
+//
+// Stale detection: an entry is flagged stale when the binary was scanned, the
+// component prefix is still reachable from it, but the (Importer, Imported)
+// pair is no longer a violation. If the component is no longer reachable at
+// all (dependency removed), its entries are silently skipped.
+//
+// Binaries in skipBinaries are excluded from the scan and from stale detection.
+func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
 
 	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
 
-	// matched[binary][i] tracks whether knownViolations[binary][i] was hit.
-	matched := make(map[string][]bool)
-	for bin, kvs := range knownViolations {
-		matched[bin] = make([]bool, len(kvs))
+	// matched[binKey][compKey][i] tracks whether knownViolations[binKey][compKey][i] was hit.
+	matched := make(map[string]map[string][]bool)
+	for binKey, comps := range knownViolations {
+		matched[binKey] = make(map[string][]bool, len(comps))
+		for compKey, kvs := range comps {
+			matched[binKey][compKey] = make([]bool, len(kvs))
+		}
 	}
 
-	findKnown := func(binary, importer, imported string) (KnownViolation, bool) {
-		bins := []string{binary, ""}
+	// Pre-compute reachable set per binary for stale detection.
+	reachableFrom := make(map[string]map[string]bool, len(mains))
+	for _, bin := range mains {
+		reachableFrom[bin] = bfsReachable(bin, importGraph)
+	}
+
+	findKnown := func(binary, importer, imported string, chain []string) (KnownViolation, bool) {
+		binKeys := []string{binary, ""}
 		if binary == "" {
-			bins = []string{""}
+			binKeys = []string{""}
 		}
-		for _, bin := range bins {
-			for i, kv := range knownViolations[bin] {
-				if kv.Importer == importer && kv.Imported == imported {
-					matched[bin][i] = true
-					return kv, true
+		for _, binKey := range binKeys {
+			for compKey, kvs := range knownViolations[binKey] {
+				if !chainContains(compKey, chain) {
+					continue
+				}
+				for i, kv := range kvs {
+					if kv.Importer == importer && kv.Imported == imported {
+						matched[binKey][compKey][i] = true
+						return kv, true
+					}
 				}
 			}
 		}
@@ -382,7 +409,7 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		copy(displayChain, chain)
 		displayChain[len(chain)] = v.Imported
 
-		if kv, ok := findKnown(v.Binary, v.Importer, v.Imported); ok {
+		if kv, ok := findKnown(v.Binary, v.Importer, v.Imported, chain); ok {
 			t.Logf("known violation (%s):\n%s\n      reason: %s", v.Imported, FormatChain(displayChain), kv.Reason)
 		} else {
 			t.Errorf("NEW violation — add to knownViolations or remove the dependency:\n%s", FormatChain(displayChain))
@@ -397,15 +424,63 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 	}
 	scanned[""] = true
 
-	for bin, hits := range matched {
-		if !scanned[bin] {
+	for binKey, comps := range matched {
+		if !scanned[binKey] {
 			continue
 		}
-		for i, hit := range hits {
-			if !hit {
-				kv := knownViolations[bin][i]
-				t.Errorf("stale knownViolations entry (no longer a violation — remove it): binary=%q importer=%q imported=%q", bin, kv.Importer, kv.Imported)
+		var binsToCheck []string
+		if binKey == "" {
+			binsToCheck = mains
+		} else {
+			binsToCheck = []string{binKey}
+		}
+		for compKey, hits := range comps {
+			// If the component is no longer reachable from any relevant binary,
+			// the dependency was removed entirely — skip silently rather than
+			// reporting every entry as stale.
+			if compKey != "" && !isReachableFromAny(compKey, binsToCheck, reachableFrom) {
+				continue
+			}
+			for i, hit := range hits {
+				if !hit {
+					kv := knownViolations[binKey][compKey][i]
+					t.Errorf("stale knownViolations entry (no longer a violation — remove it): binary=%q component=%q importer=%q imported=%q", binKey, compKey, kv.Importer, kv.Imported)
+				}
 			}
 		}
 	}
+}
+
+// chainContains reports whether key is "" (wildcard) or is a prefix of any
+// package in chain. A key without a trailing slash matches both the package
+// itself and any subpackage (e.g. "github.com/foo/bar" matches
+// "github.com/foo/bar" and "github.com/foo/bar/baz").
+func chainContains(key string, chain []string) bool {
+	if key == "" {
+		return true
+	}
+	for _, pkg := range chain {
+		if pkg == key || strings.HasPrefix(pkg, key+"/") {
+			return true
+		}
+	}
+	return false
+}
+
+// isReachableFromAny reports whether key or any subpackage of key is reachable
+// from at least one binary in bins.
+func isReachableFromAny(key string, bins []string, reachableFrom map[string]map[string]bool) bool {
+	prefix := key + "/"
+	for _, bin := range bins {
+		reachable := reachableFrom[bin]
+		if reachable[key] {
+			return true
+		}
+		for pkg := range reachable {
+			if strings.HasPrefix(pkg, prefix) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -84,9 +84,13 @@ func moduleRoot(t testing.TB) string {
 }
 
 // goListPackages runs go list -json -deps from the module root and decodes the output.
-func goListPackages(t testing.TB, patterns []string) []goListPackage {
+func goListPackages(t testing.TB, patterns []string, tags []string) []goListPackage {
 	t.Helper()
-	args := append([]string{"list", "-json", "-deps", "-tags", "requirefips"}, patterns...)
+	base := []string{"list", "-json", "-deps"}
+	if len(tags) > 0 {
+		base = append(base, "-tags", strings.Join(tags, ","))
+	}
+	args := append(base, patterns...)
 	cmd := exec.CommandContext(t.Context(), "go", args...)
 	cmd.Dir = moduleRoot(t)
 	out, err := cmd.Output()
@@ -113,10 +117,10 @@ func goListPackages(t testing.TB, patterns []string) []goListPackage {
 // violation to its binary entry point, and returns the binaries found.
 // When no binaries are present (library module) it falls back to flat violation
 // detection with no Binary set.
-func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
+func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string, []string) {
 	t.Helper()
 
-	pkgs := goListPackages(t, patterns)
+	pkgs := goListPackages(t, patterns, tags)
 
 	skip := make(map[string]bool, len(skipBinaries))
 	for _, s := range skipBinaries {
@@ -197,9 +201,9 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 // point (Violation.Binary), and returns all violations and the merged import graph.
 // Binaries whose import path appears in skipBinaries are excluded from the scan.
 // Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
-func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string) ([]Violation, map[string][]string) {
+func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
 	if len(mains) == 0 {
 		t.Fatalf("ScanBinaries: no package main found matching %v", patterns)
 	}
@@ -208,9 +212,9 @@ func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbid
 
 // Scan scans pkg and its full dependency tree and returns all violations and the
 // import graph. Calls t.Fatalf on subprocess or parse errors.
-func Scan(t testing.TB, pkg string, forbiddenPkgs []string) ([]Violation, map[string][]string) {
+func Scan(t testing.TB, pkg string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
 	t.Helper()
-	pkgs := goListPackages(t, []string{pkg})
+	pkgs := goListPackages(t, []string{pkg}, tags)
 	importGraph := make(map[string][]string, len(pkgs))
 	for _, p := range pkgs {
 		importGraph[p.ImportPath] = p.Imports
@@ -335,9 +339,9 @@ func FormatChain(chain []string) string {
 // skipped (dependency removed or path broken).
 //
 // Binaries in skipBinaries are excluded from the scan and from stale detection.
-func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, knownViolations map[string]map[string][]KnownViolation) {
+func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)
 	checkViolations(t, violations, importGraph, mains, knownViolations)
 }
 

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -344,9 +344,23 @@ func FormatChain(chain []string) string {
 //     appear in the BFS chain from the binary to the importer. Use "" to match
 //     any violation chain within that binary.
 //
-// Using a module root as the component key (e.g. "github.com/twmb/franz-go")
-// groups all violations from that module's subpackages under one entry, making
-// it obvious which library introduces each violation.
+// For a violation like:
+//
+//	cmd/kafkareceiver
+//	      -> otel-contrib/receiver/kafkareceiver
+//	      -> otel-contrib/internal/kafka          ← Importer
+//	      -> gokrb5/v8/client                     ← Imported (forbidden)
+//
+// Any of the following are valid component keys:
+//
+//	""                                    — matches any chain in this binary
+//	"cmd/kafkareceiver"                   — the binary itself (binary-level match)
+//	"otel-contrib"                        — the external module root
+//	"otel-contrib/receiver/kafkareceiver" — the specific receiver package
+//	"otel-contrib/internal/kafka"         — the exact direct importer
+//
+// The component key must match a package in the chain from binary to Importer.
+// It cannot be the forbidden package itself (Imported).
 //
 // Stale detection: an entry is flagged stale when the binary was scanned, the
 // component prefix is still reachable from it, but the (Importer, Imported)
@@ -385,7 +399,7 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 					continue
 				}
 				for i, kv := range kvs {
-					if kv.Importer == importer && kv.Imported == imported {
+					if (kv.Importer == importer || kv.Importer == binary) && kv.Imported == imported {
 						matched[binKey][compKey][i] = true
 						return kv, true
 					}

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -340,9 +340,15 @@ func FormatChain(chain []string) string {
 //
 // knownViolations is a two-level map:
 //   - Outer key: binary entry-point import path, or "" to match all binaries.
-//   - Inner key: component prefix — a package path or module prefix that must
-//     appear in the BFS chain from the binary to the importer. Use "" to match
-//     any violation chain within that binary.
+//   - Inner key: component — a package path or module-root prefix that must be
+//     reachable from the binary AND able to reach the violating importer in the
+//     import graph. Use "" to match any violation within that binary.
+//
+// A single violation can match multiple component keys simultaneously: if both
+// "fbreceiver" and "azureauthextension" can transitively reach the same
+// non-FIPS importer, listing the same (Importer, Imported) pair under both
+// component keys causes both to be suppressed and neither to be flagged stale.
+// This is the intended way to document violations shared by multiple components.
 //
 // For a violation like:
 //
@@ -353,19 +359,16 @@ func FormatChain(chain []string) string {
 //
 // Any of the following are valid component keys:
 //
-//	""                                    — matches any chain in this binary
-//	"cmd/kafkareceiver"                   — the binary itself (binary-level match)
+//	""                                    — matches any violation in this binary
 //	"otel-contrib"                        — the external module root
 //	"otel-contrib/receiver/kafkareceiver" — the specific receiver package
 //	"otel-contrib/internal/kafka"         — the exact direct importer
 //
-// The component key must match a package in the chain from binary to Importer.
-// It cannot be the forbidden package itself (Imported).
-//
 // Stale detection: an entry is flagged stale when the binary was scanned, the
-// component prefix is still reachable from it, but the (Importer, Imported)
-// pair is no longer a violation. If the component is no longer reachable at
-// all (dependency removed), its entries are silently skipped.
+// component can still reach the importer, but the (Importer, Imported) pair is
+// no longer a violation. Entries whose component is no longer reachable from the
+// binary, or whose component can no longer reach the importer, are silently
+// skipped (dependency removed or path broken).
 //
 // Binaries in skipBinaries are excluded from the scan and from stale detection.
 func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string, knownViolations map[string]map[string][]KnownViolation) {
@@ -388,25 +391,66 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		reachableFrom[bin] = bfsReachable(bin, importGraph)
 	}
 
-	findKnown := func(binary, importer, imported string, chain []string) (KnownViolation, bool) {
+	// Pre-compute which packages in importGraph match each component key
+	// (exact path or module-root prefix). Used by componentCanReach.
+	compPkgs := make(map[string][]string)
+	for _, comps := range knownViolations {
+		for compKey := range comps {
+			if compKey == "" {
+				continue
+			}
+			if _, seen := compPkgs[compKey]; seen {
+				continue
+			}
+			prefix := compKey + "/"
+			for pkg := range importGraph {
+				if pkg == compKey || strings.HasPrefix(pkg, prefix) {
+					compPkgs[compKey] = append(compPkgs[compKey], pkg)
+				}
+			}
+		}
+	}
+
+	compReach := newReachabilityCache(importGraph)
+
+	// componentCanReach reports whether the component identified by key can
+	// reach importer via forward edges in the import graph. key "" is a wildcard.
+	componentCanReach := func(key, importer string) bool {
+		if key == "" {
+			return true
+		}
+		for _, pkg := range compPkgs[key] {
+			if compReach.from(pkg)[importer] {
+				return true
+			}
+		}
+		return false
+	}
+
+	// markKnown finds ALL known entries where the component can reach importer
+	// and (Importer, Imported) matches. Marks each matched entry and returns the
+	// full list so the caller can log reasons. A single violation can match
+	// multiple component keys.
+	markKnown := func(binary, importer, imported string) ([]KnownViolation, bool) {
+		var results []KnownViolation
 		binKeys := []string{binary, ""}
 		if binary == "" {
 			binKeys = []string{""}
 		}
 		for _, binKey := range binKeys {
 			for compKey, kvs := range knownViolations[binKey] {
-				if !chainContains(compKey, chain) {
+				if !componentCanReach(compKey, importer) {
 					continue
 				}
 				for i, kv := range kvs {
-					if (kv.Importer == importer || kv.Importer == binary) && kv.Imported == imported {
+					if kv.Importer == importer && kv.Imported == imported {
 						matched[binKey][compKey][i] = true
-						return kv, true
+						results = append(results, kv)
 					}
 				}
 			}
 		}
-		return KnownViolation{}, false
+		return results, len(results) > 0
 	}
 
 	for _, v := range violations {
@@ -423,8 +467,10 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		copy(displayChain, chain)
 		displayChain[len(chain)] = v.Imported
 
-		if kv, ok := findKnown(v.Binary, v.Importer, v.Imported, chain); ok {
-			t.Logf("known violation (%s):\n%s\n      reason: %s", v.Imported, FormatChain(displayChain), kv.Reason)
+		if kvs, ok := markKnown(v.Binary, v.Importer, v.Imported); ok {
+			for _, kv := range kvs {
+				t.Logf("known violation (%s):\n%s\n      reason: %s", v.Imported, FormatChain(displayChain), kv.Reason)
+			}
 		} else {
 			t.Errorf("NEW violation — add to knownViolations or remove the dependency:\n%s", FormatChain(displayChain))
 		}
@@ -450,14 +496,18 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		}
 		for compKey, hits := range comps {
 			// If the component is no longer reachable from any relevant binary,
-			// the dependency was removed entirely — skip silently rather than
-			// reporting every entry as stale.
+			// the dependency was removed entirely — skip all entries silently.
 			if compKey != "" && !isReachableFromAny(compKey, binsToCheck, reachableFrom) {
 				continue
 			}
 			for i, hit := range hits {
 				if !hit {
 					kv := knownViolations[binKey][compKey][i]
+					// If the component can no longer reach the importer the import
+					// path was broken (package restructured or removed) — skip silently.
+					if !componentCanReach(compKey, kv.Importer) {
+						continue
+					}
 					t.Errorf("stale knownViolations entry (no longer a violation — remove it): binary=%q component=%q importer=%q imported=%q", binKey, compKey, kv.Importer, kv.Imported)
 				}
 			}
@@ -465,20 +515,26 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 	}
 }
 
-// chainContains reports whether key is "" (wildcard) or is a prefix of any
-// package in chain. A key without a trailing slash matches both the package
-// itself and any subpackage (e.g. "github.com/foo/bar" matches
-// "github.com/foo/bar" and "github.com/foo/bar/baz").
-func chainContains(key string, chain []string) bool {
-	if key == "" {
-		return true
+// reachabilityCache lazily computes and caches the reachable-package set for
+// any starting package. Shared across multiple componentCanReach calls so each
+// BFS runs at most once per starting package.
+type reachabilityCache struct {
+	importGraph map[string][]string
+	cache       map[string]map[string]bool
+}
+
+func newReachabilityCache(importGraph map[string][]string) *reachabilityCache {
+	return &reachabilityCache{importGraph: importGraph, cache: make(map[string]map[string]bool)}
+}
+
+// from returns the full set of packages reachable from pkg (inclusive).
+func (r *reachabilityCache) from(pkg string) map[string]bool {
+	if cached, ok := r.cache[pkg]; ok {
+		return cached
 	}
-	for _, pkg := range chain {
-		if pkg == key || strings.HasPrefix(pkg, key+"/") {
-			return true
-		}
-	}
-	return false
+	result := bfsReachable(pkg, r.importGraph)
+	r.cache[pkg] = result
+	return result
 }
 
 // isReachableFromAny reports whether key or any subpackage of key is reachable

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -27,7 +27,9 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -130,16 +132,34 @@ type goListPackage struct {
 	Imports    []string
 }
 
-// scanBinaries is the internal implementation shared by ScanBinaries and
-// CheckModule. It runs a single go list pass over all patterns, attributes each
-// violation to its binary entry point via BFS, and returns the binaries found.
-// When no binaries are present (library module) it falls back to flat violation
-// detection with no Binary set, so CheckModule works for both module types.
-func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
+// moduleRoot walks up from the working directory to find the nearest go.mod
+// and returns its containing directory. go test sets cwd to the test package
+// directory, so relative patterns like ./... need to run from the module root.
+func moduleRoot(t testing.TB) string {
 	t.Helper()
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("finding module root: %v", err)
+	}
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.mod")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("finding module root: go.mod not found starting from %s", dir)
+		}
+		dir = parent
+	}
+}
 
+// goListPackages runs go list -json -deps -tags requirefips from the module root
+// and decodes the output. Shared by scanBinaries and Scan.
+func goListPackages(t testing.TB, patterns []string) []goListPackage {
+	t.Helper()
 	args := append([]string{"list", "-json", "-deps", "-tags", "requirefips"}, patterns...)
 	cmd := exec.CommandContext(t.Context(), "go", args...)
+	cmd.Dir = moduleRoot(t)
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -148,6 +168,27 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraF
 		}
 		t.Fatalf("go list failed: %v", err)
 	}
+	var pkgs []goListPackage
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var p goListPackage
+		if err := dec.Decode(&p); err != nil {
+			t.Fatalf("parsing go list output: %v", err)
+		}
+		pkgs = append(pkgs, p)
+	}
+	return pkgs
+}
+
+// scanBinaries is the internal implementation shared by ScanBinaries and
+// CheckModule. It runs a single go list pass over all patterns, attributes each
+// violation to its binary entry point via BFS, and returns the binaries found.
+// When no binaries are present (library module) it falls back to flat violation
+// detection with no Binary set, so CheckModule works for both module types.
+func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
+	t.Helper()
+
+	pkgs := goListPackages(t, patterns)
 
 	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
 
@@ -156,15 +197,10 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraF
 		skip[s] = true
 	}
 
-	importGraph := make(map[string][]string)
+	importGraph := make(map[string][]string, len(pkgs))
 	var mains []string
 
-	dec := json.NewDecoder(bytes.NewReader(out))
-	for dec.More() {
-		var p goListPackage
-		if err := dec.Decode(&p); err != nil {
-			t.Fatalf("parsing go list output: %v", err)
-		}
+	for _, p := range pkgs {
 		if p.Name == "main" && !skip[p.ImportPath] {
 			mains = append(mains, p.ImportPath)
 		}
@@ -251,30 +287,24 @@ func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraF
 // errors.
 func Scan(t testing.TB, pkg string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
-
-	cmd := exec.CommandContext(t.Context(), "go", "list", "-json", "-deps", "-tags", "requirefips", pkg)
-	out, err := cmd.Output()
-	if err != nil {
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			t.Fatalf("go list failed: %v\n%s", err, exitErr.Stderr)
-		}
-		t.Fatalf("go list failed: %v", err)
-	}
-
+	pkgs := goListPackages(t, []string{pkg})
 	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
-	importGraph := make(map[string][]string)
-
-	dec := json.NewDecoder(bytes.NewReader(out))
-	for dec.More() {
-		var p goListPackage
-		if err := dec.Decode(&p); err != nil {
-			t.Fatalf("parsing go list output: %v", err)
-		}
+	importGraph := make(map[string][]string, len(pkgs))
+	for _, p := range pkgs {
 		importGraph[p.ImportPath] = p.Imports
 	}
-
 	return findViolations(importGraph, forbidden), importGraph
+}
+
+// matchesBinaryKey reports whether a binary key matches an actual binary import
+// path. The key may be an exact import path, a module-root prefix, or "" which
+// matches any binary.
+func matchesBinaryKey(key, binary string) bool {
+	if key == "" {
+		return true
+	}
+	bare := strings.TrimRight(key, "/")
+	return binary == bare || strings.HasPrefix(binary, bare+"/")
 }
 
 func isForbidden(pkg string, forbiddenPkgs []string) bool {
@@ -350,6 +380,8 @@ func FormatChain(chain []string) string {
 //
 // knownViolations is a two-level map:
 //   - Outer key: binary entry-point import path, or "" to match all binaries.
+//     May be a module-root prefix (e.g. "github.com/elastic/myagent") that
+//     matches any binary whose import path starts with that prefix.
 //   - Inner key: component — a package path or module-root prefix that must be
 //     reachable from the binary AND able to reach the violating importer in the
 //     import graph. Use "" to match any violation within that binary.
@@ -448,6 +480,18 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		return kv.Importer == importer || strings.HasPrefix(importer, kv.Importer+"/")
 	}
 
+	// importedMatches reports whether kv.Imported matches the actual imported package.
+	//   - kv.Imported == "": wildcard, matches any forbidden package.
+	//   - exact path or prefix: trailing slash is stripped before matching so
+	//     using an exported constant like XCrypto works correctly.
+	importedMatches := func(kv KnownViolation, imported string) bool {
+		if kv.Imported == "" {
+			return true
+		}
+		bare := strings.TrimRight(kv.Imported, "/")
+		return imported == bare || strings.HasPrefix(imported, bare+"/")
+	}
+
 	// componentCanReachImporter is the stale-detection fast path: returns false
 	// when the component can provably no longer reach the importer (or any
 	// subpackage of it), signalling a silent skip instead of a stale error.
@@ -472,23 +516,38 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		return false
 	}
 
+	// binKeysForBinary returns all keys in knownViolations that should be
+	// consulted for a given binary import path: the exact path, any registered
+	// key that is a module-root prefix of the binary, and always "".
+	binKeysForBinary := func(binary string) []string {
+		if binary == "" {
+			return []string{""}
+		}
+		keys := []string{binary, ""}
+		for key := range knownViolations {
+			if key == "" || key == binary {
+				continue
+			}
+			if matchesBinaryKey(key, binary) {
+				keys = append(keys, key)
+			}
+		}
+		return keys
+	}
+
 	// markKnown finds ALL known entries where the component can reach importer
 	// and (Importer, Imported) matches. Marks each matched entry and returns the
 	// full list so the caller can log reasons. A single violation can match
 	// multiple component keys.
 	markKnown := func(binary, importer, imported string) ([]KnownViolation, bool) {
 		var results []KnownViolation
-		binKeys := []string{binary, ""}
-		if binary == "" {
-			binKeys = []string{""}
-		}
-		for _, binKey := range binKeys {
+		for _, binKey := range binKeysForBinary(binary) {
 			for compKey, kvs := range knownViolations[binKey] {
 				if !componentCanReach(compKey, importer) {
 					continue
 				}
 				for i, kv := range kvs {
-					if importerMatches(kv, importer) && (kv.Imported == "" || kv.Imported == imported || strings.HasPrefix(imported, kv.Imported+"/")) {
+					if importerMatches(kv, importer) && importedMatches(kv, imported) {
 						matched[binKey][compKey][i] = true
 						results = append(results, kv)
 					}
@@ -521,29 +580,42 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		}
 	}
 
-	// Only check staleness for binaries found in this scan — avoids false
-	// stale errors when CheckModule is called per-binary in subtests.
-	scanned := make(map[string]bool, len(mains)+1)
-	for _, bin := range mains {
-		scanned[bin] = true
+	// binsForKey returns all scanned binaries whose import path matches a binary
+	// key (exact or module-root prefix). Returns mains for the "" wildcard.
+	binsForKey := func(key string) []string {
+		if key == "" {
+			return mains
+		}
+		var result []string
+		for _, bin := range mains {
+			if matchesBinaryKey(key, bin) {
+				result = append(result, bin)
+			}
+		}
+		return result
 	}
-	scanned[""] = true
 
 	for binKey, comps := range matched {
-		if !scanned[binKey] {
+		binsToCheck := binsForKey(binKey)
+		// Skip entries whose binary key matched no scanned binary — avoids false
+		// stale errors when CheckModule is called per-binary in subtests.
+		if binKey != "" && len(binsToCheck) == 0 {
 			continue
 		}
-		var binsToCheck []string
-		if binKey == "" {
-			binsToCheck = mains
-		} else {
-			binsToCheck = []string{binKey}
-		}
 		for compKey, hits := range comps {
-			// If the component is no longer reachable from any relevant binary,
-			// the dependency was removed entirely — skip all entries silently.
-			if compKey != "" && !isReachableFromAny(compKey, binsToCheck, reachableFrom) {
-				continue
+			if compKey != "" {
+				if len(binsToCheck) > 0 {
+					// Binary mode: component must be reachable from at least one matching binary.
+					if !isReachableFromAny(compKey, binsToCheck, reachableFrom) {
+						continue
+					}
+				} else {
+					// Library mode: no binary entry points. Check that the component
+					// still exists somewhere in the import graph.
+					if len(compPkgs[compKey]) == 0 {
+						continue
+					}
+				}
 			}
 			for i, hit := range hits {
 				if !hit {

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -39,7 +39,7 @@ type Violation struct {
 	Imported string // forbidden package being imported
 }
 
-// KnownViolation documents an accepted non-FIPS import for use in knownViolations maps.
+// KnownViolation documents an accepted import exception for use in knownViolations maps.
 //
 // Both Importer and Imported support three forms:
 //   - "" (empty): wildcard — matches anything in that position.
@@ -83,8 +83,7 @@ func moduleRoot(t testing.TB) string {
 	}
 }
 
-// goListPackages runs go list -json -deps -tags requirefips from the module root
-// and decodes the output. Shared by scanBinaries and Scan.
+// goListPackages runs go list -json -deps from the module root and decodes the output.
 func goListPackages(t testing.TB, patterns []string) []goListPackage {
 	t.Helper()
 	args := append([]string{"list", "-json", "-deps", "-tags", "requirefips"}, patterns...)
@@ -110,11 +109,10 @@ func goListPackages(t testing.TB, patterns []string) []goListPackage {
 	return pkgs
 }
 
-// scanBinaries is the internal implementation shared by ScanBinaries and
-// CheckModule. It runs a single go list pass over all patterns, attributes each
-// violation to its binary entry point via BFS, and returns the binaries found.
+// scanBinaries runs a single go list pass over all patterns, attributes each
+// violation to its binary entry point, and returns the binaries found.
 // When no binaries are present (library module) it falls back to flat violation
-// detection with no Binary set, so CheckModule works for both module types.
+// detection with no Binary set.
 func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
 	t.Helper()
 
@@ -161,8 +159,7 @@ func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbid
 	return violations, importGraph, mains
 }
 
-// bfsReachable returns the set of all packages reachable from from (inclusive)
-// via forward edges in importGraph.
+// bfsReachable returns the set of all packages reachable from from (inclusive).
 func bfsReachable(from string, importGraph map[string][]string) map[string]bool {
 	reachable := map[string]bool{from: true}
 	queue := []string{from}
@@ -196,9 +193,8 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 	return violations
 }
 
-// ScanBinaries runs a single `go list -json -deps -tags requirefips` pass over
-// all patterns, attributes each violation to its binary entry point
-// (Violation.Binary), and returns all violations and the merged import graph.
+// ScanBinaries scans all patterns, attributes each violation to its binary entry
+// point (Violation.Binary), and returns all violations and the merged import graph.
 // Binaries whose import path appears in skipBinaries are excluded from the scan.
 // Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
 func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string) ([]Violation, map[string][]string) {
@@ -210,9 +206,8 @@ func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbid
 	return violations, importGraph
 }
 
-// Scan runs `go list -json -deps -tags requirefips <pkg>` and returns all
-// violations and the full import graph. Calls t.Fatalf on subprocess or parse
-// errors.
+// Scan scans pkg and its full dependency tree and returns all violations and the
+// import graph. Calls t.Fatalf on subprocess or parse errors.
 func Scan(t testing.TB, pkg string, forbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
 	pkgs := goListPackages(t, []string{pkg})
@@ -315,7 +310,7 @@ func FormatChain(chain []string) string {
 //
 // A single violation can match multiple component keys simultaneously: if both
 // "fbreceiver" and "azureauthextension" can transitively reach the same
-// non-FIPS importer, listing the same (Importer, Imported) pair under both
+// forbidden importer, listing the same (Importer, Imported) pair under both
 // component keys causes both to be suppressed and neither to be flagged stale.
 // This is the intended way to document violations shared by multiple components.
 //
@@ -346,8 +341,8 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbidd
 	checkViolations(t, violations, importGraph, mains, knownViolations)
 }
 
-// checkViolations is the matching and stale-detection logic for CheckModule,
-// extracted to allow unit testing without a go list subprocess.
+// checkViolations matches violations against knownViolations and reports new
+// violations or stale entries via t.Errorf.
 func checkViolations(t testing.TB, violations []Violation, importGraph map[string][]string, mains []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
 
@@ -367,7 +362,7 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 	}
 
 	// Pre-compute which packages in importGraph match each component key
-	// (exact path or module-root prefix). Used by componentCanReach.
+	// (exact path or module-root prefix).
 	compPkgs := make(map[string][]string)
 	for _, comps := range knownViolations {
 		for compKey := range comps {
@@ -415,8 +410,7 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 
 	// importedMatches reports whether kv.Imported matches the actual imported package.
 	//   - kv.Imported == "": wildcard, matches any forbidden package.
-	//   - exact path or prefix: trailing slash is stripped before matching so
-	//     using an exported constant like XCrypto works correctly.
+	//   - exact path or prefix: trailing slash is stripped before matching.
 	importedMatches := func(kv KnownViolation, imported string) bool {
 		if kv.Imported == "" {
 			return true
@@ -449,9 +443,8 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 		return false
 	}
 
-	// binKeysForBinary returns all keys in knownViolations that should be
-	// consulted for a given binary import path: the exact path, any registered
-	// key that is a module-root prefix of the binary, and always "".
+	// binKeysForBinary returns all knownViolations keys applicable to a binary:
+	// the exact path, any module-root prefix key, and always "".
 	binKeysForBinary := func(binary string) []string {
 		if binary == "" {
 			return []string{""}
@@ -479,9 +472,9 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 				if !componentCanReach(compKey, importer) {
 					continue
 				}
-				// The component must also be reachable from the violation's binary.
-				// Without this check a component in a different binary can suppress
-				// violations here via the shared merged import graph.
+				// The component must also be reachable from the violation's own binary;
+				// a component reachable only from a different binary must not suppress
+				// violations here.
 				if binary != "" && compKey != "" && !isReachableFromAny(compKey, []string{binary}, reachableFrom) {
 					continue
 				}
@@ -519,8 +512,8 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 		}
 	}
 
-	// binsForKey returns all scanned binaries whose import path matches a binary
-	// key (exact or module-root prefix). Returns mains for the "" wildcard.
+	// binsForKey returns all scanned binaries matching a binary key
+	// (exact or module-root prefix; "" matches all).
 	binsForKey := func(key string) []string {
 		if key == "" {
 			return mains
@@ -536,8 +529,7 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 
 	for binKey, comps := range matched {
 		binsToCheck := binsForKey(binKey)
-		// Skip entries whose binary key matched no scanned binary — avoids false
-		// stale errors when CheckModule is called per-binary in subtests.
+		// Skip entries whose binary key matched no scanned binary.
 		if binKey != "" && len(binsToCheck) == 0 {
 			continue
 		}
@@ -572,8 +564,7 @@ func checkViolations(t testing.TB, violations []Violation, importGraph map[strin
 }
 
 // reachabilityCache lazily computes and caches the reachable-package set for
-// any starting package. Shared across multiple componentCanReach calls so each
-// BFS runs at most once per starting package.
+// any starting package so each BFS runs at most once.
 type reachabilityCache struct {
 	importGraph map[string][]string
 	cache       map[string]map[string]bool

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -90,7 +90,7 @@ func goListPackages(t testing.TB, patterns []string, tags []string) []goListPack
 	if len(tags) > 0 {
 		base = append(base, "-tags", strings.Join(tags, ","))
 	}
-	args := append(base, patterns...)
+	args := append(base[:len(base):len(base)], patterns...)
 	cmd := exec.CommandContext(t.Context(), "go", args...)
 	cmd.Dir = moduleRoot(t)
 	out, err := cmd.Output()
@@ -200,6 +200,7 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 // ScanBinaries scans all patterns, attributes each violation to its binary entry
 // point (Violation.Binary), and returns all violations and the merged import graph.
 // Binaries whose import path appears in skipBinaries are excluded from the scan.
+// tags is passed as -tags to go list; nil or empty means no tags.
 // Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
 func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
 	t.Helper()
@@ -211,7 +212,8 @@ func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, forbid
 }
 
 // Scan scans pkg and its full dependency tree and returns all violations and the
-// import graph. Calls t.Fatalf on subprocess or parse errors.
+// import graph. tags is passed as -tags to go list; nil or empty means no tags.
+// Calls t.Fatalf on subprocess or parse errors.
 func Scan(t testing.TB, pkg string, forbiddenPkgs []string, tags []string) ([]Violation, map[string][]string) {
 	t.Helper()
 	pkgs := goListPackages(t, []string{pkg}, tags)
@@ -339,6 +341,7 @@ func FormatChain(chain []string) string {
 // skipped (dependency removed or path broken).
 //
 // Binaries in skipBinaries are excluded from the scan and from stale detection.
+// tags is passed as -tags to go list; nil or empty means no tags.
 func CheckModule(t testing.TB, patterns []string, skipBinaries []string, forbiddenPkgs []string, tags []string, knownViolations map[string]map[string][]KnownViolation) {
 	t.Helper()
 	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, forbiddenPkgs, tags)

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -15,12 +15,10 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build requirefips
-
-// Package fipsscan provides helpers for auditing FIPS 140-3 compliance of Go
-// binaries by scanning their dependency trees for forbidden (non-FIPS) imports.
-// Only crypto/* stdlib packages are covered by Go's certified FIPS 140-3 module
-// (GOFIPS140=v1.0.0); other crypto implementations are potential violations.
+// Package fipsscan provides helpers for auditing import-policy compliance of Go
+// binaries by scanning their dependency trees for forbidden imports.
+// Callers supply the forbidden-package prefixes and known-violations allowlist;
+// the package itself is policy-agnostic and carries no build constraints.
 package fipsscan
 
 import (

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -86,6 +86,16 @@ type Violation struct {
 }
 
 // KnownViolation documents an accepted non-FIPS import for use in knownViolations maps.
+//
+// Importer is optional:
+//   - "" (empty): wildcard — matches any intermediate importer reachable from the
+//     component key that directly imports Imported. Use this when you only care
+//     which component owns the violation, not which intermediate package is the
+//     direct importer.
+//   - exact path: "github.com/foo/bar/baz" matches only that exact package.
+//   - module-root prefix: "github.com/foo/bar" matches any subpackage
+//     "github.com/foo/bar/baz" as the direct importer, collapsing many per-subpackage
+//     violations that share the same Imported into a single entry.
 type KnownViolation struct {
 	Importer string
 	Imported string
@@ -427,6 +437,41 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 		return false
 	}
 
+	// importerMatches reports whether kv.Importer matches the actual importer.
+	//   - kv.Importer == "": wildcard, matches any importer.
+	//   - exact path: must equal importer exactly.
+	//   - prefix: "github.com/foo/bar" matches "github.com/foo/bar/baz".
+	importerMatches := func(kv KnownViolation, importer string) bool {
+		if kv.Importer == "" {
+			return true
+		}
+		return kv.Importer == importer || strings.HasPrefix(importer, kv.Importer+"/")
+	}
+
+	// componentCanReachImporter is the stale-detection fast path: returns false
+	// when the component can provably no longer reach the importer (or any
+	// subpackage of it), signalling a silent skip instead of a stale error.
+	// When kv.Importer is empty the check is skipped (we can't narrow to a
+	// specific importer, so let the matched flag decide).
+	componentCanReachImporter := func(compKey string, kv KnownViolation) bool {
+		if compKey == "" || kv.Importer == "" {
+			return true
+		}
+		sub := kv.Importer + "/"
+		for _, pkg := range compPkgs[compKey] {
+			reachable := compReach.from(pkg)
+			if reachable[kv.Importer] {
+				return true
+			}
+			for rPkg := range reachable {
+				if strings.HasPrefix(rPkg, sub) {
+					return true
+				}
+			}
+		}
+		return false
+	}
+
 	// markKnown finds ALL known entries where the component can reach importer
 	// and (Importer, Imported) matches. Marks each matched entry and returns the
 	// full list so the caller can log reasons. A single violation can match
@@ -443,7 +488,7 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 					continue
 				}
 				for i, kv := range kvs {
-					if kv.Importer == importer && kv.Imported == imported {
+					if importerMatches(kv, importer) && kv.Imported == imported {
 						matched[binKey][compKey][i] = true
 						results = append(results, kv)
 					}
@@ -503,9 +548,9 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 			for i, hit := range hits {
 				if !hit {
 					kv := knownViolations[binKey][compKey][i]
-					// If the component can no longer reach the importer the import
-					// path was broken (package restructured or removed) — skip silently.
-					if !componentCanReach(compKey, kv.Importer) {
+					// If the component can no longer reach the importer (or any
+					// subpackage of it), the import path was broken — skip silently.
+					if !componentCanReachImporter(compKey, kv) {
 						continue
 					}
 					t.Errorf("stale knownViolations entry (no longer a violation — remove it): binary=%q component=%q importer=%q imported=%q", binKey, compKey, kv.Importer, kv.Imported)

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -24,6 +24,7 @@
 package fipsscan
 
 import (
+	"bytes"
 	"encoding/json"
 	"errors"
 	"os/exec"
@@ -31,8 +32,9 @@ import (
 	"testing"
 )
 
-// Non-FIPS crypto library prefixes. Pass any combination to Scan's
-// extraForbiddenPkgs, or use CommonForbiddenPkgs for the full set.
+// Non-FIPS crypto library prefixes. All are included in ForbiddenPkgs()
+// and checked by Scan automatically. Use individual constants only when
+// passing a subset via extraForbiddenPkgs.
 const (
 	// XCrypto covers golang.org/x/crypto, which is not part of Go's certified
 	// FIPS 140-3 module (GOFIPS140=v1.0.0).
@@ -78,14 +80,19 @@ const (
 
 // Violation is a forbidden import discovered in the dependency tree.
 type Violation struct {
-	Importer string // package that imports the forbidden package
+	Binary   string // binary entry point; empty for library modules
+	Importer string // package that directly imports the forbidden package
 	Imported string // forbidden package being imported
 }
 
-// CommonForbiddenPkgs is the set of well-known non-FIPS crypto libraries.
-// Scan uses this as its baseline; pass extraForbiddenPkgs only for
-// project-specific additions beyond this list.
-var CommonForbiddenPkgs = []string{
+// KnownViolation documents an accepted non-FIPS import for use in knownViolations maps.
+// Use a Go comment next to the entry to explain why it is acceptable.
+type KnownViolation struct {
+	Importer string
+	Imported string
+}
+
+var forbiddenPkgs = []string{
 	XCrypto,
 	JcmturnerAescts,
 	JcmturnerGofork,
@@ -98,16 +105,133 @@ var CommonForbiddenPkgs = []string{
 	FilippioIO,
 }
 
+// ForbiddenPkgs returns a fresh copy of the baseline non-FIPS crypto library
+// prefixes. Scan uses this automatically; pass extraForbiddenPkgs only for
+// project-specific additions beyond this list.
+func ForbiddenPkgs() []string {
+	cp := make([]string, len(forbiddenPkgs))
+	copy(cp, forbiddenPkgs)
+	return cp
+}
+
 type goListPackage struct {
 	ImportPath string
+	Name       string
 	Imports    []string
 }
 
+// scanBinaries is the internal implementation shared by ScanBinaries and
+// CheckModule. It runs a single go list pass, attributes each violation to its
+// binary entry point via BFS, and returns whether any binaries were found.
+// When no binaries are present (library module) it falls back to flat violation
+// detection with no BinaryPath set, so CheckModule works for both module types.
+func scanBinaries(t testing.TB, pattern string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, bool) {
+	t.Helper()
+
+	cmd := exec.CommandContext(t.Context(), "go", "list", "-json", "-deps", "-tags", "requirefips", pattern)
+	out, err := cmd.Output()
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			t.Fatalf("go list failed: %v\n%s", err, exitErr.Stderr)
+		}
+		t.Fatalf("go list failed: %v", err)
+	}
+
+	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
+
+	importGraph := make(map[string][]string)
+	var mains []string
+
+	dec := json.NewDecoder(bytes.NewReader(out))
+	for dec.More() {
+		var p goListPackage
+		if err := dec.Decode(&p); err != nil {
+			t.Fatalf("parsing go list output: %v", err)
+		}
+		if p.Name == "main" {
+			mains = append(mains, p.ImportPath)
+		}
+		importGraph[p.ImportPath] = p.Imports
+	}
+
+	if len(mains) == 0 {
+		return findViolations(importGraph, forbidden), importGraph, false
+	}
+
+	// Per-binary BFS attribution so each violation carries the entry point
+	// that pulls it in.
+	seen := make(map[string]bool)
+	var violations []Violation
+	for _, bin := range mains {
+		for pkg := range bfsReachable(bin, importGraph) {
+			if isForbidden(pkg, forbidden) {
+				continue
+			}
+			for _, imp := range importGraph[pkg] {
+				if isForbidden(imp, forbidden) {
+					if key := bin + "\x00" + pkg + "\x00" + imp; !seen[key] {
+						seen[key] = true
+						violations = append(violations, Violation{Binary: bin, Importer: pkg, Imported: imp})
+					}
+				}
+			}
+		}
+	}
+	return violations, importGraph, true
+}
+
+// bfsReachable returns the set of all packages reachable from from (inclusive)
+// via forward edges in importGraph.
+func bfsReachable(from string, importGraph map[string][]string) map[string]bool {
+	reachable := map[string]bool{from: true}
+	queue := []string{from}
+	for len(queue) > 0 {
+		pkg := queue[0]
+		queue = queue[1:]
+		for _, dep := range importGraph[pkg] {
+			if !reachable[dep] {
+				reachable[dep] = true
+				queue = append(queue, dep)
+			}
+		}
+	}
+	return reachable
+}
+
+// findViolations returns all (Importer, Imported) pairs in importGraph where
+// Importer is not itself forbidden but directly imports a forbidden package.
+func findViolations(importGraph map[string][]string, forbidden []string) []Violation {
+	var violations []Violation
+	for pkg, imports := range importGraph {
+		if isForbidden(pkg, forbidden) {
+			continue
+		}
+		for _, imp := range imports {
+			if isForbidden(imp, forbidden) {
+				violations = append(violations, Violation{Importer: pkg, Imported: imp})
+			}
+		}
+	}
+	return violations
+}
+
+// ScanBinaries runs `go list -json -deps -tags requirefips <pattern>` once,
+// attributes each violation to its binary entry point (Violation.BinaryPath),
+// and returns all violations and the merged import graph. Calls t.Fatalf if no
+// binaries are found or on subprocess/parse errors.
+func ScanBinaries(t testing.TB, pattern string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
+	t.Helper()
+	violations, importGraph, found := scanBinaries(t, pattern, extraForbiddenPkgs)
+	if !found {
+		t.Fatalf("ScanBinaries: no package main found matching %q", pattern)
+	}
+	return violations, importGraph
+}
+
 // Scan runs `go list -json -deps -tags requirefips <pkg>` and returns all
-// packages that directly import any prefix in CommonForbiddenPkgs or
-// extraForbiddenPkgs, along with the full import graph. Packages whose own
-// path matches a forbidden prefix are skipped (avoids flagging internal refs).
-// Calls t.Fatalf on subprocess or parse errors.
+// violations and the full import graph. Calls t.Fatalf on subprocess or parse
+// errors.
 func Scan(t testing.TB, pkg string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
 
@@ -121,38 +245,25 @@ func Scan(t testing.TB, pkg string, extraForbiddenPkgs []string) ([]Violation, m
 		t.Fatalf("go list failed: %v", err)
 	}
 
-	forbidden := append(append([]string(nil), CommonForbiddenPkgs...), extraForbiddenPkgs...)
-
+	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
 	importGraph := make(map[string][]string)
-	var violations []Violation
 
-	dec := json.NewDecoder(strings.NewReader(string(out)))
+	dec := json.NewDecoder(bytes.NewReader(out))
 	for dec.More() {
 		var p goListPackage
 		if err := dec.Decode(&p); err != nil {
 			t.Fatalf("parsing go list output: %v", err)
 		}
 		importGraph[p.ImportPath] = p.Imports
-
-		if isForbidden(p.ImportPath, forbidden) {
-			continue
-		}
-		for _, imp := range p.Imports {
-			if isForbidden(imp, forbidden) {
-				violations = append(violations, Violation{
-					Importer: p.ImportPath,
-					Imported: imp,
-				})
-			}
-		}
 	}
 
-	return violations, importGraph
+	return findViolations(importGraph, forbidden), importGraph
 }
 
 func isForbidden(pkg string, forbiddenPkgs []string) bool {
 	for _, prefix := range forbiddenPkgs {
-		if strings.HasPrefix(pkg, prefix) {
+		bare := strings.TrimRight(prefix, "/")
+		if pkg == bare || strings.HasPrefix(pkg, bare+"/") {
 			return true
 		}
 	}
@@ -216,44 +327,60 @@ func FormatChain(chain []string) string {
 	return strings.Join(parts, "\n")
 }
 
-// CheckViolations scans binaryPkg for golang.org/x/crypto imports and any
-// additional prefixes in extraForbiddenPkgs, attributes each violation to the
-// first-hop component from rootPkg, and reports unknown violations or stale
-// knownViolations entries via t.Errorf.
-func CheckViolations(t testing.TB, binaryPkg, rootPkg string, extraForbiddenPkgs []string, knownViolations map[string]string) {
+// CheckModule scans all packages and their transitive dependencies matching
+// pattern (typically "./...") and reports unknown violations or stale
+// knownViolations entries via t.Errorf. Works for both binary and library
+// modules. The map key is the binary entry point path; use "" for violations
+// that apply to all binaries or to library modules. Each entry lists the
+// (Importer, Imported) pairs that are accepted for that binary.
+func CheckModule(t testing.TB, pattern string, extraForbiddenPkgs []string, knownViolations map[string][]KnownViolation) {
 	t.Helper()
 
-	violations, importGraph := Scan(t, binaryPkg, extraForbiddenPkgs)
+	violations, importGraph, _ := scanBinaries(t, pattern, extraForbiddenPkgs)
 
-	found := make(map[string]bool)
+	// matched[binary][i] tracks whether knownViolations[binary][i] was hit.
+	matched := make(map[string][]bool)
+	for bin, kvs := range knownViolations {
+		matched[bin] = make([]bool, len(kvs))
+	}
+
+	findKnown := func(binary, importer, imported string) (KnownViolation, bool) {
+		for _, bin := range []string{binary, ""} {
+			for i, kv := range knownViolations[bin] {
+				if kv.Importer == importer && kv.Imported == imported {
+					matched[bin][i] = true
+					return kv, true
+				}
+			}
+		}
+		return KnownViolation{}, false
+	}
 
 	for _, v := range violations {
-		chain := ShortestChain(rootPkg, v.Importer, importGraph)
-		if chain == nil {
+		var chain []string
+		if v.Binary != "" {
+			chain = ShortestChain(v.Binary, v.Importer, importGraph)
+			if chain == nil {
+				chain = []string{v.Importer}
+			}
+		} else {
 			chain = []string{v.Importer}
 		}
-		displayChain := make([]string, len(chain)+1)
-		copy(displayChain, chain)
-		displayChain[len(chain)] = v.Imported
+		displayChain := append(chain, v.Imported)
 
-		var component string
-		if len(chain) > 1 {
-			component = chain[1]
+		if _, ok := findKnown(v.Binary, v.Importer, v.Imported); ok {
+			t.Logf("known violation (%s):\n%s", v.Imported, FormatChain(displayChain))
 		} else {
-			component = chain[0]
-		}
-
-		if reason, ok := knownViolations[component]; !ok {
-			t.Errorf("NEW violation via unknown component — add to knownViolations or remove the dependency:\n      -> %s", FormatChain(displayChain))
-		} else {
-			t.Logf("known violation [%s] via %s:\n      -> %s\n      reason: %s", v.Imported, component, FormatChain(displayChain), reason)
-			found[component] = true
+			t.Errorf("NEW violation — add to knownViolations or remove the dependency:\n%s", FormatChain(displayChain))
 		}
 	}
 
-	for component := range knownViolations {
-		if !found[component] {
-			t.Errorf("stale knownViolations entry (component no longer reaches a forbidden package — remove it): %s", component)
+	for bin, hits := range matched {
+		for i, hit := range hits {
+			if !hit {
+				kv := knownViolations[bin][i]
+				t.Errorf("stale knownViolations entry (no longer a violation — remove it): binary=%q importer=%q imported=%q", bin, kv.Importer, kv.Imported)
+			}
 		}
 	}
 }

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -86,10 +86,10 @@ type Violation struct {
 }
 
 // KnownViolation documents an accepted non-FIPS import for use in knownViolations maps.
-// Use a Go comment next to the entry to explain why it is acceptable.
 type KnownViolation struct {
 	Importer string
 	Imported string
+	Reason   string // why this violation is acceptable; shown in test output
 }
 
 var forbiddenPkgs = []string{
@@ -121,14 +121,15 @@ type goListPackage struct {
 }
 
 // scanBinaries is the internal implementation shared by ScanBinaries and
-// CheckModule. It runs a single go list pass, attributes each violation to its
-// binary entry point via BFS, and returns whether any binaries were found.
+// CheckModule. It runs a single go list pass over all patterns, attributes each
+// violation to its binary entry point via BFS, and returns the binaries found.
 // When no binaries are present (library module) it falls back to flat violation
-// detection with no BinaryPath set, so CheckModule works for both module types.
-func scanBinaries(t testing.TB, pattern string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, bool) {
+// detection with no Binary set, so CheckModule works for both module types.
+func scanBinaries(t testing.TB, patterns []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
 	t.Helper()
 
-	cmd := exec.CommandContext(t.Context(), "go", "list", "-json", "-deps", "-tags", "requirefips", pattern)
+	args := append([]string{"list", "-json", "-deps", "-tags", "requirefips"}, patterns...)
+	cmd := exec.CommandContext(t.Context(), "go", args...)
 	out, err := cmd.Output()
 	if err != nil {
 		var exitErr *exec.ExitError
@@ -156,7 +157,7 @@ func scanBinaries(t testing.TB, pattern string, extraForbiddenPkgs []string) ([]
 	}
 
 	if len(mains) == 0 {
-		return findViolations(importGraph, forbidden), importGraph, false
+		return findViolations(importGraph, forbidden), importGraph, nil
 	}
 
 	// Per-binary BFS attribution so each violation carries the entry point
@@ -178,7 +179,7 @@ func scanBinaries(t testing.TB, pattern string, extraForbiddenPkgs []string) ([]
 			}
 		}
 	}
-	return violations, importGraph, true
+	return violations, importGraph, mains
 }
 
 // bfsReachable returns the set of all packages reachable from from (inclusive)
@@ -216,15 +217,15 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 	return violations
 }
 
-// ScanBinaries runs `go list -json -deps -tags requirefips <pattern>` once,
-// attributes each violation to its binary entry point (Violation.BinaryPath),
-// and returns all violations and the merged import graph. Calls t.Fatalf if no
-// binaries are found or on subprocess/parse errors.
-func ScanBinaries(t testing.TB, pattern string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
+// ScanBinaries runs a single `go list -json -deps -tags requirefips` pass over
+// all patterns, attributes each violation to its binary entry point
+// (Violation.Binary), and returns all violations and the merged import graph.
+// Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
+func ScanBinaries(t testing.TB, patterns []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
-	violations, importGraph, found := scanBinaries(t, pattern, extraForbiddenPkgs)
-	if !found {
-		t.Fatalf("ScanBinaries: no package main found matching %q", pattern)
+	violations, importGraph, mains := scanBinaries(t, patterns, extraForbiddenPkgs)
+	if len(mains) == 0 {
+		t.Fatalf("ScanBinaries: no package main found matching %v", patterns)
 	}
 	return violations, importGraph
 }
@@ -328,15 +329,15 @@ func FormatChain(chain []string) string {
 }
 
 // CheckModule scans all packages and their transitive dependencies matching
-// pattern (typically "./...") and reports unknown violations or stale
-// knownViolations entries via t.Errorf. Works for both binary and library
-// modules. The map key is the binary entry point path; use "" for violations
-// that apply to all binaries or to library modules. Each entry lists the
-// (Importer, Imported) pairs that are accepted for that binary.
-func CheckModule(t testing.TB, pattern string, extraForbiddenPkgs []string, knownViolations map[string][]KnownViolation) {
+// patterns and reports unknown violations or stale knownViolations entries via
+// t.Errorf. Works for both binary and library modules. The map key is the
+// binary entry point path; use "" for violations that apply to all binaries or
+// to library modules. Stale detection only covers binaries found in this scan,
+// so per-binary subtest calls work correctly with per-binary map keys.
+func CheckModule(t testing.TB, patterns []string, extraForbiddenPkgs []string, knownViolations map[string][]KnownViolation) {
 	t.Helper()
 
-	violations, importGraph, _ := scanBinaries(t, pattern, extraForbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, extraForbiddenPkgs)
 
 	// matched[binary][i] tracks whether knownViolations[binary][i] was hit.
 	matched := make(map[string][]bool)
@@ -345,7 +346,11 @@ func CheckModule(t testing.TB, pattern string, extraForbiddenPkgs []string, know
 	}
 
 	findKnown := func(binary, importer, imported string) (KnownViolation, bool) {
-		for _, bin := range []string{binary, ""} {
+		bins := []string{binary, ""}
+		if binary == "" {
+			bins = []string{""}
+		}
+		for _, bin := range bins {
 			for i, kv := range knownViolations[bin] {
 				if kv.Importer == importer && kv.Imported == imported {
 					matched[bin][i] = true
@@ -366,16 +371,29 @@ func CheckModule(t testing.TB, pattern string, extraForbiddenPkgs []string, know
 		} else {
 			chain = []string{v.Importer}
 		}
-		displayChain := append(chain, v.Imported)
+		displayChain := make([]string, len(chain)+1)
+		copy(displayChain, chain)
+		displayChain[len(chain)] = v.Imported
 
-		if _, ok := findKnown(v.Binary, v.Importer, v.Imported); ok {
-			t.Logf("known violation (%s):\n%s", v.Imported, FormatChain(displayChain))
+		if kv, ok := findKnown(v.Binary, v.Importer, v.Imported); ok {
+			t.Logf("known violation (%s):\n%s\n      reason: %s", v.Imported, FormatChain(displayChain), kv.Reason)
 		} else {
 			t.Errorf("NEW violation — add to knownViolations or remove the dependency:\n%s", FormatChain(displayChain))
 		}
 	}
 
+	// Only check staleness for binaries found in this scan — avoids false
+	// stale errors when CheckModule is called per-binary in subtests.
+	scanned := make(map[string]bool, len(mains)+1)
+	for _, bin := range mains {
+		scanned[bin] = true
+	}
+	scanned[""] = true
+
 	for bin, hits := range matched {
+		if !scanned[bin] {
+			continue
+		}
 		for i, hit := range hits {
 			if !hit {
 				kv := knownViolations[bin][i]

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -87,15 +87,15 @@ type Violation struct {
 
 // KnownViolation documents an accepted non-FIPS import for use in knownViolations maps.
 //
-// Importer is optional:
-//   - "" (empty): wildcard — matches any intermediate importer reachable from the
-//     component key that directly imports Imported. Use this when you only care
-//     which component owns the violation, not which intermediate package is the
-//     direct importer.
-//   - exact path: "github.com/foo/bar/baz" matches only that exact package.
-//   - module-root prefix: "github.com/foo/bar" matches any subpackage
-//     "github.com/foo/bar/baz" as the direct importer, collapsing many per-subpackage
-//     violations that share the same Imported into a single entry.
+// Both Importer and Imported support three forms:
+//   - "" (empty): wildcard — matches anything in that position.
+//     Importer "" matches any intermediate package; Imported "" matches any forbidden package.
+//   - exact path: matches only that specific package.
+//   - module-root prefix: "github.com/foo/bar" matches "github.com/foo/bar" itself
+//     and any subpackage "github.com/foo/bar/baz".
+//
+// Use prefix or wildcard to collapse many per-subpackage entries into one. For example,
+// {Imported: "github.com/jcmturner/gokrb5/v8"} matches violations from any gokrb5 subpackage.
 type KnownViolation struct {
 	Importer string
 	Imported string
@@ -488,7 +488,7 @@ func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraFo
 					continue
 				}
 				for i, kv := range kvs {
-					if importerMatches(kv, importer) && kv.Imported == imported {
+					if importerMatches(kv, importer) && (kv.Imported == "" || kv.Imported == imported || strings.HasPrefix(imported, kv.Imported+"/")) {
 						matched[binKey][compKey][i] = true
 						results = append(results, kv)
 					}

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -31,15 +31,71 @@ import (
 	"testing"
 )
 
-// XCrypto is the import path prefix for golang.org/x/crypto, which is not
-// covered by Go's certified FIPS 140-3 module. Use as the forbiddenPkgs entry
-// for standard FIPS compliance checks.
-const XCrypto = "golang.org/x/crypto/"
+// Non-FIPS crypto library prefixes. Pass any combination to Scan's
+// extraForbiddenPkgs, or use CommonForbiddenPkgs for the full set.
+const (
+	// XCrypto covers golang.org/x/crypto, which is not part of Go's certified
+	// FIPS 140-3 module (GOFIPS140=v1.0.0).
+	XCrypto = "golang.org/x/crypto/"
+
+	// JcmturnerAescts covers github.com/jcmturner/aescts (AES-CBC-CTS, own
+	// AES block cipher implementation not using crypto/aes).
+	JcmturnerAescts = "github.com/jcmturner/aescts/"
+
+	// JcmturnerGofork covers github.com/jcmturner/gofork, a fork of stdlib
+	// encoding/asn1 and crypto packages with non-FIPS modifications.
+	JcmturnerGofork = "github.com/jcmturner/gofork/"
+
+	// JcmturnerGokrb5 covers github.com/jcmturner/gokrb5 (Kerberos 5); pulls
+	// in JcmturnerAescts and JcmturnerGofork.
+	JcmturnerGokrb5 = "github.com/jcmturner/gokrb5/"
+
+	// XdgGoPbkdf2 covers github.com/xdg-go/pbkdf2, a standalone PBKDF2
+	// implementation independent of Go's crypto/pbkdf2.
+	XdgGoPbkdf2 = "github.com/xdg-go/pbkdf2"
+
+	// ProtonMailGoCrypto covers github.com/ProtonMail/go-crypto (OpenPGP);
+	// implements its own OpenPGP cipher suite including non-FIPS algorithms.
+	ProtonMailGoCrypto = "github.com/ProtonMail/go-crypto/"
+
+	// CloudflareCircl covers github.com/cloudflare/circl; implements a wide
+	// variety of primitives (SIDH, FourQ, Ristretto255, etc.) outside FIPS scope.
+	CloudflareCircl = "github.com/cloudflare/circl/"
+
+	// AzureGoNtlmssp covers github.com/Azure/go-ntlmssp; implements NTLM/SSPI
+	// authentication which relies on MD4/MD5/DES — none FIPS-approved.
+	AzureGoNtlmssp = "github.com/Azure/go-ntlmssp"
+
+	// YoumarkPkcs8 covers github.com/youmark/pkcs8; handles PKCS#8 keys and
+	// may negotiate non-FIPS ciphers (RC2, 3DES, SM4) depending on the key file.
+	YoumarkPkcs8 = "github.com/youmark/pkcs8"
+
+	// FilippioIO covers filippo.io/ packages (edwards25519, age, mlkem768,
+	// etc.). None are part of a FIPS 140-3 certified module boundary, even
+	// when they implement a FIPS-standardized algorithm (e.g. FIPS 203 ML-KEM).
+	FilippioIO = "filippo.io/"
+)
 
 // Violation is a forbidden import discovered in the dependency tree.
 type Violation struct {
 	Importer string // package that imports the forbidden package
 	Imported string // forbidden package being imported
+}
+
+// CommonForbiddenPkgs is the set of well-known non-FIPS crypto libraries.
+// Scan uses this as its baseline; pass extraForbiddenPkgs only for
+// project-specific additions beyond this list.
+var CommonForbiddenPkgs = []string{
+	XCrypto,
+	JcmturnerAescts,
+	JcmturnerGofork,
+	JcmturnerGokrb5,
+	XdgGoPbkdf2,
+	ProtonMailGoCrypto,
+	CloudflareCircl,
+	AzureGoNtlmssp,
+	YoumarkPkcs8,
+	FilippioIO,
 }
 
 type goListPackage struct {
@@ -48,7 +104,7 @@ type goListPackage struct {
 }
 
 // Scan runs `go list -json -deps -tags requirefips <pkg>` and returns all
-// packages that directly import golang.org/x/crypto or any prefix in
+// packages that directly import any prefix in CommonForbiddenPkgs or
 // extraForbiddenPkgs, along with the full import graph. Packages whose own
 // path matches a forbidden prefix are skipped (avoids flagging internal refs).
 // Calls t.Fatalf on subprocess or parse errors.
@@ -65,7 +121,7 @@ func Scan(t testing.TB, pkg string, extraForbiddenPkgs []string) ([]Violation, m
 		t.Fatalf("go list failed: %v", err)
 	}
 
-	forbidden := append([]string{XCrypto}, extraForbiddenPkgs...)
+	forbidden := append(append([]string(nil), CommonForbiddenPkgs...), extraForbiddenPkgs...)
 
 	importGraph := make(map[string][]string)
 	var violations []Violation

--- a/testing/fipsscan/fipsscan.go
+++ b/testing/fipsscan/fipsscan.go
@@ -125,7 +125,7 @@ type goListPackage struct {
 // violation to its binary entry point via BFS, and returns the binaries found.
 // When no binaries are present (library module) it falls back to flat violation
 // detection with no Binary set, so CheckModule works for both module types.
-func scanBinaries(t testing.TB, patterns []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
+func scanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string, []string) {
 	t.Helper()
 
 	args := append([]string{"list", "-json", "-deps", "-tags", "requirefips"}, patterns...)
@@ -141,6 +141,11 @@ func scanBinaries(t testing.TB, patterns []string, extraForbiddenPkgs []string) 
 
 	forbidden := append(ForbiddenPkgs(), extraForbiddenPkgs...)
 
+	skip := make(map[string]bool, len(skipBinaries))
+	for _, s := range skipBinaries {
+		skip[s] = true
+	}
+
 	importGraph := make(map[string][]string)
 	var mains []string
 
@@ -150,7 +155,7 @@ func scanBinaries(t testing.TB, patterns []string, extraForbiddenPkgs []string) 
 		if err := dec.Decode(&p); err != nil {
 			t.Fatalf("parsing go list output: %v", err)
 		}
-		if p.Name == "main" {
+		if p.Name == "main" && !skip[p.ImportPath] {
 			mains = append(mains, p.ImportPath)
 		}
 		importGraph[p.ImportPath] = p.Imports
@@ -220,10 +225,11 @@ func findViolations(importGraph map[string][]string, forbidden []string) []Viola
 // ScanBinaries runs a single `go list -json -deps -tags requirefips` pass over
 // all patterns, attributes each violation to its binary entry point
 // (Violation.Binary), and returns all violations and the merged import graph.
+// Binaries whose import path appears in skipBinaries are excluded from the scan.
 // Calls t.Fatalf if no binaries are found or on subprocess/parse errors.
-func ScanBinaries(t testing.TB, patterns []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
+func ScanBinaries(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string) ([]Violation, map[string][]string) {
 	t.Helper()
-	violations, importGraph, mains := scanBinaries(t, patterns, extraForbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
 	if len(mains) == 0 {
 		t.Fatalf("ScanBinaries: no package main found matching %v", patterns)
 	}
@@ -332,12 +338,13 @@ func FormatChain(chain []string) string {
 // patterns and reports unknown violations or stale knownViolations entries via
 // t.Errorf. Works for both binary and library modules. The map key is the
 // binary entry point path; use "" for violations that apply to all binaries or
-// to library modules. Stale detection only covers binaries found in this scan,
+// to library modules. Binaries in skipBinaries are excluded from the scan and
+// from stale detection. Stale detection only covers binaries found in this scan,
 // so per-binary subtest calls work correctly with per-binary map keys.
-func CheckModule(t testing.TB, patterns []string, extraForbiddenPkgs []string, knownViolations map[string][]KnownViolation) {
+func CheckModule(t testing.TB, patterns []string, skipBinaries []string, extraForbiddenPkgs []string, knownViolations map[string][]KnownViolation) {
 	t.Helper()
 
-	violations, importGraph, mains := scanBinaries(t, patterns, extraForbiddenPkgs)
+	violations, importGraph, mains := scanBinaries(t, patterns, skipBinaries, extraForbiddenPkgs)
 
 	// matched[binary][i] tracks whether knownViolations[binary][i] was hit.
 	matched := make(map[string][]bool)

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -15,8 +15,6 @@
 // specific language governing permissions and limitations
 // under the License.
 
-//go:build requirefips
-
 package fipsscan
 
 import (

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -20,9 +20,72 @@
 package fipsscan
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"testing"
 )
+
+func TestModuleRoot(t *testing.T) {
+	root := moduleRoot(t)
+	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
+		t.Fatalf("moduleRoot returned %q but no go.mod found there: %v", root, err)
+	}
+}
+
+func TestMatchesBinaryKey(t *testing.T) {
+	tests := []struct {
+		key    string
+		binary string
+		want   bool
+	}{
+		// wildcard
+		{"", "github.com/foo/cmd/agent", true},
+		// exact match
+		{"github.com/foo/cmd/agent", "github.com/foo/cmd/agent", true},
+		// module-root prefix
+		{"github.com/foo", "github.com/foo/cmd/agent", true},
+		// prefix with trailing slash in key (normalised)
+		{"github.com/foo/", "github.com/foo/cmd/agent", true},
+		// no false prefix: foobar must not match foo
+		{"github.com/foo", "github.com/foobar/cmd/agent", false},
+		// key longer than binary
+		{"github.com/foo/cmd/agent/extra", "github.com/foo/cmd/agent", false},
+	}
+	for _, tc := range tests {
+		got := matchesBinaryKey(tc.key, tc.binary)
+		if got != tc.want {
+			t.Errorf("matchesBinaryKey(%q, %q) = %v, want %v", tc.key, tc.binary, got, tc.want)
+		}
+	}
+}
+
+func TestIsForbidden(t *testing.T) {
+	tests := []struct {
+		pkg      string
+		prefixes []string
+		want     bool
+	}{
+		// exact match without trailing slash
+		{"golang.org/x/crypto", []string{"golang.org/x/crypto/"}, true},
+		// sub-package matched by prefix with trailing slash
+		{"golang.org/x/crypto/md4", []string{"golang.org/x/crypto/"}, true},
+		// sub-package matched by prefix without trailing slash
+		{"golang.org/x/crypto/md4", []string{"golang.org/x/crypto"}, true},
+		// no false prefix: cryptography must not match crypto
+		{"golang.org/x/cryptography", []string{"golang.org/x/crypto/"}, false},
+		// filippo.io prefix
+		{"filippo.io/edwards25519", []string{"filippo.io/"}, true},
+		// not matched
+		{"github.com/safe/pkg", []string{"golang.org/x/crypto/"}, false},
+	}
+	for _, tc := range tests {
+		got := isForbidden(tc.pkg, tc.prefixes)
+		if got != tc.want {
+			t.Errorf("isForbidden(%q, %v) = %v, want %v", tc.pkg, tc.prefixes, got, tc.want)
+		}
+	}
+}
 
 func TestShortestChain(t *testing.T) {
 	graph := map[string][]string{

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -152,10 +152,9 @@ func TestShortestChain(t *testing.T) {
 	}
 }
 
-// TestCheckViolationsCrossBinaryAttribution is a regression test for the bug
-// where a component reachable only from binary B could suppress a violation
-// attributed to binary A, because markKnown checked component->importer
-// reachability but not binary->component reachability.
+// TestCheckViolationsCrossBinaryAttribution verifies that a component reachable
+// only from binary B does not suppress a violation attributed to binary A,
+// even when the component can reach the same importer.
 func TestCheckViolationsCrossBinaryAttribution(t *testing.T) {
 	// Import graph:
 	//   cmd/binary-a  ->  importer  ->  golang.org/x/crypto/sha256

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -195,6 +195,23 @@ func TestCheckViolationsCrossBinaryAttribution(t *testing.T) {
 	}
 }
 
+// TestScanBinariesAllSkipped verifies that when every discovered binary is in
+// skipBinaries, scanBinaries returns no violations and signals binary mode so
+// callers do not fall through to a library-mode flat scan.
+func TestScanBinariesAllSkipped(t *testing.T) {
+	const certutilCmd = "github.com/elastic/elastic-agent-libs/testing/certutil/cmd"
+	violations, _, mains, binaryModule := scanBinaries(t, []string{"./testing/certutil/cmd"}, []string{certutilCmd}, []string{"forbiddenX/"}, nil)
+	if !binaryModule {
+		t.Fatal("expected binaryModule=true (a package main exists), got false")
+	}
+	if len(mains) != 0 {
+		t.Fatalf("expected empty mains after skipping the only binary, got %v", mains)
+	}
+	if len(violations) != 0 {
+		t.Fatalf("expected no violations when all binaries are skipped, got %v", violations)
+	}
+}
+
 // captureT wraps *testing.T and redirects Errorf so tests can inspect failures.
 type captureT struct {
 	*testing.T

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -20,9 +20,11 @@
 package fipsscan
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -151,6 +153,59 @@ func TestShortestChain(t *testing.T) {
 		})
 	}
 }
+
+// TestCheckViolationsCrossBinaryAttribution is a regression test for the bug
+// where a component reachable only from binary B could suppress a violation
+// attributed to binary A, because markKnown checked component->importer
+// reachability but not binary->component reachability.
+func TestCheckViolationsCrossBinaryAttribution(t *testing.T) {
+	// Import graph:
+	//   cmd/binary-a  ->  importer  ->  golang.org/x/crypto/sha256
+	//   cmd/binary-b  ->  comp-b    ->  importer  ->  golang.org/x/crypto/sha256
+	//
+	// comp-b can reach importer, but comp-b is only reachable from cmd/binary-b.
+	// A violation attributed to cmd/binary-a must NOT be suppressed by the
+	// comp-b entry registered under the "" wildcard binary key.
+	importGraph := map[string][]string{
+		"cmd/binary-a":               {"importer"},
+		"cmd/binary-b":               {"comp-b"},
+		"comp-b":                     {"importer"},
+		"importer":                   {"golang.org/x/crypto/sha256"},
+		"golang.org/x/crypto/sha256": {},
+	}
+	mains := []string{"cmd/binary-a", "cmd/binary-b"}
+	violations := []Violation{
+		{Binary: "cmd/binary-a", Importer: "importer", Imported: "golang.org/x/crypto/sha256"},
+		{Binary: "cmd/binary-b", Importer: "importer", Imported: "golang.org/x/crypto/sha256"},
+	}
+	// comp-b is documented under the wildcard binary key "".
+	// It can reach importer, but must NOT suppress binary-a's violation.
+	knownViolations := map[string]map[string][]KnownViolation{
+		"": {
+			"comp-b": {{Reason: "ok for binary-b"}},
+		},
+	}
+
+	var errors []string
+	tb := &captureT{T: t, errorf: func(f string, a ...any) {
+		errors = append(errors, fmt.Sprintf(f, a...))
+	}}
+	checkViolations(tb, violations, importGraph, mains, knownViolations)
+
+	// binary-a's violation must be reported as NEW (comp-b is not reachable from it).
+	if len(errors) != 1 || !strings.Contains(errors[0], "NEW violation") {
+		t.Errorf("expected exactly one NEW violation for cmd/binary-a, got %v", errors)
+	}
+}
+
+// captureT wraps *testing.T and redirects Errorf so tests can inspect failures.
+type captureT struct {
+	*testing.T
+	errorf func(string, ...any)
+}
+
+func (c *captureT) Errorf(format string, args ...any) { c.errorf(format, args...) }
+func (c *captureT) Helper()                           { c.T.Helper() }
 
 func TestFormatChain(t *testing.T) {
 	tests := []struct {

--- a/testing/fipsscan/fipsscan_test.go
+++ b/testing/fipsscan/fipsscan_test.go
@@ -19,79 +19,202 @@ package fipsscan
 
 import (
 	"fmt"
-	"os"
-	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
 )
 
-func TestModuleRoot(t *testing.T) {
-	root := moduleRoot(t)
-	if _, err := os.Stat(filepath.Join(root, "go.mod")); err != nil {
-		t.Fatalf("moduleRoot returned %q but no go.mod found there: %v", root, err)
-	}
-}
+// -----------------------------------------------------------------------------
+// Section 1: pathMatches
+// -----------------------------------------------------------------------------
 
-func TestMatchesBinaryKey(t *testing.T) {
+// TestPathMatches covers the shared prefix-matching rule used for binary keys,
+// component keys and KnownViolation.Imported.
+//
+// Rules:
+//   - "" is a wildcard and matches anything.
+//   - a trailing slash in the pattern is stripped before matching.
+//   - a match is either exact or on a "/" boundary, so "foo" never matches "foobar".
+func TestPathMatches(t *testing.T) {
 	tests := []struct {
-		key    string
-		binary string
-		want   bool
+		pattern string
+		path    string
+		want    bool
 	}{
-		// wildcard
+		// wildcard matches anything
 		{"", "github.com/foo/cmd/agent", true},
 		// exact match
 		{"github.com/foo/cmd/agent", "github.com/foo/cmd/agent", true},
-		// module-root prefix
+		// sub-package match, pattern without trailing slash
 		{"github.com/foo", "github.com/foo/cmd/agent", true},
-		// prefix with trailing slash in key (normalised)
+		// sub-package match, pattern with trailing slash (normalised away)
 		{"github.com/foo/", "github.com/foo/cmd/agent", true},
-		// no false prefix: foobar must not match foo
-		{"github.com/foo", "github.com/foobar/cmd/agent", false},
-		// key longer than binary
+		// no false prefix: "foo" is not a prefix of "foobar" on a path boundary
+		{"github.com/foo", "github.com/foobar", false},
+		{"github.com/foo", "github.com/foobar/pkg", false},
+		// pattern longer than the path
 		{"github.com/foo/cmd/agent/extra", "github.com/foo/cmd/agent", false},
+		// module root without a github.com host
+		{"filippo.io", "filippo.io/edwards25519", true},
+		// empty path with empty pattern
+		{"", "", true},
 	}
+
 	for _, tc := range tests {
-		got := matchesBinaryKey(tc.key, tc.binary)
+		got := pathMatches(tc.pattern, tc.path)
 		if got != tc.want {
-			t.Errorf("matchesBinaryKey(%q, %q) = %v, want %v", tc.key, tc.binary, got, tc.want)
+			t.Errorf("pathMatches(%q, %q) = %v, want %v", tc.pattern, tc.path, got, tc.want)
 		}
 	}
 }
 
-func TestIsForbidden(t *testing.T) {
-	tests := []struct {
-		pkg      string
-		prefixes []string
-		want     bool
-	}{
-		// exact match without trailing slash
-		{"golang.org/x/crypto", []string{"golang.org/x/crypto/"}, true},
-		// sub-package matched by prefix with trailing slash
-		{"golang.org/x/crypto/md4", []string{"golang.org/x/crypto/"}, true},
-		// sub-package matched by prefix without trailing slash
-		{"golang.org/x/crypto/md4", []string{"golang.org/x/crypto"}, true},
-		// no false prefix: cryptography must not match crypto
-		{"golang.org/x/cryptography", []string{"golang.org/x/crypto/"}, false},
-		// filippo.io prefix
-		{"filippo.io/edwards25519", []string{"filippo.io/"}, true},
-		// not matched
-		{"github.com/safe/pkg", []string{"golang.org/x/crypto/"}, false},
+// -----------------------------------------------------------------------------
+// Section 2: bfsReachable
+// -----------------------------------------------------------------------------
+
+// TestBfsReachable_Linear checks a simple chain.
+//
+//	a ─→ b ─→ c ─→ d
+//
+// Expected: everything downstream of a, plus a itself.
+func TestBfsReachable_Linear(t *testing.T) {
+	graph := map[string][]string{
+		"a": {"b"},
+		"b": {"c"},
+		"c": {"d"},
+		"d": {},
 	}
-	for _, tc := range tests {
-		got := isForbidden(tc.pkg, tc.prefixes)
-		if got != tc.want {
-			t.Errorf("isForbidden(%q, %v) = %v, want %v", tc.pkg, tc.prefixes, got, tc.want)
-		}
+
+	got := bfsReachable("a", graph)
+	want := map[string]bool{"a": true, "b": true, "c": true, "d": true}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bfsReachable(a) = %v, want %v", got, want)
 	}
 }
 
+// TestBfsReachable_Diamond checks that a node reachable through two different
+// parents appears exactly once and does not confuse the traversal.
+//
+//	root ─→ a ─┐
+//	  └──→ b ─┴─→ shared
+//
+// Expected: root, a, b, shared.
+func TestBfsReachable_Diamond(t *testing.T) {
+	graph := map[string][]string{
+		"root":   {"a", "b"},
+		"a":      {"shared"},
+		"b":      {"shared"},
+		"shared": {},
+	}
+
+	got := bfsReachable("root", graph)
+	want := map[string]bool{"root": true, "a": true, "b": true, "shared": true}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bfsReachable(root) = %v, want %v", got, want)
+	}
+}
+
+// TestBfsReachable_Cycle checks that a cycle terminates instead of looping.
+//
+//	a ─→ b ─→ c ─┐
+//	↑            │
+//	└────────────┘
+//
+// Expected: a, b, c — and the call returns.
+func TestBfsReachable_Cycle(t *testing.T) {
+	graph := map[string][]string{
+		"a": {"b"},
+		"b": {"c"},
+		"c": {"a"},
+	}
+
+	got := bfsReachable("a", graph)
+	want := map[string]bool{"a": true, "b": true, "c": true}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bfsReachable(a) = %v, want %v", got, want)
+	}
+}
+
+// TestBfsReachable_Disconnected checks that unrelated components are excluded.
+//
+//	a ─→ b        x ─→ y   (separate component)
+//
+// Expected: only a and b.
+func TestBfsReachable_Disconnected(t *testing.T) {
+	graph := map[string][]string{
+		"a": {"b"},
+		"b": {},
+		"x": {"y"},
+		"y": {},
+	}
+
+	got := bfsReachable("a", graph)
+	want := map[string]bool{"a": true, "b": true}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bfsReachable(a) = %v, want %v", got, want)
+	}
+}
+
+// TestBfsReachable_RootNotInGraph checks the behaviour for an unknown root.
+//
+//	a ─→ b        (root "zz" is absent)
+//
+// Expected: empty set. An unknown package has no known dependencies, so it must
+// not be reported as reachable from itself either — otherwise a typo in a
+// component key would silently look like a real package.
+func TestBfsReachable_RootNotInGraph(t *testing.T) {
+	graph := map[string][]string{
+		"a": {"b"},
+		"b": {},
+	}
+
+	got := bfsReachable("zz", graph)
+
+	if len(got) != 0 {
+		t.Errorf("bfsReachable(zz) = %v, want empty set", got)
+	}
+}
+
+// TestBfsReachable_LeafNode checks a package that exists but imports nothing.
+//
+//	a ─→ b        (start from b)
+//
+// Expected: just b.
+func TestBfsReachable_LeafNode(t *testing.T) {
+	graph := map[string][]string{
+		"a": {"b"},
+		"b": {},
+	}
+
+	got := bfsReachable("b", graph)
+	want := map[string]bool{"b": true}
+
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("bfsReachable(b) = %v, want %v", got, want)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Section 3: ShortestChain and FormatChain
+// -----------------------------------------------------------------------------
+
+// TestShortestChain checks that the reported chain is always the shortest one.
+//
+//	root ─→ a ─→ c ─→ target
+//	 │      └──→ d ─→ e
+//	 └───→ b ─→ target
+//	          └─→ e
+//
+// Expected: the two-hop route wins over the three-hop route.
 func TestShortestChain(t *testing.T) {
 	graph := map[string][]string{
 		"root":   {"a", "b"},
 		"a":      {"c", "d"},
-		"b":      {"d", "e"},
+		"b":      {"target", "e"},
 		"c":      {"target"},
 		"d":      {"e"},
 		"e":      {},
@@ -105,7 +228,7 @@ func TestShortestChain(t *testing.T) {
 		want []string
 	}{
 		{
-			name: "direct child",
+			name: "direct neighbour",
 			from: "root",
 			to:   "a",
 			want: []string{"root", "a"},
@@ -120,7 +243,7 @@ func TestShortestChain(t *testing.T) {
 			name: "shortest of two paths",
 			from: "root",
 			to:   "target",
-			want: []string{"root", "a", "c", "target"},
+			want: []string{"root", "b", "target"},
 		},
 		{
 			name: "same node",
@@ -135,7 +258,7 @@ func TestShortestChain(t *testing.T) {
 			want: nil,
 		},
 		{
-			name: "leaf with no edges",
+			name: "leaf reachable two ways picks the shorter",
 			from: "root",
 			to:   "e",
 			want: []string{"root", "b", "e"},
@@ -152,75 +275,7 @@ func TestShortestChain(t *testing.T) {
 	}
 }
 
-// TestCheckViolationsCrossBinaryAttribution verifies that a component reachable
-// only from binary B does not suppress a violation attributed to binary A,
-// even when the component can reach the same importer.
-func TestCheckViolationsCrossBinaryAttribution(t *testing.T) {
-	// Import graph:
-	//   cmd/binary-a  ->  importer  ->  golang.org/x/crypto/sha256
-	//   cmd/binary-b  ->  comp-b    ->  importer  ->  golang.org/x/crypto/sha256
-	//
-	// comp-b can reach importer, but comp-b is only reachable from cmd/binary-b.
-	// A violation attributed to cmd/binary-a must NOT be suppressed by the
-	// comp-b entry registered under the "" wildcard binary key.
-	importGraph := map[string][]string{
-		"cmd/binary-a":               {"importer"},
-		"cmd/binary-b":               {"comp-b"},
-		"comp-b":                     {"importer"},
-		"importer":                   {"golang.org/x/crypto/sha256"},
-		"golang.org/x/crypto/sha256": {},
-	}
-	mains := []string{"cmd/binary-a", "cmd/binary-b"}
-	violations := []Violation{
-		{Binary: "cmd/binary-a", Importer: "importer", Imported: "golang.org/x/crypto/sha256"},
-		{Binary: "cmd/binary-b", Importer: "importer", Imported: "golang.org/x/crypto/sha256"},
-	}
-	// comp-b is documented under the wildcard binary key "".
-	// It can reach importer, but must NOT suppress binary-a's violation.
-	knownViolations := map[string]map[string][]KnownViolation{
-		"": {
-			"comp-b": {{Reason: "ok for binary-b"}},
-		},
-	}
-
-	var errors []string
-	tb := &captureT{T: t, errorf: func(f string, a ...any) {
-		errors = append(errors, fmt.Sprintf(f, a...))
-	}}
-	checkViolations(tb, violations, importGraph, mains, knownViolations)
-
-	// binary-a's violation must be reported as NEW (comp-b is not reachable from it).
-	if len(errors) != 1 || !strings.Contains(errors[0], "NEW violation") {
-		t.Errorf("expected exactly one NEW violation for cmd/binary-a, got %v", errors)
-	}
-}
-
-// TestScanBinariesAllSkipped verifies that when every discovered binary is in
-// skipBinaries, scanBinaries returns no violations and signals binary mode so
-// callers do not fall through to a library-mode flat scan.
-func TestScanBinariesAllSkipped(t *testing.T) {
-	const certutilCmd = "github.com/elastic/elastic-agent-libs/testing/certutil/cmd"
-	violations, _, mains, binaryModule := scanBinaries(t, []string{"./testing/certutil/cmd"}, []string{certutilCmd}, []string{"forbiddenX/"}, nil)
-	if !binaryModule {
-		t.Fatal("expected binaryModule=true (a package main exists), got false")
-	}
-	if len(mains) != 0 {
-		t.Fatalf("expected empty mains after skipping the only binary, got %v", mains)
-	}
-	if len(violations) != 0 {
-		t.Fatalf("expected no violations when all binaries are skipped, got %v", violations)
-	}
-}
-
-// captureT wraps *testing.T and redirects Errorf so tests can inspect failures.
-type captureT struct {
-	*testing.T
-	errorf func(string, ...any)
-}
-
-func (c *captureT) Errorf(format string, args ...any) { c.errorf(format, args...) }
-func (c *captureT) Helper()                           { c.T.Helper() }
-
+// TestFormatChain checks the indented rendering used in failure output.
 func TestFormatChain(t *testing.T) {
 	tests := []struct {
 		name  string
@@ -233,17 +288,17 @@ func TestFormatChain(t *testing.T) {
 			want:  "",
 		},
 		{
-			name:  "single",
+			name:  "single element",
 			chain: []string{"pkg/a"},
 			want:  "pkg/a",
 		},
 		{
-			name:  "two",
+			name:  "two elements",
 			chain: []string{"pkg/a", "pkg/b"},
 			want:  "pkg/a\n      -> pkg/b",
 		},
 		{
-			name:  "three",
+			name:  "three elements",
 			chain: []string{"pkg/a", "pkg/b", "pkg/c"},
 			want:  "pkg/a\n      -> pkg/b\n      -> pkg/c",
 		},
@@ -256,5 +311,1074 @@ func TestFormatChain(t *testing.T) {
 				t.Errorf("FormatChain(%v) =\n%q\nwant:\n%q", tc.chain, got, tc.want)
 			}
 		})
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Section 4: violation matching
+// -----------------------------------------------------------------------------
+
+// TestCheckViolations_NewViolation_NoEntry — a violation with no allowlist entry
+// at all.
+//
+//	binary ─→ forbidden
+//
+// Expected: 1 NEW error.
+func TestCheckViolations_NewViolation_NoEntry(t *testing.T) {
+	const (
+		binary    = "github.com/foo/cmd/agent"
+		forbidden = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:    {forbidden},
+		forbidden: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbidden}}
+	known := map[string]map[string][]KnownViolation{}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Errorf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+}
+
+// TestCheckViolations_KnownAndMatched_FlatBinary — component key "" covers any
+// path from the binary to the forbidden package.
+//
+//	binary ─→ forbidden
+//
+// Expected: 0 errors.
+func TestCheckViolations_KnownAndMatched_FlatBinary(t *testing.T) {
+	const (
+		binary    = "github.com/foo/cmd/agent"
+		forbidden = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:    {forbidden},
+		forbidden: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbidden}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {{Imported: forbidden, Reason: "accepted for now"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestCheckViolations_KnownAndMatched_ComponentOnPath — the component key is
+// enforced and the component really sits on the path.
+//
+//	binary ─→ vendor/comp/pkg ─→ forbidden
+//
+// Component key "github.com/vendor/comp" matches "github.com/vendor/comp/pkg".
+//
+// Expected: 0 errors.
+func TestCheckViolations_KnownAndMatched_ComponentOnPath(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		componentKey  = "github.com/vendor/comp"
+		componentPkg  = "github.com/vendor/comp/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {componentPkg},
+		componentPkg:  {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			componentKey: {{Imported: forbiddenPath, Reason: "comp needs md4"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestCheckViolations_ComponentExistsButNotOnPath — the component is reachable
+// from the binary but never reaches the forbidden package. The forbidden package
+// arrives through a different edge.
+//
+//	binary ─→ vendor/comp/pkg      (dead end for forbidden)
+//	binary ─→ forbidden            (direct, bypasses the component)
+//
+// Expected: 1 NEW error — the entry only covers violations that go through the
+// component.
+func TestCheckViolations_ComponentExistsButNotOnPath(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		componentKey  = "github.com/vendor/comp"
+		componentPkg  = "github.com/vendor/comp/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {componentPkg, forbiddenPath},
+		componentPkg:  {},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			componentKey: {{Imported: forbiddenPath, Reason: "comp needs md4"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Errorf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+}
+
+// TestCheckViolations_ConjunctionBug_TwoDifferentPackages — the component check
+// must be satisfied by ONE package, not by two packages each covering half of it.
+//
+//	cmd/binary-a ─→ vendor/comp/pkg-1   (reachable from a, but never reaches forbidden)
+//	cmd/binary-a ─→ forbidden           (direct, this is the violation)
+//	cmd/binary-b ─→ vendor/comp/pkg-2 ─→ forbidden   (reaches forbidden, but not from a)
+//
+// Component key "github.com/vendor/comp" matches pkg-1 and pkg-2:
+//
+//	pkg-1: reachable from binary-a yes, reaches forbidden no
+//	pkg-2: reachable from binary-a no,  reaches forbidden yes
+//
+// Expected: 1 NEW error — no single package satisfies both halves.
+func TestCheckViolations_ConjunctionBug_TwoDifferentPackages(t *testing.T) {
+	const (
+		binaryA       = "github.com/foo/cmd/binary-a"
+		binaryB       = "github.com/foo/cmd/binary-b"
+		componentKey  = "github.com/vendor/comp"
+		componentPkg1 = "github.com/vendor/comp/pkg-1"
+		componentPkg2 = "github.com/vendor/comp/pkg-2"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binaryA:       {componentPkg1, forbiddenPath},
+		binaryB:       {componentPkg2},
+		componentPkg1: {},
+		componentPkg2: {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binaryA, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binaryA: {
+			componentKey: {{Imported: forbiddenPath, Reason: "only valid through comp"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binaryA, binaryB}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Errorf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+}
+
+// TestCheckViolations_ComponentSubPackageMatches — the component key is a module
+// root, the package on the path is a sub-package of it.
+//
+//	binary ─→ gokrb5/v8/crypto/aescts ─→ forbidden
+//
+// Expected: 0 errors.
+func TestCheckViolations_ComponentSubPackageMatches(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		componentKey  = "github.com/elastic/gokrb5/v8"
+		componentPkg  = "github.com/elastic/gokrb5/v8/crypto/aescts"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {componentPkg},
+		componentPkg:  {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			componentKey: {{Imported: forbiddenPath, Reason: "kerberos crypto"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestCheckViolations_BinaryKeyPrefixMatch — the binary key is a module-root
+// prefix of the real binary import path.
+//
+//	binary key: github.com/elastic/beats/v7/x-pack
+//	binary:     github.com/elastic/beats/v7/x-pack/filebeat ─→ forbidden
+//
+// Expected: 0 errors — the key covers the binary.
+func TestCheckViolations_BinaryKeyPrefixMatch(t *testing.T) {
+	const (
+		binaryKey     = "github.com/elastic/beats/v7/x-pack"
+		binary        = "github.com/elastic/beats/v7/x-pack/filebeat"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binaryKey: {
+			"": {{Imported: forbiddenPath, Reason: "x-pack wide exception"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestCheckViolations_BinaryKeyNoPrefixFalsePositive — a binary key must only
+// match on a "/" boundary.
+//
+//	binary key: github.com/elastic/beats
+//	binary:     github.com/elastic/beatsagent ─→ forbidden
+//
+// Expected: 1 NEW error — "beats" does not cover "beatsagent".
+func TestCheckViolations_BinaryKeyNoPrefixFalsePositive(t *testing.T) {
+	const (
+		binaryKey     = "github.com/elastic/beats"
+		binary        = "github.com/elastic/beatsagent"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binaryKey: {
+			"": {{Imported: forbiddenPath, Reason: "beats only"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Errorf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+}
+
+// TestCheckViolations_CrossBinaryIsolation — an entry filed under binary-a must
+// not cover the same forbidden import pulled in by binary-b.
+//
+//	cmd/binary-a ─→ forbidden   (covered by the entry)
+//	cmd/binary-b ─→ forbidden   (not covered)
+//
+// Expected: 1 NEW error, and it names binary-b.
+func TestCheckViolations_CrossBinaryIsolation(t *testing.T) {
+	const (
+		binaryA       = "github.com/foo/cmd/binary-a"
+		binaryB       = "github.com/foo/cmd/binary-b"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binaryA:       {forbiddenPath},
+		binaryB:       {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{
+		{Binary: binaryA, Imported: forbiddenPath},
+		{Binary: binaryB, Imported: forbiddenPath},
+	}
+	known := map[string]map[string][]KnownViolation{
+		binaryA: {
+			"": {{Imported: forbiddenPath, Reason: "binary-a only"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binaryA, binaryB}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Fatalf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+	if n := countContaining(*errs, binaryB); n != 1 {
+		t.Errorf("expected the NEW error to name %q, got: %v", binaryB, *errs)
+	}
+}
+
+// TestCheckViolations_ImportedPrefixMatch — KnownViolation.Imported is a module
+// root that covers a specific forbidden sub-package.
+//
+//	binary ─→ golang.org/x/crypto/md4
+//	entry Imported: golang.org/x/crypto
+//
+// Expected: 0 errors.
+func TestCheckViolations_ImportedPrefixMatch(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		importedKey   = "golang.org/x/crypto"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {{Imported: importedKey, Reason: "all of x/crypto accepted here"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestCheckViolations_MultipleForbiddenSameComponent — one component key holds a
+// separate entry per forbidden package.
+//
+//	binary ─→ vendor/comp/pkg ─→ forbidden-1
+//	                          └─→ forbidden-2
+//
+// Expected: 0 errors.
+func TestCheckViolations_MultipleForbiddenSameComponent(t *testing.T) {
+	const (
+		binary       = "github.com/foo/cmd/agent"
+		componentKey = "github.com/vendor/comp"
+		componentPkg = "github.com/vendor/comp/pkg"
+		forbidden1   = "golang.org/x/crypto/md4"
+		forbidden2   = "golang.org/x/crypto/blowfish"
+	)
+
+	graph := map[string][]string{
+		binary:       {componentPkg},
+		componentPkg: {forbidden1, forbidden2},
+		forbidden1:   {},
+		forbidden2:   {},
+	}
+	violations := []Violation{
+		{Binary: binary, Imported: forbidden1},
+		{Binary: binary, Imported: forbidden2},
+	}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			componentKey: {
+				{Imported: forbidden1, Reason: "comp needs md4"},
+				{Imported: forbidden2, Reason: "comp needs blowfish"},
+			},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Section 5: stale detection
+// -----------------------------------------------------------------------------
+
+// TestStale_ViolationFixed — the dependency is gone but the entry is still listed.
+//
+//	binary                      (no edge to forbidden any more)
+//
+// Expected: 1 stale error.
+func TestStale_ViolationFixed(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary: {},
+	}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {{Imported: forbiddenPath, Reason: "was needed once"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, nil, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "stale"); n != 1 {
+		t.Errorf("expected 1 stale error, got %d: %v", n, *errs)
+	}
+	if len(*errs) != 1 {
+		t.Errorf("expected exactly 1 error in total, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestStale_ComponentRemovedFromGraph — the forbidden import is still there but
+// the component it used to come through is gone from the dependency tree.
+//
+//	binary ─→ forbidden          (direct; the old component is absent)
+//
+// Expected: 1 NEW error (the entry no longer matches) and 1 stale error.
+func TestStale_ComponentRemovedFromGraph(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		removedComp   = "github.com/vendor/removed"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			removedComp: {{Imported: forbiddenPath, Reason: "came through the removed component"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Errorf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+	if n := countContaining(*errs, "stale"); n != 1 {
+		t.Errorf("expected 1 stale error, got %d: %v", n, *errs)
+	}
+}
+
+// TestStale_ComponentTypo_BothNewAndStale — a typo in the component key breaks
+// the entry in both directions at once.
+//
+//	binary ─→ vendor/comp/pkg ─→ forbidden
+//	entry component key: github.com/vendor/kmop   (typo, matches nothing)
+//
+// Expected: 1 NEW error and 1 stale error.
+func TestStale_ComponentTypo_BothNewAndStale(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		componentPkg  = "github.com/vendor/comp/pkg"
+		typoComponent = "github.com/vendor/kmop"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {componentPkg},
+		componentPkg:  {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			typoComponent: {{Imported: forbiddenPath, Reason: "typo in the component key"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Errorf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+	if n := countContaining(*errs, "stale"); n != 1 {
+		t.Errorf("expected 1 stale error, got %d: %v", n, *errs)
+	}
+}
+
+// TestStale_NotStale_ViolationStillPresent — a matched entry is never stale.
+//
+//	binary ─→ forbidden
+//
+// Expected: 0 errors.
+func TestStale_NotStale_ViolationStillPresent(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {{Imported: forbiddenPath, Reason: "still needed"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestStale_TwoEntries_IndependentTracking — entries under the same key are
+// tracked one by one.
+//
+//	binary ─→ forbidden-1        (forbidden-2 is gone)
+//
+// Expected: 1 stale error, naming forbidden-2 only.
+func TestStale_TwoEntries_IndependentTracking(t *testing.T) {
+	const (
+		binary     = "github.com/foo/cmd/agent"
+		forbidden1 = "golang.org/x/crypto/md4"
+		forbidden2 = "golang.org/x/crypto/blowfish"
+	)
+
+	graph := map[string][]string{
+		binary:     {forbidden1},
+		forbidden1: {},
+	}
+	violations := []Violation{{Binary: binary, Imported: forbidden1}}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {
+				{Imported: forbidden1, Reason: "still active"},
+				{Imported: forbidden2, Reason: "now fixed - should be stale"},
+			},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "stale"); n != 1 {
+		t.Fatalf("expected 1 stale error, got %d: %v", n, *errs)
+	}
+	if n := countContaining(*errs, forbidden2); n != 1 {
+		t.Errorf("expected the stale error to name %q, got: %v", forbidden2, *errs)
+	}
+	if n := countContaining(*errs, forbidden1); n != 0 {
+		t.Errorf("did not expect any error naming %q, got: %v", forbidden1, *errs)
+	}
+}
+
+// TestStale_UnknownBinaryKey_Error — a binary key that matches no scanned binary
+// is its own error class, separate from stale.
+//
+// Expected: an error naming the unknown key.
+func TestStale_UnknownBinaryKey_Error(t *testing.T) {
+	const (
+		typoKey       = "github.com/foo/cmd/typo"
+		scannedBinary = "github.com/foo/cmd/agent"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		scannedBinary: {},
+	}
+	known := map[string]map[string][]KnownViolation{
+		typoKey: {
+			"": {{Imported: forbiddenPath, Reason: "binary name has a typo"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, nil, graph, []string{scannedBinary}, known)
+
+	if n := countContaining(*errs, typoKey); n != 1 {
+		t.Errorf("expected 1 error naming the unknown binary key %q, got %d: %v", typoKey, n, *errs)
+	}
+}
+
+// TestStale_LibraryBinaryKey_NeverUnknown — the "" binary key is always active,
+// even when the module has no binaries at all.
+//
+//	library/pkg ─→ forbidden     (flat scan, Binary is "")
+//
+// Expected: 0 errors — the violation matches and "" never triggers the
+// unknown-binary error.
+func TestStale_LibraryBinaryKey_NeverUnknown(t *testing.T) {
+	const (
+		libraryPkg    = "github.com/foo/library/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		libraryPkg:    {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: "", Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		"": {
+			"": {{Imported: forbiddenPath, Reason: "library level exception"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, nil, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestStale_LibraryScope_Stale — the "" binary key entry goes stale once the
+// library violation is fixed.
+//
+//	library/pkg                  (no edge to forbidden any more)
+//
+// Expected: 1 stale error.
+func TestStale_LibraryScope_Stale(t *testing.T) {
+	const (
+		libraryPkg    = "github.com/foo/library/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		libraryPkg: {},
+	}
+	known := map[string]map[string][]KnownViolation{
+		"": {
+			"": {{Imported: forbiddenPath, Reason: "no longer imported"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, nil, graph, nil, known)
+
+	if n := countContaining(*errs, "stale"); n != 1 {
+		t.Errorf("expected 1 stale error, got %d: %v", n, *errs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Section 6: scope - flat scan plus per-binary BFS
+// -----------------------------------------------------------------------------
+
+// TestScope_FlatScanCatchesLibraryPackages — a package that no binary imports is
+// still scanned, and its violation carries an empty Binary.
+//
+//	cmd/binary  ─→ forbidden-1     (binary scope, covered by an entry)
+//	library/pkg ─→ forbidden-2     (flat scan, not covered)
+//
+// Expected: 1 NEW error, for the flat-scan violation.
+func TestScope_FlatScanCatchesLibraryPackages(t *testing.T) {
+	const (
+		binary     = "github.com/foo/cmd/binary"
+		libraryPkg = "github.com/foo/library/pkg"
+		forbidden1 = "golang.org/x/crypto/md4"
+		forbidden2 = "golang.org/x/crypto/blowfish"
+	)
+
+	graph := map[string][]string{
+		binary:     {forbidden1},
+		libraryPkg: {forbidden2},
+		forbidden1: {},
+		forbidden2: {},
+	}
+	violations := []Violation{
+		{Binary: binary, Imported: forbidden1},
+		{Binary: "", Imported: forbidden2},
+	}
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {{Imported: forbidden1, Reason: "binary scope exception"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Fatalf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+	if n := countContaining(*errs, forbidden2); n != 1 {
+		t.Errorf("expected the NEW error to name %q, got: %v", forbidden2, *errs)
+	}
+}
+
+// TestScope_FlatScanViolation_CoveredByLibraryEntry — a flat-scan violation is
+// covered by the "" binary key.
+//
+//	library/pkg ─→ forbidden
+//
+// Expected: 0 errors.
+func TestScope_FlatScanViolation_CoveredByLibraryEntry(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/binary"
+		libraryPkg    = "github.com/foo/library/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {},
+		libraryPkg:    {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: "", Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		"": {
+			"": {{Imported: forbiddenPath, Reason: "library level exception"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Section 7: skipBinaries validation
+// -----------------------------------------------------------------------------
+
+// TestValidateSkipBinaries_UnknownEntry_Error — a skip entry that matches no
+// discovered binary is a mistake.
+//
+// Expected: 1 error naming the unknown entry.
+func TestValidateSkipBinaries_UnknownEntry_Error(t *testing.T) {
+	const (
+		mistyped   = "github.com/foo/cmd/mistyped"
+		discovered = "github.com/foo/cmd/agent"
+	)
+
+	ct, errs := collectErrors(t)
+	validateSkipBinaries(ct, []string{mistyped}, []string{discovered})
+
+	if len(*errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(*errs), *errs)
+	}
+	if !strings.Contains((*errs)[0], mistyped) {
+		t.Errorf("expected the error to name %q, got: %v", mistyped, *errs)
+	}
+}
+
+// TestValidateSkipBinaries_PrefixMatch_NoError — a module-root skip entry covers
+// longer binary paths underneath it.
+//
+// Expected: 0 errors.
+func TestValidateSkipBinaries_PrefixMatch_NoError(t *testing.T) {
+	const (
+		skipPrefix = "github.com/foo/dev-tools"
+		discovered = "github.com/foo/dev-tools/cmd/lint"
+	)
+
+	ct, errs := collectErrors(t)
+	validateSkipBinaries(ct, []string{skipPrefix}, []string{discovered})
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestValidateSkipBinaries_ExactMatch_NoError — an exact skip entry.
+//
+// Expected: 0 errors.
+func TestValidateSkipBinaries_ExactMatch_NoError(t *testing.T) {
+	const binary = "github.com/foo/cmd/tool"
+
+	ct, errs := collectErrors(t)
+	validateSkipBinaries(ct, []string{binary}, []string{binary})
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestValidateSkipBinaries_MultipleEntries_OneMissing — only the entry that
+// matches nothing is reported.
+//
+// Expected: 1 error, naming the missing entry only.
+func TestValidateSkipBinaries_MultipleEntries_OneMissing(t *testing.T) {
+	const (
+		good    = "github.com/foo/cmd/tool"
+		missing = "github.com/foo/cmd/gone"
+	)
+
+	ct, errs := collectErrors(t)
+	validateSkipBinaries(ct, []string{good, missing}, []string{good})
+
+	if len(*errs) != 1 {
+		t.Fatalf("expected 1 error, got %d: %v", len(*errs), *errs)
+	}
+	if !strings.Contains((*errs)[0], missing) {
+		t.Errorf("expected the error to name %q, got: %v", missing, *errs)
+	}
+	if strings.Contains((*errs)[0], good) {
+		t.Errorf("did not expect the error to name %q, got: %v", good, *errs)
+	}
+}
+
+// -----------------------------------------------------------------------------
+// Section 8: helpers
+// -----------------------------------------------------------------------------
+
+// captureT wraps *testing.T and redirects Errorf so tests can inspect reported failures.
+type captureT struct {
+	*testing.T
+	errorf func(string, ...any)
+	fatalf func(string, ...any)
+}
+
+func (c *captureT) Errorf(format string, args ...any) { c.errorf(format, args...) }
+
+func (c *captureT) Fatalf(format string, args ...any) {
+	if c.fatalf != nil {
+		c.fatalf(format, args...)
+	} else {
+		c.T.Fatalf(format, args...)
+	}
+}
+
+func (c *captureT) Helper() { c.T.Helper() }
+
+// collectErrors returns a testing.TB that appends every Errorf call to a slice.
+func collectErrors(t *testing.T) (*captureT, *[]string) {
+	var errs []string
+	ct := &captureT{T: t, errorf: func(f string, a ...any) {
+		errs = append(errs, fmt.Sprintf(f, a...))
+	}}
+	return ct, &errs
+}
+
+// countContaining returns how many collected errors contain marker.
+func countContaining(errs []string, marker string) int {
+	n := 0
+	for _, e := range errs {
+		if strings.Contains(e, marker) {
+			n++
+		}
+	}
+	return n
+}
+
+// -----------------------------------------------------------------------------
+// Section 9: Regression tests for known bugs
+// -----------------------------------------------------------------------------
+
+// TestBug1_ScanBinaryViolations_ForbiddenImportsForbidden — when a forbidden
+// package under prefix A imports another forbidden package under prefix B,
+// scanBinaryViolations must report both violations.
+//
+// The isForbidden(pkg) guard in the scan loop was silently skipping all imports
+// of forbidden packages, causing the inner violation to be dropped entirely.
+//
+//	binary → lib/pkg → golang.org/x/crypto/md4 → filippo.io/edwards25519
+//	                      ^--- forbidden (A)           ^--- forbidden (B)
+//
+// Expected: 2 violations — one for each forbidden package.
+// Bug: 1 violation — filippo.io/edwards25519 is silently dropped.
+func TestScanBinaryViolations_ForbiddenImportsForbidden_BothReported(t *testing.T) {
+	const (
+		binary     = "github.com/foo/cmd/agent"
+		lib        = "github.com/foo/lib/pkg"
+		forbiddenA = "golang.org/x/crypto/md4"
+		forbiddenB = "filippo.io/edwards25519"
+	)
+
+	graph := map[string][]string{
+		binary:     {lib},
+		lib:        {forbiddenA},
+		forbiddenA: {forbiddenB},
+		forbiddenB: {},
+	}
+
+	violations, _ := scanBinaryViolations(graph, []string{binary}, []string{"golang.org/x/crypto/", "filippo.io/"})
+
+	found := map[string]bool{}
+	for _, v := range violations {
+		if v.Binary == binary {
+			found[v.Imported] = true
+		}
+	}
+
+	for _, want := range []string{forbiddenA, forbiddenB} {
+		if !found[want] {
+			t.Errorf("missing violation {binary=%q, imported=%q}; got violations: %v", binary, want, violations)
+		}
+	}
+}
+
+// TestBug1_ScanFlatViolations_ForbiddenImportsForbidden — same isForbidden guard
+// bug, but in scanFlatViolations. When a forbidden package under prefix A imports
+// another forbidden package under prefix B, the inner violation must be reported.
+//
+//	lib/pkg → golang.org/x/crypto/md4 → filippo.io/edwards25519
+//	           ^--- forbidden (A)           ^--- forbidden (B)
+//
+// Expected: 2 flat-scan violations.
+// Bug: 1 — filippo.io/edwards25519 is silently dropped.
+func TestScanFlatViolations_ForbiddenImportsForbidden_BothReported(t *testing.T) {
+	const (
+		lib        = "github.com/foo/lib/pkg"
+		forbiddenA = "golang.org/x/crypto/md4"
+		forbiddenB = "filippo.io/edwards25519"
+	)
+
+	graph := map[string][]string{
+		lib:        {forbiddenA},
+		forbiddenA: {forbiddenB},
+		forbiddenB: {},
+	}
+
+	violations := scanFlatViolations(graph, map[string]bool{}, []string{"golang.org/x/crypto/", "filippo.io/"})
+
+	found := map[string]bool{}
+	for _, v := range violations {
+		found[v.Imported] = true
+	}
+
+	for _, want := range []string{forbiddenA, forbiddenB} {
+		if !found[want] {
+			t.Errorf("missing flat-scan violation {imported=%q}; got violations: %v", want, violations)
+		}
+	}
+}
+
+// TestBug1_FalseStale_InnerViolationDropped — end-to-end consequence of the
+// isForbidden guard bug: when the inner violation (forbiddenB) is silently
+// dropped, a valid allowlist entry for it is incorrectly reported as stale.
+//
+//	binary → lib/pkg → forbiddenA → forbiddenB
+//
+// Both violations are real and both allowlist entries are active. Expected: 0
+// errors. Bug: 1 stale error for the forbiddenB entry (violation was dropped).
+func TestCheckViolations_ForbiddenChain_AllViolationsMatchedNoFalseStale(t *testing.T) {
+	const (
+		binary     = "github.com/foo/cmd/agent"
+		lib        = "github.com/foo/lib/pkg"
+		forbiddenA = "golang.org/x/crypto/md4"
+		forbiddenB = "filippo.io/edwards25519"
+	)
+
+	graph := map[string][]string{
+		binary:     {lib},
+		lib:        {forbiddenA},
+		forbiddenA: {forbiddenB},
+		forbiddenB: {},
+	}
+
+	violations, _ := scanBinaryViolations(graph, []string{binary}, []string{"golang.org/x/crypto/", "filippo.io/"})
+
+	known := map[string]map[string][]KnownViolation{
+		binary: {
+			"": {
+				{Imported: forbiddenA, Reason: "crypto/md4 used by lib"},
+				{Imported: forbiddenB, Reason: "filippo.io/edwards25519 imported by crypto/md4"},
+			},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if len(*errs) != 0 {
+		t.Errorf("expected 0 errors, got %d: %v", len(*errs), *errs)
+	}
+}
+
+// TestBug2_FlatScanViolation_ImporterAbsentFromErrorMessage — for flat-scan NEW
+// violations, the error message must name the library package that imports the
+// forbidden package. Without it the output is just the forbidden package name,
+// which gives no actionable information.
+//
+//	lib/pkg → golang.org/x/crypto/md4
+//
+// Expected: the NEW error message contains "lib/pkg".
+// Bug: the message only contains "golang.org/x/crypto/md4" — the importer is lost.
+func TestCheckViolations_FlatScanNewError_NamesImporter(t *testing.T) {
+	const (
+		lib           = "github.com/foo/lib/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		lib:           {forbiddenPath},
+		forbiddenPath: {},
+	}
+	violations := []Violation{{Binary: "", Importer: lib, Imported: forbiddenPath}}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, nil, nil)
+
+	if n := countContaining(*errs, "NEW"); n != 1 {
+		t.Fatalf("expected 1 NEW error, got %d: %v", n, *errs)
+	}
+	if n := countContaining(*errs, lib); n == 0 {
+		t.Errorf("NEW error must name the importer %q to be actionable; got: %v", lib, *errs)
+	}
+}
+
+// TestBug3_ComponentCheck_FlatScan_BinaryScopePackageCoversLibraryViolation —
+// componentOnPath skips the binaryReach guard when binary=="", allowing a
+// package that is exclusively in a binary's dependency tree to silently validate
+// a flat-scan violation it has nothing to do with.
+//
+//	binary  → comp/pkg → forbidden    (binary scope)
+//	lib/pkg → forbidden                (flat-scan violation, Binary="")
+//
+// Entry {"": {"comp": [{Imported: forbidden}]}}: comp/pkg reaches forbidden, so
+// componentOnPath returns true — but comp/pkg is unreachable from lib/pkg. The
+// flat-scan violation must not be suppressed by a binary-scope component package.
+//
+// Expected: at least 1 NEW error for the uncovered flat-scan violation.
+// Bug: 0 errors — the entry unsoundly covers the flat-scan violation.
+func TestCheckViolations_FlatScan_BinaryScopeComponentDoesNotCoverLibraryViolation(t *testing.T) {
+	const (
+		binary        = "github.com/foo/cmd/agent"
+		componentKey  = "github.com/vendor/comp"
+		componentPkg  = "github.com/vendor/comp/pkg"
+		lib           = "github.com/foo/lib/pkg"
+		forbiddenPath = "golang.org/x/crypto/md4"
+	)
+
+	graph := map[string][]string{
+		binary:        {componentPkg},
+		componentPkg:  {forbiddenPath},
+		lib:           {forbiddenPath},
+		forbiddenPath: {},
+	}
+	// Only the flat-scan violation — comp/pkg is binary-scope, not lib-scope.
+	violations := []Violation{{Binary: "", Imported: forbiddenPath}}
+	known := map[string]map[string][]KnownViolation{
+		"": {
+			componentKey: {{Imported: forbiddenPath, Reason: "binary-scope comp must not cover lib violation"}},
+		},
+	}
+
+	ct, errs := collectErrors(t)
+	checkViolations(ct, violations, graph, []string{binary}, known)
+
+	if n := countContaining(*errs, "NEW"); n < 1 {
+		t.Errorf("expected at least 1 NEW error (flat-scan violation must not be suppressed by a binary-scope component), got %d: %v", n, *errs)
 	}
 }


### PR DESCRIPTION
## TL;DR

Unifying the way we test binaries/modules for FIPS compliance. Aim was to just import this module, prepare list of known violations and Voilà. Example usages:

- https://github.com/elastic/fleet-server/pull/7395
- https://github.com/elastic/beats/pull/52036
- https://github.com/elastic/elastic-agent/pull/15600

vibe-coded. This PR is bigger than I expected and mostly resonate about resolving the dependencies between binary, component and library which violates the FIPS

Iterated few times to give satisfying results and minimal usage in fleet-server, elastic-agent and beats repo

## Summary

Extend `testing/fipsscan` package — a shared Go testing helper for auditing FIPS 140-3 compliance of Go modules. It scans dependency trees for imports of known non-FIPS crypto libraries and reports violations via the standard `testing.T` interface.

The package is guarded by `//go:build requirefips` so it compiles and incurs zero overhead outside FIPS-focused test runs (`go test -tags requirefips`).

## Motivation

FIPS compliance needs to be enforced across multiple Elastic repositories (elastic-agent, otel-collector-components, beats, …). Without a shared helper, each repo would reimplement violation detection independently and inconsistently. This package provides a single place to maintain the list of known non-FIPS libraries and a stable API for documenting accepted violations per component.

## API

### `CheckModule` — the main entry point

```go
fipsscan.CheckModule(t,
    []string{"./..."},   // patterns passed to go list
    skipBinaries,        // non-shipped binaries to exclude
    nil,                 // extra forbidden prefixes beyond the baseline
    map[string]map[string][]fipsscan.KnownViolation{
        // outer key: binary import path or module-root prefix; "" = all binaries
        "github.com/elastic/elastic-agent": {
            // inner key: component — package path or module-root prefix in the chain
            "github.com/elastic/gokrb5/v8": {
                {Imported: "github.com/jcmturner/gofork", Reason: "Elastic gokrb5 fork depends on jcmturner gofork"},
                {Imported: "golang.org/x/crypto/md4",     Reason: "Kerberos RC4-HMAC requires MD4"},
            },
            "github.com/foxboron/go-tpm-keyfiles": {
                {Imported: "golang.org/x/crypto/chacha20poly1305", Reason: "TPM key parsing uses ChaCha20"},
            },
        },
    },
)
```

`CheckModule` reports undocumented violations via `t.Errorf` and flags stale entries (violations that no longer exist) so the map stays current.

### Key design points

- **Component-oriented config.** The two-level map (`binary → component → violations`) lets you document *which part of the binary* owns each violation. The component key is any package path or module-root prefix appearing in the import chain from the binary down to the direct importer — use a broad prefix like `"github.com/twmb/franz-go"` to cover all violations from that library in one entry, or an exact package for precision.
- **Prefix matching.** Both the outer binary key and `KnownViolation.Imported` support module-root prefixes. `{Imported: "github.com/jcmturner/gokrb5/v8"}` matches any `gokrb5/v8/…` sub-package. Binary key `"github.com/elastic/elastic-agent"` matches any binary under that module root.
- **Stale detection.** Entries whose violation no longer exists are flagged stale. Entries whose component was removed from the dependency tree entirely are silently skipped (not a stale error — the problem went away).
- **Library module support.** Falls back to flat violation detection (no binary attribution) when the scanned module has no `package main` entries.
- **`skipBinaries`.** Dev tools, test helpers, and non-shipped binaries can be excluded from the scan and from stale detection.
- **Single `go list` pass.** All patterns are resolved in one subprocess invocation regardless of how many binaries match.

### Lower-level functions

```go
// Per-binary scan with BFS attribution; Violation.Binary is set.
violations, importGraph := fipsscan.ScanBinaries(t, []string{"./cmd/..."}, skipBinaries, nil)

// Flat scan; Violation.Binary is empty.
violations, importGraph := fipsscan.Scan(t, "./...", nil)

// Display helpers.
chain := fipsscan.ShortestChain(v.Binary, v.Importer, importGraph)
fmt.Println(fipsscan.FormatChain(append(chain, v.Imported)))
```

### Baseline forbidden-package list

Ten third-party crypto libraries are checked by default (all exported as constants):

| Constant | Module prefix |
|---|---|
| `XCrypto` | `golang.org/x/crypto/` |
| `JcmturnerGokrb5` | `github.com/jcmturner/gokrb5/` |
| `JcmturnerAescts` | `github.com/jcmturner/aescts/` |
| `JcmturnerGofork` | `github.com/jcmturner/gofork/` |
| `XdgGoPbkdf2` | `github.com/xdg-go/pbkdf2` |
| `ProtonMailGoCrypto` | `github.com/ProtonMail/go-crypto/` |
| `CloudflareCircl` | `github.com/cloudflare/circl/` |
| `AzureGoNtlmssp` | `github.com/Azure/go-ntlmssp` |
| `YoumarkPkcs8` | `github.com/youmark/pkcs8` |
| `FilippioIO` | `filippo.io/` |

## Usage convention

The recommended filename is `fips_compliance_test.go` and function name `TestFIPSCompliance` in every adopting module. This makes ecosystem-wide auditing trivial:

```bash
grep -rl 'TestFIPSCompliance' .          # find all modules with a FIPS test
go test -tags requirefips -run TestFIPSCompliance ./...  # run them all
```

## Test plan

- [ ] `go build -tags requirefips ./testing/fipsscan/` passes
- [ ] `go test -tags requirefips ./testing/fipsscan/` passes (unit tests for `ShortestChain`, `FormatChain`, `matchesBinaryKey`, `isForbidden`, `moduleRoot`)
- [ ] Validate against real usage: `drosiek-fips` branch in elastic-agent uses this package for `elastic-agent` and `edot` binaries
