### PR TITLE
fix: correct casing to lowercase streams (matches actual GitHub team slug)

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,7 +9,7 @@ metadata:
 
 spec:
   type: library
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   lifecycle: production
 
@@ -26,7 +26,7 @@ metadata:
 
 spec:
   type: buildkite-pipeline
-  owner: group:Streams
+  owner: group:streams
   system: platform-ingest
   implementation:
     apiVersion: buildkite.elastic.dev/v1
@@ -53,7 +53,7 @@ spec:
       env:
         ELASTIC_PR_COMMENTS_ENABLED: 'true'
       teams:
-        Streams:
+        streams:
           access_level: MANAGE_BUILD_AND_READ
         everyone:
           access_level: READ_ONLY


### PR DESCRIPTION
The previous PR renamed the team reference in `catalog-info.yaml` to `Streams` (capital S), but GitHub team slugs are always lowercase. The actual team is `elastic/streams`. This PR corrects the casing to `streams` — no other changes.